### PR TITLE
fix: Honor use_http11 flag

### DIFF
--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -545,9 +545,7 @@ impl RestateDeployment {
 
         let resp: DeploymentResponse = ctx
             .request(Method::POST, &self.spec.restate.register, "/deployments")?
-            .json(&serde_json::json!({
-                "uri": service_endpoint,
-            }))
+            .json(&payload)
             .send()
             .await
             .map_err(Error::AdminCallFailed)?


### PR DESCRIPTION
**use_http11 flag was being ignored**: The code was building a payload with the use_http_11 parameter but then sending a hardcoded JSON object without it. This caused all registrations to use HTTP/2 regardless of the useHttp11 setting in the RestateDeployment spec.
