### PR TITLE
Add printer columns to RestateCloudEnvironment CRD

### DIFF
--- a/crd/restatecloudenvironments.yaml
+++ b/crd/restatecloudenvironments.yaml
@@ -12,7 +12,17 @@ spec:
     singular: restatecloudenvironment
   scope: Cluster
   versions:
-  - additionalPrinterColumns: []
+  - additionalPrinterColumns:
+    - jsonPath: .spec.environmentId
+      name: Environment
+      type: string
+    - jsonPath: .spec.region
+      name: Region
+      type: string
+    - description: CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/src/resources/restatecloudenvironments.rs
+++ b/src/resources/restatecloudenvironments.rs
@@ -19,7 +19,10 @@ pub static RESTATE_CLOUD_ENVIRONMENT_FINALIZER: &str = "cloudenvironments.restat
     kind = "RestateCloudEnvironment",
     group = "restate.dev",
     version = "v1beta1",
-    schema = "manual"
+    schema = "manual",
+    printcolumn = r#"{"name":"Environment", "type":"string", "jsonPath":".spec.environmentId"}"#,
+    printcolumn = r#"{"name":"Region", "type":"string", "jsonPath":".spec.region"}"#,
+    printcolumn = r#"{"name":"Age", "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC", "type":"date", "jsonPath":".metadata.creationTimestamp"}"#
 )]
 #[kube(shortname = "rce")]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Problem

`RestateCloudEnvironment` is the only Restate CRD without declared `printcolumn`s, so [`kube::CustomResourceExt::crd()`](https://docs.rs/kube-derive/latest/kube_derive/) emits:

\`\`\`yaml
versions:
- additionalPrinterColumns: []
  name: v1beta1
\`\`\`

The empty array is silently stripped by the k8s API server on apply (it's a default), but downstream tooling — most visibly ArgoCD — still sees \`additionalPrinterColumns: []\` in the rendered chart manifest while \`kubectl get crd … -o yaml\` returns nothing for the field. This produces perpetual drift on the CRD that **no amount of re-syncing can converge**, and shows up in ArgoCD as a Synced-but-with-diff state on the operator Application. Same issue happens for any user installing the Helm chart via GitOps.

## Fix

Add three useful `printcolumn` attributes — Environment, Region, Age — mirroring what `RestateCluster` already declares. Now `kube` emits real columns and downstream tooling stops drifting.

## Side benefit

\`kubectl get rce\` becomes genuinely useful:

\`\`\`
NAME                        ENVIRONMENT                          REGION   AGE
echofi-cloud-environment    env_201kc7eqa2yphqtdxs5z38vjjn6      us       7d
\`\`\`

(before this PR: just NAME + AGE.)

## Files changed

- \`src/resources/restatecloudenvironments.rs\` — three new \`printcolumn\` attributes inside \`#[kube(...)]\`
- \`crd/restatecloudenvironments.yaml\` — regenerated to match

## Testing

Edited the Rust source by hand and updated the generated YAML to match exactly what the macro would emit (mirroring the format of the existing \`RestateCluster\` CRD). Did not run \`just generate\` locally because the build chain (\`protoc\`, k8s libs) wasn't available — happy to re-run if a maintainer wants verification, but the diff is mechanical.