### PR TITLE
Release 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "restate-operator"
-version = "2.2.0-alpha1"
+version = "2.2.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restate-operator"
-version = "2.2.0-alpha1"
+version = "2.2.0"
 authors = ["restate.dev"]
 edition = "2024"
 rust-version = "1.92"

--- a/charts/restate-operator-helm/Chart.yaml
+++ b/charts/restate-operator-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: restate-operator-helm
 description: An operator for Restate clusters
 type: application
-version: "2.2.0-alpha1"
+version: "2.2.0"


### PR DESCRIPTION
## Release 2.2.0

This PR prepares the v2.2.0 release.

### Changes in This PR

- **Documentation**: Add dedicated Knative Serving Mode section to README
- **Version bump**: Update version to 2.2.0 in Cargo.toml, Cargo.lock, and Chart.yaml

### Changes Since v2.1.0

#### ✨ New Features

* **Knative Serving deployment mode** - RestateDeployment now supports Knative Serving as an alternative to traditional ReplicaSets. This enables:
  - **Scale-to-zero**: Services automatically scale down when idle
  - **In-place updates**: Update services without changing their Restate deployment identity
  - **Tag-based identity**: Control versioning behavior with the `tag` field
  
  See the [Knative Serving Mode documentation](https://github.com/restatedev/restate-operator#knative-serving-mode) for details. (#64)

#### 🐛 Bug Fixes

* **Fix DNS network policy for NodeLocal DNSCache** - The operator now creates DNS egress policies that work with both traditional kube-dns and NodeLocal DNSCache (169.254.20.10). This fixes DNS resolution issues on GKE Autopilot and other Kubernetes environments using node-local DNS caching. (#88)

#### ⚙️ Configuration Changes

* **Default partitions increased to 24** - The default number of partitions is now 24 (previously lower). This provides better parallelism for most workloads. (#84)

#### 📝 Documentation

* Added dedicated Knative Serving mode section to README
* Added troubleshooting section for DNS resolution issues
* Updated RocksDB memory documentation (#82)

---

### Release Process

After this PR is approved and merged:
1. Tag the release: `git tag v2.2.0 && git push restate v2.2.0`
2. Wait for CI to create draft release
3. Edit release notes if needed and publish

### Upgrading Notes (for release)

**CRD Update Required**: Helm does not automatically upgrade CRDs. After upgrading the operator, users must manually apply the new CRDs:

```bash
kubectl apply --server-side -f https://github.com/restatedev/restate-operator/releases/download/v2.2.0/restateclusters.yaml
kubectl apply --server-side -f https://github.com/restatedev/restate-operator/releases/download/v2.2.0/restatedeployments.yaml
kubectl apply --server-side -f https://github.com/restatedev/restate-operator/releases/download/v2.2.0/restatecloudenvironments.yaml
```