### PR TITLE
Canary pods need to be created via Jobs

### DIFF
--- a/charts/restate-operator-helm/templates/rbac.yaml
+++ b/charts/restate-operator-helm/templates/rbac.yaml
@@ -47,6 +47,7 @@ rules:
       - statefulsets
       - persistentvolumeclaims
       - pods
+      - jobs
       - securitygrouppolicies
       - secretproviderclasses
     verbs:
@@ -64,7 +65,7 @@ rules:
   - resources:
       - statefulsets
       - networkpolicies
-      - pods
+      - jobs
       - securitygrouppolicies
       - secretproviderclasses
     verbs:


### PR DESCRIPTION
For the pia canary to work well, the pod creation needs to be on the same apiserver instance that the controller manager uses. I really hope that controller manager requests are not load balanced across all 3. We can use a Job object so that the controller manager makes the pods.