### PR TITLE
chore: regenerate manifests from pkl

### DIFF
--- a/crd/examples/restatecluster.pkl
+++ b/crd/examples/restatecluster.pkl
@@ -9,7 +9,7 @@ cluster = (RestateCluster) {
       autoProvision = true
     }
     compute {
-      image = "restatedev/restate:1.5.6"
+      image = "restatedev/restate:1.6.2"
     }
     storage {
       storageRequestBytes = 2.gib.toUnit("b").value as Int

--- a/crd/examples/restatecluster.yaml
+++ b/crd/examples/restatecluster.yaml
@@ -6,7 +6,7 @@ spec:
   cluster:
     autoProvision: true
   compute:
-    image: restatedev/restate:1.5.6
+    image: restatedev/restate:1.6.2
   config: auto-provision = false
   storage:
     storageRequestBytes: 2147483648


### PR DESCRIPTION
closes #99 

in commit c45b111 (PR #96) the yaml was hand edited, so the pkl generation has been out of sync since then. i simply re-ran it after updating the example and have committed the results. the output yaml is cosmetically different only.