### PR TITLE
Ignore completed invs when determining active invocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2383,7 +2383,7 @@ dependencies = [
 
 [[package]]
 name = "restate-operator"
-version = "1.8.4"
+version = "1.9.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restate-operator"
-version = "1.9.0"
+version = "1.9.1"
 authors = ["restate.dev"]
 edition = "2021"
 rust-version = "1.86"

--- a/charts/restate-operator-helm/Chart.yaml
+++ b/charts/restate-operator-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: restate-operator-helm
 description: An operator for Restate clusters
 type: application
-version: "1.9.0"
+version: "1.9.1"

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -311,11 +311,12 @@ impl RestateDeployment {
         )
         .await?;
 
-        let service_endpoint =
-            self.spec
-                .restate
-                .register
-                .service_url(&ctx.rce_store, &versioned_name, namespace, self.spec.restate.service_path.as_deref())?;
+        let service_endpoint = self.spec.restate.register.service_url(
+            &ctx.rce_store,
+            &versioned_name,
+            namespace,
+            self.spec.restate.service_path.as_deref(),
+        )?;
 
         let mut deployments = self.list_deployments(&ctx).await?;
 
@@ -600,7 +601,7 @@ impl RestateDeployment {
                 UNION
                 SELECT DISTINCT pinned_deployment_id as id
                 FROM sys_invocation_status
-                WHERE pinned_deployment_id IS NOT NULL
+                WHERE pinned_deployment_id IS NOT NULL AND status != 'completed'
             )
             SELECT d.id as deployment_id,
                    a.id IS NOT NULL as active


### PR DESCRIPTION
Before 1.5, this query worked, but since 1.5 we show the pinned invocation even for a completed invocation.

fyi @marcus-sa