### PR TITLE
chore: bump default tunnel client

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -50,7 +50,7 @@ struct Arguments {
         long = "tunnel-client-default-image",
         env = "OPERATOR_TUNNEL_CLIENT_DEFAULT_IMAGE",
         value_name = "IMAGE",
-        default_value = "ghcr.io/restatedev/restate-cloud-tunnel-client:0.5.0"
+        default_value = "ghcr.io/restatedev/restate-cloud-tunnel-client:0.6.0"
     )]
     tunnel_client_default_image: String,
 


### PR DESCRIPTION
closes #117 

in [this PR](https://github.com/restatedev/restate-cloud-tunnel-client/pull/16) a fix was made to handle the URLs you get if you're a restate BYOC customer. this PR bumps that to be the default region, as we had a BYOC customer discover that 0.5.0 didn't work for them and they had to reverse engineer what happened in the git history to figure it out and overwrite it themselves.