### PR TITLE
Support secret provider in restatecloudenvironment

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,7 +426,8 @@ spec:
 
 | Field | Type | Description |
 |---|---|---|
-| `secret` | `object` | **Required**. A reference to a secret in the same namespace as the operator. See details below. |
+| `secret` | `object` | **Required**. A reference to a secret that will be used for registration, as well as being mounted to the tunnel pods unless a `secretProvider` is also specified. |
+| `secretProvider` | `object` | A reference to a `SecretProviderClass` that should be mounted to the tunnel pods to authenticate the tunnel. A Kubernetes Secret (synced by the Secret Store CSI Driver) is still necessary for the operator to register services. See details below. |
 
 **`secret` Fields**
 
@@ -434,6 +435,13 @@ spec:
 |---|---|---|
 | `name` | `string` | **Required**. The name of the referenced secret. It must be in the same namespace as the operator. |
 | `key` | `string` | **Required**. The key to read from the referenced Secret. |
+
+**`secretProvider` Fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `secretProviderClass` | `string` | **Required**. The name of the referenced `SecretProviderClass`. It must be in the same namespace as the operator. |
+| `path` | `string` | **Required**. The path that the token will be available at inside the secret volume. |
 
 ---
 

--- a/crd/RestateCloudEnvironment.pkl
+++ b/crd/RestateCloudEnvironment.pkl
@@ -46,17 +46,35 @@ class Spec {
 
 /// Where to get credentials for communication with the Cloud environment
 class Authentication {
-  /// Configured a reference to a secret in the same namespace as the operator
+  /// A reference to a secret that will be used for registration, as well as being mounted to the tunnel
+  /// pods unless a secretProvider is also specified.
   secret: Secret
+
+  /// A reference to a SecretProviderClass that should be mounted to the tunnel pods to authenticate the
+  /// tunnel. A Kubernetes Secret (synced by the Secret Store CSI Driver) is still necessary for the
+  /// operator to register services.
+  secretProvider: SecretProvider?
 }
 
-/// Configured a reference to a secret in the same namespace as the operator
+/// A reference to a secret that will be used for registration, as well as being mounted to the tunnel
+/// pods unless a secretProvider is also specified.
 class Secret {
   /// The key to read from the referenced Secret
   key: String
 
   /// The name of the referenced secret. It must be in the same namespace as the operator.
   name: String
+}
+
+/// A reference to a SecretProviderClass that should be mounted to the tunnel pods to authenticate the
+/// tunnel. A Kubernetes Secret (synced by the Secret Store CSI Driver) is still necessary for the
+/// operator to register services.
+class SecretProvider {
+  /// The path that the token will be available inside the secret volume
+  path: String
+
+  /// The name of the referenced SecretProviderClass. It must be in the same namespace as the operator.
+  secretProviderClass: String
 }
 
 /// Optional configuration for the deployment of tunnel pods

--- a/crd/restatecloudenvironments.yaml
+++ b/crd/restatecloudenvironments.yaml
@@ -33,7 +33,7 @@ spec:
                 description: Where to get credentials for communication with the Cloud environment
                 properties:
                   secret:
-                    description: Configured a reference to a secret in the same namespace as the operator
+                    description: A reference to a secret that will be used for registration, as well as being mounted to the tunnel pods unless a secretProvider is also specified.
                     properties:
                       key:
                         description: The key to read from the referenced Secret
@@ -44,6 +44,20 @@ spec:
                     required:
                     - key
                     - name
+                    type: object
+                  secretProvider:
+                    description: A reference to a SecretProviderClass that should be mounted to the tunnel pods to authenticate the tunnel. A Kubernetes Secret (synced by the Secret Store CSI Driver) is still necessary for the operator to register services.
+                    nullable: true
+                    properties:
+                      path:
+                        description: The path that the token will be available inside the secret volume
+                        type: string
+                      secretProviderClass:
+                        description: The name of the referenced SecretProviderClass. It must be in the same namespace as the operator.
+                        type: string
+                    required:
+                    - path
+                    - secretProviderClass
                     type: object
                 required:
                 - secret

--- a/src/resources/restatecloudenvironments.rs
+++ b/src/resources/restatecloudenvironments.rs
@@ -175,10 +175,18 @@ impl RestateCloudEnvironment {
     }
 }
 
-/// Configuration for authentication to the Cloud environment. Currently, only secret references are supported and one must be provided.
+/// Configuration for authentication to the Cloud environment. A secret reference is currently required, but
+/// a CSI Secret Store provider can be used to sync this secret.
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub struct RestateCloudEnvironmentAuthentication {
+    /// A reference to a secret that will be used for registration, as well as being mounted to the tunnel pods
+    /// unless a secretProvider is also specified.
     pub secret: SecretReference,
+    /// A reference to a SecretProviderClass that should be mounted to the tunnel pods to authenticate the tunnel.
+    /// A Kubernetes Secret (synced by the Secret Store CSI Driver) is still necessary
+    /// for the operator to register services.
+    pub secret_provider: Option<SecretProviderReference>,
 }
 
 /// Configured a reference to a secret in the same namespace as the operator
@@ -188,6 +196,15 @@ pub struct SecretReference {
     pub name: String,
     /// The key to read from the referenced Secret
     pub key: String,
+}
+
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SecretProviderReference {
+    /// The name of the referenced SecretProviderClass. It must be in the same namespace as the operator.
+    pub secret_provider_class: String,
+    /// The path that the token will be available inside the secret volume
+    pub path: String,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, CELSchema)]


### PR DESCRIPTION
This PR supports csi secrets store secret provider for the restatecloudenvironment secret. However, syncing the secret to a k8s secret is still required, as the operator needs to be able to read secrets of all the tunnel pods it managed so it can hit the deployment api. So a `secret` is always required, while `secretProvider` is optional.