### PR TITLE
Add support for custom restate entrypoint/args

### DIFF
--- a/crd/RestateCluster.pkl
+++ b/crd/RestateCluster.pkl
@@ -52,6 +52,12 @@ class Compute {
   /// Affinity is a group of affinity scheduling rules.
   affinity: PodSpec.Affinity?
 
+  /// Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided.
+  command: Listing<String>?
+
+  /// Arguments to the entrypoint. The container image's CMD is used if this is not provided.
+  args: Listing<String>?
+
   /// Specifies the DNS parameters of the Restate pod. Parameters specified here will be merged to the
   /// generated DNS configuration based on DNSPolicy.
   dnsConfig: PodSpec.PodDNSConfig?

--- a/crd/restateclusters.yaml
+++ b/crd/restateclusters.yaml
@@ -549,6 +549,18 @@ spec:
                             type: array
                         type: object
                     type: object
+                  args:
+                    description: Arguments to the entrypoint. The container image's CMD is used if this is not provided.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
+                  command:
+                    description: Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided.
+                    items:
+                      type: string
+                    nullable: true
+                    type: array
                   dnsConfig:
                     description: Specifies the DNS parameters of the Restate pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                     nullable: true

--- a/justfile
+++ b/justfile
@@ -77,3 +77,11 @@ build *flags:
 
 docker:
     docker build . -f docker/Dockerfile --tag={{ image }} --progress='{{ DOCKER_PROGRESS }}' --load
+
+fmt:
+    cargo fmt --all
+
+lint:
+    cargo clippy
+
+check: fmt lint

--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -355,6 +355,8 @@ fn restate_statefulset(
                         name: "restate".into(),
                         image: Some(spec.compute.image.clone()),
                         image_pull_policy: spec.compute.image_pull_policy.clone(),
+                        command: spec.compute.command.clone(),
+                        args: spec.compute.args.clone(),
                         env: Some(env),
                         ports: Some(vec![
                             ContainerPort {

--- a/src/resources/restateclusters.rs
+++ b/src/resources/restateclusters.rs
@@ -123,6 +123,10 @@ pub struct RestateClusterCompute {
     pub replicas: Option<i32>,
     /// Container image name. More info: https://kubernetes.io/docs/concepts/containers/images.
     pub image: String,
+    /// Entrypoint array. Not executed within a shell. The container image's ENTRYPOINT is used if this is not provided.
+    pub command: Option<Vec<String>>,
+    /// Arguments to the entrypoint. The container image's CMD is used if this is not provided.
+    pub args: Option<Vec<String>>,
     /// Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
     pub image_pull_policy: Option<String>,
     /// Optional list of references to secrets in the same namespace to use for pulling the image.


### PR DESCRIPTION
This can come in handy for dynamically setting up the environment with startup scripts (e.g. force a specific node id derived from the pod name).