### PR TITLE
Support registering at a subpath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -3342,6 +3343,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ reqwest = { version = "0.12.15", default-features = false, features = [
     "rustls-tls",
 ] }
 fnv = "1.0.7"
+url = { version = "2.5.4", features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ This field contains Restate-specific configuration.
 | Field | Type | Description |
 |---|---|---|
 | `register` | `object` | **Required**. The location of the Restate Admin API to register this deployment against. See details below. |
+| `servicePath` | `string` | Optional path to append to the Service url when registering with Restate. |
 
 The `register` field must specify exactly one of `cluster`, `service`, or `url`.
 

--- a/crd/RestateDeployment.pkl
+++ b/crd/RestateDeployment.pkl
@@ -57,6 +57,10 @@ class Spec {
 class Restate {
   /// The location of the Restate Admin API to register this deployment against
   register: Register
+
+  /// Optional path to append to the Service url when registering with Restate. If not provided, the
+  /// service will be registered at the root path "/".
+  servicePath: String?
 }
 
 /// The location of the Restate Admin API to register this deployment against

--- a/crd/restatedeployments.yaml
+++ b/crd/restatedeployments.yaml
@@ -104,6 +104,10 @@ spec:
                         description: A url of the restate admin endpoint against which to register the deployment Exactly one of `cluster`, `service` or `url` must be specified
                         type: string
                     type: object
+                  servicePath:
+                    description: Optional path to append to the Service url when registering with Restate. If not provided, the service will be registered at the root path "/".
+                    nullable: true
+                    type: string
                 required:
                 - register
                 type: object

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
 use tokio::sync::RwLock;
+use url::Url;
 
 pub mod restatecluster;
 pub mod restatedeployment;
@@ -82,4 +83,21 @@ impl State {
             ..self
         }
     }
+}
+
+pub fn service_url(
+    service_name: &str,
+    service_namespace: &str,
+    port: i32,
+    path: Option<&str>,
+) -> Result<Url, url::ParseError> {
+    let mut url = Url::parse(&format!(
+        "http://{service_name}.{service_namespace}.svc.cluster.local:{port}",
+    ))?;
+
+    if let Some(path) = path {
+        url.set_path(path)
+    }
+
+    Ok(url)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@ pub enum Error {
 
     #[error("This RestateDeployment is backing recently-active versions in Restate. It will be removed after the drain delay period.")]
     DeploymentDraining { requeue_after: Option<Duration> },
+
+    #[error(transparent)]
+    InvalidUrl(#[from] url::ParseError),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -70,6 +73,7 @@ impl Error {
             Error::HashCollision => "HashCollision",
             Error::DeploymentInUse => "DeploymentInUse",
             Error::DeploymentDraining { .. } => "DeploymentDraining",
+            Error::InvalidUrl { .. } => "InvalidUrl",
         }
     }
 }


### PR DESCRIPTION
In addition, stop looking for active deployments by their ID; instead use the deployment id annotation which we store against a replicaset.