### PR TITLE
Set pod management policy to parallel

### DIFF
--- a/src/reconcilers/compute.rs
+++ b/src/reconcilers/compute.rs
@@ -386,6 +386,9 @@ fn restate_statefulset(
                     ..Default::default()
                 }),
             },
+            // It's important to start multiple pods at the same time in case multiple pods died.
+            // Otherwise, we risk unavailability of an already configured metadata cluster
+            pod_management_policy: Some("Parallel".to_owned()),
             volume_claim_templates: Some(vec![PersistentVolumeClaim {
                 metadata: ObjectMeta {
                     name: Some("storage".into()),


### PR DESCRIPTION
In order to restart a distributed Restate cluster, we need to be able to start all pods at the same time. Otherwise, we risk that the embedded metadata cluster does not become operational.

This fixes #22.