### PR TITLE
Expose tolerations and nodeSelector in values

### DIFF
--- a/charts/restate-operator-helm/templates/deployment.yaml
+++ b/charts/restate-operator-helm/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
       affinity:
         {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "controller.fullname" . }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/restate-operator-helm/values.yaml
+++ b/charts/restate-operator-helm/values.yaml
@@ -37,6 +37,8 @@ logging:
 env: []
 
 affinity: {}
+nodeSelector: {}
+tolerations: []
 
 service:
   type: ClusterIP


### PR DESCRIPTION
The `tolerations` template was already in `deployment.yaml`, just wasn't declared in `values.yaml`. Adds the declaration and a matching `nodeSelector` block per issue #127