### PR TITLE
fix: include message from restate in admin API errors

### DIFF
--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -131,6 +131,19 @@ impl Context {
     }
 }
 
+/// Check an admin API response, returning the response if successful or an error
+/// that includes the response body if not. This replaces the `error_for_status()`
+/// pattern which discards the response body.
+pub(crate) async fn check_admin_response(resp: reqwest::Response) -> Result<reqwest::Response> {
+    if resp.status().is_success() {
+        return Ok(resp);
+    }
+    let status = resp.status();
+    let url = resp.url().to_string();
+    let body = resp.text().await.unwrap_or_default();
+    Err(Error::AdminCallRejected { status, url, body })
+}
+
 #[instrument(skip(ctx, rs), fields(trace_id))]
 async fn reconcile(rs: Arc<RestateDeployment>, ctx: Arc<Context>) -> Result<Action> {
     if let Some(trace_id) = telemetry::get_trace_id() {
@@ -544,7 +557,7 @@ impl RestateDeployment {
                 Err(Error::AdminCallFailed(ref err)) => {
                     let message = format!("Failed to make Restate admin API call: {}", err);
                     let requeue_after = Duration::from_secs(30);
-                    debug!(
+                    warn!(
                         name = %self.metadata.name.as_deref().unwrap_or("unknown"),
                         namespace = %namespace,
                         error = %err,
@@ -555,6 +568,29 @@ impl RestateDeployment {
                         Ok(Action::requeue(requeue_after)),
                         message,
                         "AdminCallFailed".into(),
+                        "False".into(),
+                    )
+                }
+                Err(Error::AdminCallRejected {
+                    ref status,
+                    ref url,
+                    ref body,
+                }) => {
+                    let message = format!("Restate admin API call failed ({status}): {body}");
+                    let requeue_after = Duration::from_secs(30);
+                    warn!(
+                        name = %self.metadata.name.as_deref().unwrap_or("unknown"),
+                        namespace = %namespace,
+                        %status,
+                        %url,
+                        body = %body,
+                        requeue_after_secs = %requeue_after.as_secs(),
+                        "Admin API call rejected, requeueing"
+                    );
+                    (
+                        Ok(Action::requeue(requeue_after)),
+                        message,
+                        "AdminCallRejected".into(),
                         "False".into(),
                     )
                 }
@@ -581,7 +617,7 @@ impl RestateDeployment {
             }
         } else {
             // ReplicaSet mode
-            match self.reconcile(ctx, namespace).await {
+            match self.reconcile(ctx.clone(), namespace).await {
                 Ok((current_replicaset, next_removal)) => {
                     let action = match next_removal {
                         Some(next_removal) if next_removal < now => Action::requeue(Duration::ZERO), // immediate requeue
@@ -651,7 +687,7 @@ impl RestateDeployment {
                 Err(Error::AdminCallFailed(ref err)) => {
                     let message = format!("Failed to make Restate admin API call: {}", err);
                     let requeue_after = Duration::from_secs(30);
-                    debug!(
+                    warn!(
                         name = %self.metadata.name.as_deref().unwrap_or("unknown"),
                         namespace = %namespace,
                         error = %err,
@@ -662,6 +698,29 @@ impl RestateDeployment {
                         Ok(Action::requeue(requeue_after)),
                         message,
                         "AdminCallFailed".into(),
+                        "False".into(),
+                    )
+                }
+                Err(Error::AdminCallRejected {
+                    ref status,
+                    ref url,
+                    ref body,
+                }) => {
+                    let message = format!("Restate admin API call failed ({status}): {body}");
+                    let requeue_after = Duration::from_secs(30);
+                    warn!(
+                        name = %self.metadata.name.as_deref().unwrap_or("unknown"),
+                        namespace = %namespace,
+                        %status,
+                        %url,
+                        body = %body,
+                        requeue_after_secs = %requeue_after.as_secs(),
+                        "Admin API call rejected, requeueing"
+                    );
+                    (
+                        Ok(Action::requeue(requeue_after)),
+                        message,
+                        "AdminCallRejected".into(),
                         "False".into(),
                     )
                 }
@@ -676,6 +735,23 @@ impl RestateDeployment {
                 }
             }
         };
+
+        // Emit a K8s Warning event for admin API failures so they're visible
+        // via `kubectl describe` and `kubectl get events`
+        if reason == "AdminCallFailed" || reason == "AdminCallRejected" {
+            ctx.recorder
+                .publish(
+                    &Event {
+                        type_: EventType::Warning,
+                        reason: reason.clone(),
+                        note: Some(message.clone()),
+                        action: "Reconcile".into(),
+                        secondary: None,
+                    },
+                    &self.object_ref(&()),
+                )
+                .await?;
+        }
 
         let last_transition_time = if existing_ready.is_none_or(|r| r.status != status) {
             Time(now)
@@ -750,14 +826,14 @@ impl RestateDeployment {
             payload["use_http_11"] = serde_json::Value::Bool(use_http11);
         }
 
-        let resp: DeploymentResponse = ctx
+        let resp = ctx
             .request(Method::POST, &self.spec.restate.register, "/deployments")?
             .json(&payload)
             .send()
             .await
-            .map_err(Error::AdminCallFailed)?
-            .error_for_status()
-            .map_err(Error::AdminCallFailed)?
+            .map_err(Error::AdminCallFailed)?;
+        let resp: DeploymentResponse = check_admin_response(resp)
+            .await?
             .json()
             .await
             .map_err(Error::AdminCallFailed)?;
@@ -801,7 +877,7 @@ impl RestateDeployment {
             active: bool,
         }
 
-        let response: DeploymentQueryResult = ctx
+        let resp = ctx
             .request(Method::POST, &self.spec.restate.register, "/query")?
             .header(reqwest::header::ACCEPT, "application/json")
             .json(&serde_json::json!({
@@ -809,9 +885,9 @@ impl RestateDeployment {
             }))
             .send()
             .await
-            .map_err(Error::AdminCallFailed)?
-            .error_for_status()
-            .map_err(Error::AdminCallFailed)?
+            .map_err(Error::AdminCallFailed)?;
+        let response: DeploymentQueryResult = check_admin_response(resp)
+            .await?
             .json()
             .await
             .map_err(Error::AdminCallFailed)?;

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -908,7 +908,10 @@ pub async fn cleanup_old_configurations(
 
                     // for idempotency we have to allow 404
                     if resp.status() != reqwest::StatusCode::NOT_FOUND {
-                        let _ = resp.error_for_status().map_err(Error::AdminCallFailed)?;
+                        crate::controllers::restatedeployment::controller::check_admin_response(
+                            resp,
+                        )
+                        .await?;
                     }
                 }
 

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -338,7 +338,10 @@ pub async fn cleanup_old_replicasets(
 
                     // for idempotency we have to allow 404
                     if resp.status() != reqwest::StatusCode::NOT_FOUND {
-                        let _ = resp.error_for_status().map_err(Error::AdminCallFailed)?;
+                        crate::controllers::restatedeployment::controller::check_admin_response(
+                            resp,
+                        )
+                        .await?;
                     }
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,13 @@ pub enum Error {
     #[error("Failed to make Restate admin API call: {0}")]
     AdminCallFailed(reqwest::Error),
 
+    #[error("Restate admin API call failed ({status}): {body}")]
+    AdminCallRejected {
+        status: reqwest::StatusCode,
+        url: String,
+        body: String,
+    },
+
     #[error("Encountered a hash collision, will retry with a new template hash")]
     HashCollision,
 
@@ -105,6 +112,7 @@ impl Error {
             Error::InvalidBearerToken => "InvalidBearerToken",
             Error::InvalidSigningKeyError(_) => "InvalidSigningKeyError",
             Error::AdminCallFailed(_) => "AdminCallFailed",
+            Error::AdminCallRejected { .. } => "AdminCallRejected",
             Error::HashCollision => "HashCollision",
             Error::DeploymentInUse => "DeploymentInUse",
             Error::DeploymentDraining { .. } => "DeploymentDraining",


### PR DESCRIPTION
if you registered a deployment that included breaking changes, then the admin API call would fail (because the operator doesn't pass --force or --breaking), however the error message was unclear because it didn't include the helpful message returned from restate, and it was only discoverable in the status subresource, it wasn't logged.

- added a new error variant for admin API rejections
- added a helper that extracts the message out of the response body
- use that helper for all admin API call sites
- log the error when it happens and emit a k8s event

this scenario is now much easier to discover; by looking at the logs, at `describe` or `get events`.

i tested this by spinning up a kind cluster and registering a service that would return an error from the admin API. it emitted the event and logged it.

we really need better tests, so i filed #101.