### PR TITLE
fix: bind to dual-stack address

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -146,7 +146,7 @@ async fn main() -> anyhow::Result<()> {
             .service(health)
             .service(metrics)
     })
-    .bind("0.0.0.0:8080")?
+    .bind("[::]:8080")?
     .shutdown_timeout(5)
     .run();
 


### PR DESCRIPTION
closes #93 

the existing code bound to `0.0.0.0`, which works for IP 4&6. in fact `::` is technically more correct for dual-stack, but since `0.0.0.0` works for most people most people just use that. IP6-only is rare but becoming less rare, so this will come up more and more. TIL.

credit to @miran248 for finding this and suggesting the fix.