### PR TITLE
fix: deregister Restate deployment before revision history check

### DIFF
--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -313,13 +313,10 @@ pub async fn cleanup_old_replicasets(
                         .await?;
                 }
 
-                // If we are here, there is a 0 sized replicaset which should be subject to the history limit
-                if historic_count < rsd.spec.revision_history_limit {
-                    historic_count += 1;
-                    // we haven't hit that limit yet, so we don't need to delete this rs
-                    continue;
-                }
-
+                // Deregister the Restate deployment before checking the history
+                // limit. A zero-scaled RS kept for history still has a Service
+                // with no endpoints; leaving the deployment registered causes
+                // Restate to route calls into the void.
                 if deployment_exists {
                     let rs_deployment_id = rs_deployment_id.unwrap();
 
@@ -343,6 +340,13 @@ pub async fn cleanup_old_replicasets(
                         )
                         .await?;
                     }
+                }
+
+                // If we are here, there is a 0 sized replicaset which should be subject to the history limit
+                if historic_count < rsd.spec.revision_history_limit {
+                    historic_count += 1;
+                    // we haven't hit that limit yet, so we don't need to delete this rs
+                    continue;
                 }
 
                 debug!("Deleting old ReplicaSet {rs_name} in namespace {namespace}");


### PR DESCRIPTION
## Summary

When a drained ReplicaSet is within the `revisionHistoryLimit`, the operator scales it to zero and keeps it for rollback history. However, the Restate deployment was only deregistered for RS that *exceeded* the limit and were being deleted.

This leaves ghost deployments registered in Restate that point at per-ReplicaSet Services with zero endpoints. Restate routes invocations to these deployments, resulting in connection failures / 404s that cascade into paused invocations on Virtual Objects.

The paused invocations then pin to the ghost deployment, marking it as "active" in `sys_invocation_status`, which prevents the operator from ever draining the associated ReplicaSet — creating a permanent death spiral where:

1. Ghost deployment → 404 → invocation paused
2. Paused invocation → deployment marked "active"
3. "Active" deployment → operator skips drain
4. Old RS stays running with stale pods → more ghost deployments accumulate on next rollout

## Fix

Move the `DELETE /deployments/{id}` call **before** the `revisionHistoryLimit` check so that Restate deployments are always removed when a RS is scaled to zero, regardless of whether the RS itself is kept for history.

## Reproduction

Reproduced locally with kind + restate-operator v2.1.0 + self-hosted RestateCluster:

1. Deploy a RestateDeployment with `revisionHistoryLimit: 3`
2. Perform 5 rollouts (annotation changes)
3. Wait for drains to complete
4. Observe: RS within history limit are scaled to 0, but their Restate deployments remain registered with zero-endpoint Services

After applying this fix, ghost deployments are deregistered on first reconcile.

Also confirmed in production (us-east-1): 31 Restate deployments accumulated over 83 days, 12 of which are complete orphans with no K8s RS, and 10 are ghost deployments from drained RS within the history limit.