### PR TITLE
fix: poll every 10s when old deployments are actively draining

### DIFF
--- a/release-notes/unreleased/requeue-on-active-drain.md
+++ b/release-notes/unreleased/requeue-on-active-drain.md
@@ -1,0 +1,23 @@
+# Release Notes: Requeue based on drain poll interval when old deployments are still active
+
+## Bug Fix
+
+### What Changed
+When old deployment versions still have active invocations (draining), the
+operator now requeues every 10 seconds instead of the hardcoded 5-minute
+reconcile interval. This applies to both ReplicaSet and Knative deployment
+modes.
+
+### Why This Matters
+Previously, even with `drainDelaySeconds: 0`, old versions could take up to
+5 minutes to be cleaned up because the controller's default requeue interval
+was always used when active invocations were still present. The drain delay
+setting had no effect on how quickly the operator polled for drain completion.
+
+### Impact on Users
+- Cleanup of old versions now happens within ~10 seconds of drain completion
+  instead of up to 5 minutes
+- No configuration changes needed
+
+### Related Issues
+- Follow-up to PR #96 (configurable drain delay)

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -979,6 +979,17 @@ pub async fn cleanup_old_configurations(
         }
     }
 
+    // If there are active old deployments still draining but no removal is yet scheduled,
+    // requeue on a short poll interval to detect drain completion promptly.
+    if active_count > 0 && next_removal.is_none() {
+        let poll_seconds = 10;
+        next_removal = Some(
+            chrono::Utc::now()
+                .checked_add_signed(chrono::TimeDelta::seconds(poll_seconds))
+                .expect("next_removal in bounds"),
+        );
+    }
+
     Ok((active_count, next_removal))
 }
 

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -402,5 +402,16 @@ pub async fn cleanup_old_replicasets(
         }
     }
 
+    // If there are active old deployments still draining but no removal is yet scheduled,
+    // requeue on a short poll interval to detect drain completion promptly.
+    if active_count > 0 && next_removal.is_none() {
+        let poll_seconds = 10;
+        next_removal = Some(
+            chrono::Utc::now()
+                .checked_add_signed(chrono::TimeDelta::seconds(poll_seconds))
+                .expect("next_removal in bounds"),
+        );
+    }
+
     Ok((active_count, next_removal))
 }


### PR DESCRIPTION
When old deployments have active invocations (draining), `cleanup_old_replicasets` / `cleanup_old_configurations` [skip them](https://github.com/restatedev/restate-operator/blob/main/src/controllers/restatedeployment/reconcilers/replicaset.rs#L240) without setting `next_removal`, so the controller falls back to the [hardcoded 5-minute requeue](https://github.com/restatedev/restate-operator/blob/main/src/controllers/restatedeployment/controller.rs#L632). This means even with `drainDelaySeconds: 0`, cleanup takes ~5 minutes.

This PR polls every 10 seconds when active drains are detected, so the operator notices drain completion promptly instead of always waiting 5 minutes.

Open to discussion on the 10s interval - happy to make it configurable or use a different value if there's a preference.

Follow-up to #96.