### PR TITLE
Emit resourceRef.apiVersion on restate-workload-identity IAMPolicyMember

### DIFF
--- a/release-notes/unreleased/iampolicymember-apiversion.md
+++ b/release-notes/unreleased/iampolicymember-apiversion.md
@@ -1,0 +1,42 @@
+# Release Notes: Fix IAMPolicyMember server-side apply wedge
+
+## Bug Fix
+
+### What Changed
+The `restate-workload-identity` IAMPolicyMember CR is now applied with
+`spec.resourceRef.apiVersion` set to `iam.cnrm.cloud.google.com/v1beta1`,
+matching the value Config Connector defaults at creation time.
+
+### Why This Matters
+The operator previously omitted `resourceRef.apiVersion` from its
+server-side apply request. Config Connector defaults the field on the
+initial create, but SSA's atomic-struct semantics then stripped that
+defaulted value on every subsequent reconcile. Config Connector's
+`deny-immutable-field-updates` admission webhook rejected the change
+with:
+
+```
+admission webhook "deny-immutable-field-updates.cnrm.cloud.google.com"
+denied the request: the IAMPolicyMember's spec is immutable
+```
+
+Reconcile looped on the failure and blocked unrelated `RestateCluster`
+updates (image overrides, resource changes, etc.) from being applied.
+
+### Impact on Users
+- Affects clusters using GCP workload identity binding via the operator
+  (BYOC installs on GKE / Config Connector).
+- Existing installs already wedged on this error are unblocked once the
+  upgraded operator runs a reconcile.
+- The webhook only fires on changes to immutable fields, and the value
+  the operator now emits matches what Config Connector defaulted at
+  create time, so the apply becomes a no-op for that field.
+
+### Migration Guidance
+No user action required beyond upgrading the operator. Existing BYOC
+installs need an operator chart version bump and a Nuon roll to pick
+up the fix.
+
+### Related Issues
+- restatedev/restate-cloud#833 (per-environment GCP service account
+  identity, where this bug was surfaced during dev canary validation)

--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -1292,6 +1292,11 @@ fn restate_iam_policy_member(
             member: format!("serviceAccount:{gcp_project}.svc.id.goog[{ns}/restate]"),
             role: "roles/iam.workloadIdentityUser".into(),
             resource_ref: IAMPolicyMemberResourceRef {
+                // Emit the apiVersion that Config Connector defaults on
+                // create. Without it, server-side apply strips the field
+                // from the existing object and the immutability webhook
+                // rejects every subsequent reconcile.
+                api_version: Some("iam.cnrm.cloud.google.com/v1beta1".into()),
                 kind: "IAMServiceAccount".into(),
                 external: Some(format!(
                     "projects/{gcp_project}/serviceAccounts/{gcp_service_account_email}"
@@ -1628,6 +1633,7 @@ mod tests {
                 member: "test".into(),
                 role: "test".into(),
                 resource_ref: IAMPolicyMemberResourceRef {
+                    api_version: None,
                     kind: "IAMServiceAccount".into(),
                     external: None,
                     name: None,
@@ -1676,6 +1682,7 @@ mod tests {
                 member: "test".into(),
                 role: "test".into(),
                 resource_ref: IAMPolicyMemberResourceRef {
+                    api_version: None,
                     kind: "IAMServiceAccount".into(),
                     external: None,
                     name: None,
@@ -1744,6 +1751,13 @@ mod tests {
             "sa@proj.iam.gserviceaccount.com",
         );
         assert_eq!(ipm.spec.resource_ref.kind, "IAMServiceAccount");
+        assert_eq!(
+            ipm.spec.resource_ref.api_version.as_deref(),
+            Some("iam.cnrm.cloud.google.com/v1beta1"),
+            "resourceRef.apiVersion must be emitted so server-side apply \
+             does not strip Config Connector's defaulted value and trip \
+             the deny-immutable-field-updates webhook",
+        );
         assert_eq!(
             ipm.spec.resource_ref.external.as_deref(),
             Some("projects/proj/serviceAccounts/sa@proj.iam.gserviceaccount.com")

--- a/src/resources/iampolicymembers.rs
+++ b/src/resources/iampolicymembers.rs
@@ -31,6 +31,14 @@ pub struct IAMPolicyMemberSpec {
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IAMPolicyMemberResourceRef {
+    /// The Config Connector API version of the referenced resource, e.g.
+    /// `iam.cnrm.cloud.google.com/v1beta1`. Config Connector defaults this
+    /// field at creation time; we must emit it on subsequent server-side
+    /// applies so the value is not stripped from the existing object and
+    /// rejected by the `deny-immutable-field-updates` webhook.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_version: Option<String>,
+
     /// The Config Connector kind, e.g. `IAMServiceAccount`
     pub kind: String,
 


### PR DESCRIPTION
## Summary

The operator's server-side apply of the `restate-workload-identity` `IAMPolicyMember` CR was sending `spec.resourceRef` without `apiVersion`. Config Connector defaults that field at creation, but SSA's atomic-struct semantics strip the defaulted value on every subsequent apply, and CC's `deny-immutable-field-updates` webhook then denies the change with:

```
admission webhook "deny-immutable-field-updates.cnrm.cloud.google.com" denied the request: the IAMPolicyMember's spec is immutable
```

Reconcile loops on this and blocks any unrelated `RestateCluster` update (e.g. image overrides) from propagating.

This change adds `apiVersion` to `IAMPolicyMemberResourceRef` and sets it to `iam.cnrm.cloud.google.com/v1beta1` when constructing the workload-identity binding (the referenced resource is always an `IAMServiceAccount`). The webhook only fires on changes to immutable fields, and the value the operator now emits matches what Config Connector defaulted at create time, so the apply becomes a no-op for that field.

Related: restatedev/restate-cloud#833

## Quality gates

All green inside the workspace:

- `cargo check`: passes
- `cargo nextest run --all-features`: 48 passed, 1 skipped
- `cargo fmt --all -- --check`: clean for files touched by this PR (a pre-existing fmt diff in `src/resources/restatedeployments.rs:375` is on `main` and out of scope here)
- `cargo clippy --all-features --all-targets -- -D warnings`: clean

## Rollout note

This needs an operator chart version bump and a Nuon roll to land on existing BYOC installs that are wedged on the immutability webhook.

## Test plan

- [x] Upgrade operator on a wedged dev BYOC env, confirm `IAMPolicyMember` reconciles cleanly and the wedge clears
- [x] Confirm a subsequent `RestateCluster` image override applies without retriggering the webhook
- [ ] Verify on a fresh install that the `IAMPolicyMember` is created and reaches `Ready=True`