### PR TITLE
fix: requeue based on drain delay when old deployments are still active

### DIFF
--- a/release-notes/unreleased/requeue-on-active-drain.md
+++ b/release-notes/unreleased/requeue-on-active-drain.md
@@ -1,0 +1,25 @@
+# Release Notes: Requeue based on drain delay when old deployments are still active
+
+## Bug Fix
+
+### What Changed
+When old deployment versions still have active invocations (draining), the
+operator now requeues based on `drainDelaySeconds` instead of the hardcoded
+5-minute reconcile interval. This applies to both ReplicaSet and Knative
+deployment modes.
+
+### Why This Matters
+Previously, even with `drainDelaySeconds: 0`, old versions could take up to
+5 minutes to be cleaned up because the controller's default requeue interval
+was always used when active invocations were still present. The drain delay
+setting had no effect on how quickly the operator polled for drain completion.
+
+### Impact on Users
+- `drainDelaySeconds: 0` now results in near-immediate cleanup polling
+  instead of a 5-minute wait
+- Custom drain delay values are now respected for requeue timing during the
+  active drain phase
+- No change for users relying on the default 300-second drain delay
+
+### Related Issues
+- Follow-up to PR #96 (configurable drain delay)

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -979,6 +979,17 @@ pub async fn cleanup_old_configurations(
         }
     }
 
+    // If there are active old deployments still draining but no removal is yet scheduled,
+    // signal the controller to requeue based on the drain delay instead of the default 5m interval.
+    if active_count > 0 && next_removal.is_none() {
+        let drain_delay_seconds = rsd.spec.restate.drain_delay_seconds();
+        next_removal = Some(
+            chrono::Utc::now()
+                .checked_add_signed(chrono::TimeDelta::seconds(drain_delay_seconds))
+                .expect("next_removal in bounds"),
+        );
+    }
+
     Ok((active_count, next_removal))
 }
 

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -402,5 +402,16 @@ pub async fn cleanup_old_replicasets(
         }
     }
 
+    // If there are active old deployments still draining but no removal is yet scheduled,
+    // signal the controller to requeue based on the drain delay instead of the default 5m interval.
+    if active_count > 0 && next_removal.is_none() {
+        let drain_delay_seconds = rsd.spec.restate.drain_delay_seconds();
+        next_removal = Some(
+            chrono::Utc::now()
+                .checked_add_signed(chrono::TimeDelta::seconds(drain_delay_seconds))
+                .expect("next_removal in bounds"),
+        );
+    }
+
     Ok((active_count, next_removal))
 }


### PR DESCRIPTION
## Summary

- When old deployment versions have active invocations (still draining), `cleanup_old_replicasets` / `cleanup_old_configurations` returned `next_removal = None`, causing the controller to fall back to the default 5-minute requeue interval
- This meant `drainDelaySeconds` (from #96) had no effect on how quickly the operator polled for drain completion — even `drainDelaySeconds: 0` resulted in a ~5 minute wait
- Now, when active old deployments exist but no removal is yet scheduled, `next_removal` is set to `now + drainDelaySeconds`, so the controller requeues appropriately

## Problem

The reconcile flow after a new version is deployed:

1. New ReplicaSet created + registered with Restate
2. `cleanup_old_replicasets` runs — old RS has `deployment_active = true` (in-flight invocations) → `continue` without contributing to `next_removal`
3. `next_removal = None` → controller requeues in `5 * 60` seconds (hardcoded default)
4. ~5 minutes later, invocations have drained, old deployment becomes inactive → removal annotation set → cleanup proceeds

With `drainDelaySeconds: 0`, step 3 should requeue immediately, not in 5 minutes.

## Fix

After the loop in both `cleanup_old_replicasets` (ReplicaSet mode) and `cleanup_old_configurations` (Knative mode), if there are active old deployments but `next_removal` is still `None`, set it to `now + drain_delay_seconds`. This causes the controller to requeue based on the configured drain delay rather than the hardcoded 5-minute interval.

## Test plan

- [ ] Deploy with `drainDelaySeconds: 0` and verify old ReplicaSets are cleaned up within seconds (one reconcile cycle) rather than ~5 minutes
- [ ] Deploy with default `drainDelaySeconds` (300) and verify no behavior change
- [ ] Verify Knative mode has equivalent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)