### PR TITLE
Support existing namespaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restate-operator"
-version = "1.8.4"
+version = "1.9.0"
 authors = ["restate.dev"]
 edition = "2021"
 rust-version = "1.86"

--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ The default behaviour can be disabled with `spec.security.disableNetworkPolicies
 Alternatively, you can add new allowed inbound callers of the Restate ports with `spec.security.networkPeers.{ingress,admin,metrics}`, which are arrays of [`NetworkPolicyPeer`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#networkpolicypeer-v1-networking-k8s-io).
 You can allow new outbound destinations by adding to the `spec.security.networkEgressRules` list, which is an array of [`NetworkPolicyEgressRule`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#networkpolicyegressrule-v1-networking-k8s-io).
 
-**NOTE**: Each cluster is created in its own namespace (enforced by the operator). Do not create the namespace manually,
-and do not use the same namespace that the operator is in.
+**NOTE**: Each cluster is created in its own namespace. Naming the cluster after an existing Namespace is supported, but deploying into namespaces with other applications is not recommended.
 
 #### Minimal Example
 

--- a/charts/restate-operator-helm/Chart.yaml
+++ b/charts/restate-operator-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: restate-operator-helm
 description: An operator for Restate clusters
 type: application
-version: "1.8.4"
+version: "1.9.0"

--- a/src/controllers/restatecluster/reconcilers/network_policies.rs
+++ b/src/controllers/restatecluster/reconcilers/network_policies.rs
@@ -28,6 +28,7 @@ fn deny_all(base_metadata: &ObjectMeta) -> NetworkPolicy {
     NetworkPolicy {
         metadata: object_meta(base_metadata, DENY_ALL_POLICY_NAME),
         spec: Some(NetworkPolicySpec {
+            pod_selector: label_selector(base_metadata),
             policy_types: Some(vec!["Egress".into(), "Ingress".into()]),
             ..Default::default()
         }),
@@ -40,6 +41,7 @@ fn allow_dns(base_metadata: &ObjectMeta) -> NetworkPolicy {
     NetworkPolicy {
         metadata: object_meta(base_metadata, ALLOW_DNS_POLICY_NAME),
         spec: Some(NetworkPolicySpec {
+            pod_selector: label_selector(base_metadata),
             policy_types: Some(vec!["Egress".into()]),
             egress: Some(vec![NetworkPolicyEgressRule {
                 to: Some(vec![NetworkPolicyPeer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,6 @@ pub enum Error {
     // so boxing this error to break cycles
     FinalizerError(#[from] Box<kube::runtime::finalizer::Error<Error>>),
 
-    #[error("A namespace cannot be created for this name as one already exists")]
-    NameConflict,
-
     #[error("Cluster is not yet Ready: {message}")]
     NotReady {
         message: String,
@@ -75,7 +72,6 @@ impl Error {
             Error::SerializationError(_) => "SerializationError",
             Error::KubeError(_) => "KubeError",
             Error::FinalizerError(_) => "FinalizerError",
-            Error::NameConflict => "NameConflict",
             Error::NotReady { .. } => "NotReady",
             Error::DeploymentNotReady { .. } => "ServiceNotReady",
             Error::InvalidRestateConfig(_) => "InvalidRestateConfig",


### PR DESCRIPTION
To support this properly we need to change our network policies to all select operator-managed pods only.

Image: `ghcr.io/restatedev/restate-operator:1.9.0-existingnamespace`
helm chart: `helm upgrade --install restate-operator oci://ghcr.io/restatedev/restate-operator-helm --version 1.9.0-existingnamespace --namespace restate-operator`