### PR TITLE
Fix: add missing patch events to RBAC config

### DIFF
--- a/charts/restate-operator-helm/templates/rbac.yaml
+++ b/charts/restate-operator-helm/templates/rbac.yaml
@@ -40,6 +40,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
     apiGroups:
       - events.k8s.io
   - resources:


### PR DESCRIPTION
This PR updates the RBAC configuration to include missing patch events, ensuring the operator has the necessary permissions for patch operations. This helps prevent permission errors during resource updates.

This missing permission was causing RestateDeployment resources not to be deployed when changes occurred, due to insufficient RBAC for patch events.