### PR TITLE
Propagate labels and annotations into all created objects

### DIFF
--- a/src/reconcilers/mod.rs
+++ b/src/reconcilers/mod.rs
@@ -1,31 +1,34 @@
 use std::collections::BTreeMap;
 
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta, OwnerReference};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 
 pub mod compute;
 pub mod network_policies;
 
-// resource_labels returns labels to apply to all created resources
+// resource_labels returns labels to apply to all created resources on top of the RestateCluster labels
 // it is not safe to change these; statefulset volume template labels are immutable
-pub fn resource_labels(instance: &str) -> BTreeMap<String, String> {
-    BTreeMap::from([
+pub fn mandatory_labels(base_metadata: &ObjectMeta) -> BTreeMap<String, String> {
+    BTreeMap::from_iter([
         ("app.kubernetes.io/name".into(), "restate".into()),
-        ("app.kubernetes.io/instance".into(), instance.into()),
+        (
+            "app.kubernetes.io/instance".into(),
+            base_metadata.name.clone().unwrap(),
+        ),
     ])
 }
 
-pub fn label_selector(instance: &str) -> LabelSelector {
+pub fn label_selector(base_metadata: &ObjectMeta) -> LabelSelector {
     LabelSelector {
-        match_labels: Some(resource_labels(instance)),
+        match_labels: Some(mandatory_labels(base_metadata)),
         match_expressions: None,
     }
 }
 
-pub fn object_meta(oref: &OwnerReference, name: impl Into<String>) -> ObjectMeta {
-    ObjectMeta {
-        name: Some(name.into()),
-        labels: Some(resource_labels(&oref.name)),
-        owner_references: Some(vec![oref.clone()]),
-        ..Default::default()
-    }
+pub fn object_meta(base_metadata: &ObjectMeta, name: impl Into<String>) -> ObjectMeta {
+    let mut meta = base_metadata.clone();
+    meta.name = Some(name.into());
+    meta.labels
+        .get_or_insert_with(Default::default)
+        .extend(mandatory_labels(base_metadata));
+    meta
 }


### PR DESCRIPTION
Except for pvcs, because pvc templates are immutable