### PR TITLE
Add initial readiness delay

### DIFF
--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -381,6 +381,7 @@ fn restate_statefulset(
                                 path: Some("/health".into()),
                                 ..Default::default()
                             }),
+                            initial_delay_seconds: Some(30),
                             ..Default::default()
                         }),
                         resources: spec.compute.resources.clone(),


### PR DESCRIPTION
This seems to be fairly standard practice for statefulsets on Kubernetes, otherwise rollouts will happen super quickly and can be quite disruptive.