### PR TITLE
Set RESTATE_NODE_NAME to POD_NAME by default

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -10,8 +10,8 @@ use futures::StreamExt;
 use k8s_openapi::api::apps::v1::{StatefulSet, StatefulSetStatus};
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{
-    ConfigMap, EnvVar, Namespace, PersistentVolumeClaim, PodDNSConfig, ResourceRequirements,
-    Service, ServiceAccount, ServiceSpec, Toleration, Affinity,
+    Affinity, ConfigMap, EnvVar, Namespace, PersistentVolumeClaim, PodDNSConfig,
+    ResourceRequirements, Service, ServiceAccount, ServiceSpec, Toleration,
 };
 use k8s_openapi::api::networking::v1;
 use k8s_openapi::api::networking::v1::{NetworkPolicy, NetworkPolicyPeer, NetworkPolicyPort};
@@ -198,7 +198,6 @@ pub struct RestateClusterCompute {
     pub node_selector: Option<BTreeMap<String, String>>,
     // If specified, pod affinity
     pub affinity: Option<Affinity>,
-
 }
 
 fn env_schema(g: &mut schemars::gen::SchemaGenerator) -> Schema {

--- a/src/reconcilers/compute.rs
+++ b/src/reconcilers/compute.rs
@@ -186,6 +186,11 @@ fn env(cluster_name: &str, custom: Option<&[EnvVar]>) -> Vec<EnvVar> {
             // POD_NAME comes from the downward api, below
             "http://$(POD_NAME).restate-cluster:5122",
         ),
+        (
+            "RESTATE_NODE_NAME",
+            // POD_NAME comes from the downward api, below
+            "$(POD_NAME)",
+        ),
     ];
 
     // allow crd to override our defaults


### PR DESCRIPTION
In order to support running on volumes where restate-data contains other directories (e.g. lost+found), we need to explicitly set the RESTATE_NODE_NAME. This commit does this but still allows users to override the node name.