### PR TITLE
Allow cleaning up old replicasets while the new one is not ready

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "restate-operator"
-version = "1.8.1"
+version = "1.8.2"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restate-operator"
-version = "1.8.1"
+version = "1.8.2"
 authors = ["restate.dev"]
 edition = "2021"
 rust-version = "1.86"

--- a/charts/restate-operator-helm/Chart.yaml
+++ b/charts/restate-operator-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: restate-operator-helm
 description: An operator for Restate clusters
 type: application
-version: "1.8.1"
+version: "1.8.2"


### PR DESCRIPTION
Avoid a chicken and egg problem when the cluster is out of capacity - the new replicaset can't schedule until old ones are cleaned up, but old ones aren't cleared up until the new replicaset is scheduled and registered. To fix, we check if cleanup is possible while we wait for the current version replicaset to become ready - ensuring not to remove the current version replicaset while we are at it.