### PR TITLE
fix: route Knative service URLs through cloud tunnel when using Restate Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 target
+
+# Claude
+.claude/
+
+# Opencode
+.opencode/

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -662,6 +662,11 @@ async fn register_or_lookup_deployment(
         })?;
 
     let url = Url::parse(url_str)?;
+    let url = rsd
+        .spec
+        .restate
+        .register
+        .maybe_tunnel_url(&ctx.rce_store, url)?;
 
     let deployment_id = rsd
         .register_service_with_restate(ctx, &url, rsd.spec.restate.use_http11.as_ref().cloned())

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -374,30 +374,39 @@ impl RestateAdminEndpoint {
         service_path: Option<&str>,
         cluster_dns: &str,
     ) -> crate::Result<Url> {
-        match (
-            self.cluster.as_deref(),
-            self.cloud.as_deref(),
-            self.service.as_ref(),
-            self.url.as_ref(),
-        ) {
-            (Some(_), None, None, None)
-            | (None, None, Some(_), None)
-            | (None, None, None, Some(_)) => {
-                Ok(service_url(service_name, service_namespace, 9080, service_path, cluster_dns)?)
-            }
-            (None, Some(cloud), None, None) => {
-                let Some(rce) = rce_store.get(&ObjectRef::new(cloud)) else {
-                    return Err(crate::Error::RestateCloudEnvironmentNotFound(cloud.into()))
-                };
+        self.validate_exactly_one_set()?;
+        let url = service_url(service_name, service_namespace, 9080, service_path, cluster_dns)?;
+        self.maybe_tunnel_url(rce_store, url)
+    }
 
-                let service_url = service_url(service_name, service_namespace, 9080, service_path, cluster_dns)?;
-
-                Ok(rce.tunnel_url(service_url)?)
-            }
-            _ => Err(crate::Error::InvalidRestateConfig(
+    fn validate_exactly_one_set(&self) -> crate::Result<()> {
+        let count = self.cluster.is_some() as u8
+            + self.cloud.is_some() as u8
+            + self.service.is_some() as u8
+            + self.url.is_some() as u8;
+        if count != 1 {
+            return Err(crate::Error::InvalidRestateConfig(
                 "Exactly one of `cluster`, `cloud`, `service` or `url` must be specified in spec.restate"
                     .into(),
-            )),
+            ));
+        }
+        Ok(())
+    }
+
+    /// If this endpoint is configured to use Restate Cloud, rewrite the given URL
+    /// to go through the cloud tunnel. Otherwise, return the URL unchanged.
+    pub fn maybe_tunnel_url(
+        &self,
+        rce_store: &Store<RestateCloudEnvironment>,
+        url: Url,
+    ) -> crate::Result<Url> {
+        if let Some(cloud) = self.cloud.as_deref() {
+            let Some(rce) = rce_store.get(&ObjectRef::new(cloud)) else {
+                return Err(crate::Error::RestateCloudEnvironmentNotFound(cloud.into()));
+            };
+            Ok(rce.tunnel_url(url)?)
+        } else {
+            Ok(url)
         }
     }
 


### PR DESCRIPTION
The Knative reconciler was passing the raw in-cluster Route URL directly
to register_service_with_restate, which Restate Cloud cannot reach. This
adds maybe_tunnel_url() to RestateAdminEndpoint and uses it in the
Knative path, matching the existing ReplicaSet behavior. Also simplifies
service_url() to use the same method internally.

Closes https://github.com/restatedev/restate-operator/issues/120