### PR TITLE
Add tunnelMode: in-process for RestateDeployments registered against Restate Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ This field contains Restate-specific configuration.
 | `register` | `object` | **Required**. The location of the Restate Admin API to register this deployment against. See details below. |
 | `servicePath` | `string` | Optional path to append to the Service url when registering with Restate. |
 | `useHttp11`  | `boolean` | Force the use of HTTP/1.1 when registering with Restate. Defaults to HTTP/2 if not specified. |
+| `tunnelMode` | `string` | How Restate Cloud reaches this deployment; only takes effect with `register.cloud` (`in-process` requires it, and is not supported in Knative mode). `external` (default): invocations are forwarded to the deployment's Service by the tunnel-client pods managed by the `RestateCloudEnvironment`. `in-process`: the pods hold their own outbound tunnel connections. See [In-process tunnels](#in-process-tunnels). |
 
 
 The `register` field must specify exactly one of `cluster`, `service`, or `url`.
@@ -661,6 +662,77 @@ spec:
       cloud: my-cloud-environment
 ```
 
+#### In-process tunnels
+
+By default, invocations from Restate Cloud reach your services through the tunnel-client pods
+managed by the `RestateCloudEnvironment`, which forward them to each version's `Service`. With
+`tunnelMode: in-process`, your pods instead hold their own outbound tunnel connections — for
+example with the [`@restatedev/restate-sdk-tunnel`](https://www.npmjs.com/package/@restatedev/restate-sdk-tunnel)
+package — so invocations arrive without any inbound networking to the pods, and without
+tunnel-client pods on the invocation path.
+
+```yaml
+apiVersion: restate.dev/v1beta1
+kind: RestateDeployment
+metadata:
+  name: my-deployment
+spec:
+  restate:
+    register:
+      cloud: my-cloud-environment
+    tunnelMode: in-process
+  template:
+    spec:
+      containers:
+        - name: app
+          image: my-restate-service-image:main
+```
+
+In this mode the operator injects environment variables into every container of the pod
+template (including init containers, so native sidecars are covered), which in-process
+tunnel clients use to connect and identify themselves:
+
+| Variable | Value |
+|---|---|
+| `RESTATE_INPROC_TUNNEL_NAME` | The versioned name of this revision (e.g. `my-deployment-5b8c7d9f4`). Each replica registers its tunnel connections under this name, and the tunnel server load-balances invocations across them. |
+| `RESTATE_INPROC_ENVIRONMENT_ID` | The `environmentId` of the referenced `RestateCloudEnvironment`, normalized to its `env_`-prefixed form. |
+| `RESTATE_INPROC_CLOUD_REGION` | The `region` of the referenced `RestateCloudEnvironment`. |
+| `RESTATE_INPROC_SIGNING_PUBLIC_KEY` | The `signingPublicKey` of the referenced `RestateCloudEnvironment`, used to verify that requests genuinely come from your environment. |
+
+The operator then registers each version under its tunnel URL
+(`https://tunnel.<region>.restate.cloud:9080/<environment-id-without-env_-prefix>/<versioned-name>/http/in-process/9080/`)
+instead of the Service URL, and versioning, draining and removal work exactly as in the default
+mode. Because the tunnel name identifies a revision, a change to any of the injected values
+(like a rotated signing key) creates a new version. Unlike a pod template change, an edit to
+the `RestateCloudEnvironment` is only picked up on the next periodic reconciliation, so the
+new version may take a few minutes to appear.
+
+A few things to be aware of:
+
+- **Credentials are not injected.** Your pods still need a Restate Cloud API key with tunnel
+  access to open tunnel connections. Mount one from a `Secret` yourself, e.g. as a file whose
+  path you pass to the client (`RESTATE_INPROC_AUTH_TOKEN_FILE` is the conventional variable
+  name for file-based tokens, re-read on every reconnect so rotations are picked up).
+- **Declaring any of the four injected variables yourself is an error**: the operator refuses
+  to reconcile rather than risk pods that disagree with the URL it registers.
+  (`RESTATE_INPROC_AUTH_TOKEN_FILE` is yours to set, and values supplied indirectly via
+  `envFrom` are silently overridden by the injected entries — `env` takes precedence in
+  Kubernetes — rather than rejected.)
+- **Deployments are identified by content, not by namespace.** The tunnel name is
+  `<name>-<template-hash>`, so two `RestateDeployment`s with the same name and identical
+  content (template and Restate configuration) that register against the same environment —
+  across namespaces or even clusters — share one tunnel name and load-balance as one
+  deployment. That is coherent (same code, same environment, same registered URL), but if you
+  want isolation, give them distinct names.
+- **Rotate the signing key gracefully.** Old versions keep verifying requests with the key
+  they were created with. After a hard key cutover their in-flight invocations can no longer
+  be delivered, which also prevents them from draining; let old versions drain before
+  decommissioning the old key, or purge their invocations.
+- **Registration waits for pod readiness**, but pods become Ready slightly before their first
+  tunnel handshake completes; if registration races ahead it is retried after 30 seconds.
+  Consider a readiness probe that reflects tunnel establishment if you need tighter rollouts.
+- `tunnelMode: in-process` is not supported in Knative mode: the Knative autoscaler sees no
+  inbound traffic for tunnel invocations, so scale-to-zero would never scale back up.
 
 ### EKS Pod Identity
 

--- a/crd/restatedeployments.yaml
+++ b/crd/restatedeployments.yaml
@@ -198,6 +198,22 @@ spec:
                       If not provided, the service will be registered at the root path "/".
                     nullable: true
                     type: string
+                  tunnelMode:
+                    description: |-
+                      How Restate Cloud reaches this deployment. Only takes effect with
+                      `register.cloud` (`in-process` requires it, and is not supported in Knative
+                      mode).
+                      - `external` (default): invocations are forwarded to this deployment's Service
+                        by the tunnel-client pods managed by the RestateCloudEnvironment.
+                      - `in-process`: the deployment's pods hold their own outbound tunnel connections
+                        (e.g. with @restatedev/restate-sdk-tunnel), so no inbound networking to them is
+                        needed. The operator injects RESTATE_INPROC_* environment variables identifying
+                        the revision into the pod template and registers the per-revision tunnel URL.
+                    enum:
+                    - external
+                    - in-process
+                    nullable: true
+                    type: string
                   useHttp11:
                     description: Force the use of HTTP/1.1 when registering with Restate
                     nullable: true

--- a/release-notes/unreleased/144-in-process-tunnel-mode.md
+++ b/release-notes/unreleased/144-in-process-tunnel-mode.md
@@ -1,0 +1,53 @@
+# Release Notes for PR #144: `tunnelMode: in-process` for Restate Cloud deployments
+
+## New Feature
+
+### What Changed
+`RestateDeployment` gained `spec.restate.tunnelMode` (only takes effect with
+`register.cloud`). With `tunnelMode: in-process`, the deployment's pods hold
+their own outbound tunnel connections to Restate Cloud — for example with the
+`@restatedev/restate-sdk-tunnel` npm package — instead of being reached
+through the tunnel-client pods and each version's `Service`.
+
+For such deployments the operator:
+
+- injects `RESTATE_INPROC_TUNNEL_NAME` (the versioned name of the revision),
+  `RESTATE_INPROC_ENVIRONMENT_ID`, `RESTATE_INPROC_CLOUD_REGION` and
+  `RESTATE_INPROC_SIGNING_PUBLIC_KEY` into every container (and init
+  container) of the pod template; declaring one of these yourself is a
+  reconcile error. Credentials are never injected —
+  `RESTATE_INPROC_AUTH_TOKEN_FILE` is reserved for your own Secret mount
+- registers each version under its tunnel URL
+  (`https://tunnel.<region>.restate.cloud:9080/<env>/<versioned-name>/http/in-process/9080/`)
+  instead of the Service URL
+- mints a new version when the referenced `RestateCloudEnvironment`'s
+  environment id, region or signing key changes, exactly like a pod template
+  change (the values are folded into the revision hash — only when the mode
+  is set, so existing deployments keep their hashes)
+
+Versioning, draining, removal and the per-revision `Service` are unchanged.
+`tunnelMode: in-process` is rejected in Knative mode.
+
+### Why This Matters
+Workloads in private networks can serve a Restate Cloud environment with zero
+inbound networking — no Service reachability from the tunnel-client pods
+required — while keeping the operator's transparent per-revision registration
+and draining. Paired with the npm package's `RESTATE_INPROC_*` fallbacks,
+application code needs no tunnel configuration at all beyond a mounted API
+key.
+
+### Impact on Users
+- Existing deployments: no impact. The field is optional; hashes of
+  deployments that don't set it are unchanged, so no ReplicaSets roll on
+  upgrade.
+- New in-process deployments: set `tunnelMode: in-process` under
+  `spec.restate` with `register.cloud`, run an in-process tunnel client in
+  your pods, and mount an API key Secret (point
+  `RESTATE_INPROC_AUTH_TOKEN_FILE` at it).
+
+### Migration Guidance
+No migration required. To adopt the mode on an existing cloud-registered
+deployment, add `tunnelMode: in-process` — this creates a new version (new
+hash), which is registered through the tunnel while the old Service-routed
+version drains as usual. Reapply the CRDs (`kubectl apply --server-side -f
+crd/restatedeployments.yaml`) before using the new field.

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -207,6 +207,26 @@ fn error_policy<K, C>(_rs: Arc<K>, _: &Error, _ctx: C) -> Action {
 }
 
 impl RestateDeployment {
+    /// Resolve the RestateCloudEnvironment values a `tunnelMode: in-process`
+    /// deployment derives its identity from (None for every other mode). They feed
+    /// the revision hash, the env vars injected into the pods, the registered URL,
+    /// and the status labelSelector — all of which must agree.
+    fn in_process_tunnel_params(&self, ctx: &Context) -> Result<Option<InProcessTunnelParams>> {
+        if !self.spec.restate.is_in_process_tunnel() {
+            return Ok(None);
+        }
+        let Some(cloud) = self.spec.restate.register.cloud.as_deref() else {
+            return Err(Error::InvalidRestateConfig(
+                "tunnelMode: in-process requires registering against a RestateCloudEnvironment (spec.restate.register.cloud)"
+                    .into(),
+            ));
+        };
+        let Some(rce) = ctx.rce_store.get(&ObjectRef::new(cloud)) else {
+            return Err(Error::RestateCloudEnvironmentNotFound(cloud.into()));
+        };
+        Ok(Some(InProcessTunnelParams::from_rce(rce.as_ref())?))
+    }
+
     // Reconcile (for non-finalizer related changes)
     async fn reconcile(
         &self,
@@ -220,20 +240,7 @@ impl RestateDeployment {
         // tunnelMode: in-process needs the RestateCloudEnvironment values up front:
         // they feed the revision hash, the env vars injected into the pods, and the
         // registered URL, all of which must agree within one reconcile.
-        let in_process_tunnel = if self.spec.restate.is_in_process_tunnel() {
-            let Some(cloud) = self.spec.restate.register.cloud.as_deref() else {
-                return Err(Error::InvalidRestateConfig(
-                    "tunnelMode: in-process requires registering against a RestateCloudEnvironment (spec.restate.register.cloud)"
-                        .into(),
-                ));
-            };
-            let Some(rce) = ctx.rce_store.get(&ObjectRef::new(cloud)) else {
-                return Err(Error::RestateCloudEnvironmentNotFound(cloud.into()));
-            };
-            Some(InProcessTunnelParams::from_rce(rce.as_ref())?)
-        } else {
-            None
-        };
+        let in_process_tunnel = self.in_process_tunnel_params(&ctx)?;
 
         let pod_template_annotation = reconcilers::replicaset::pod_template_annotation(self);
 
@@ -836,7 +843,14 @@ impl RestateDeployment {
 
         // Only set labelSelector for ReplicaSet mode (Knative manages pods directly)
         if !is_knative {
-            rsd_status.label_selector = latest_version_label_selector(self);
+            // The selector hash must use the same inputs as the latest ReplicaSet's
+            // hash, including the in-process tunnel params. If those can't be
+            // resolved the reconcile above already failed; keep the previous
+            // selector rather than scoping to a hash no ReplicaSet has.
+            if let Ok(in_process_tunnel) = self.in_process_tunnel_params(&ctx) {
+                rsd_status.label_selector =
+                    latest_version_label_selector(self, in_process_tunnel.as_ref());
+            }
         }
         rsd_status.observed_generation = self.metadata.generation;
 
@@ -1073,12 +1087,19 @@ impl RestateDeployment {
 /// ReplicaSets still draining pinned invocations, polluting the averaged metric
 /// for the whole (potentially multi-hour) drain window and under-provisioning
 /// the genuinely-busy latest version. The hash is computed the same way as the
-/// latest versioned ReplicaSet, so the selector matches exactly that RS's pods.
+/// latest versioned ReplicaSet, so the selector matches exactly that RS's pods —
+/// which is why it takes the same in-process tunnel params as the hash.
 /// See #139.
-fn latest_version_label_selector(rsd: &RestateDeployment) -> Option<String> {
+fn latest_version_label_selector(
+    rsd: &RestateDeployment,
+    in_process_tunnel: Option<&InProcessTunnelParams>,
+) -> Option<String> {
     let pod_template_annotation = reconcilers::replicaset::pod_template_annotation(rsd);
-    let latest_hash =
-        reconcilers::replicaset::generate_pod_template_hash(rsd, &pod_template_annotation);
+    let latest_hash = reconcilers::replicaset::generate_pod_template_hash(
+        rsd,
+        &pod_template_annotation,
+        in_process_tunnel,
+    );
 
     let mut label_selector = rsd.spec.selector.clone().unwrap_or_default();
     label_selector
@@ -1391,13 +1412,13 @@ mod tests {
     /// The hash the latest versioned ReplicaSet would use, recomputed independently.
     fn latest_hash(rsd: &RestateDeployment) -> String {
         let annotation = reconcilers::replicaset::pod_template_annotation(rsd);
-        reconcilers::replicaset::generate_pod_template_hash(rsd, &annotation)
+        reconcilers::replicaset::generate_pod_template_hash(rsd, &annotation, None)
     }
 
     #[test]
     fn label_selector_appends_pod_template_hash_when_no_user_selector() {
         let rsd = make_rsd(None, "greeter:v1");
-        let selector = latest_version_label_selector(&rsd).expect("selector is set");
+        let selector = latest_version_label_selector(&rsd, None).expect("selector is set");
 
         // With no user selector the result is exactly the version scoping.
         assert_eq!(
@@ -1409,7 +1430,7 @@ mod tests {
     #[test]
     fn label_selector_preserves_user_match_labels() {
         let rsd = make_rsd(Some(&[("app", "greeter")]), "greeter:v1");
-        let selector = latest_version_label_selector(&rsd).expect("selector is set");
+        let selector = latest_version_label_selector(&rsd, None).expect("selector is set");
 
         // Both the user's label and the version scoping must be present (order
         // is not guaranteed by Selector::to_string).
@@ -1433,7 +1454,7 @@ mod tests {
         // same one used to name/select the latest versioned ReplicaSet, so the
         // HPA aggregates exactly that RS's pods and not old draining versions'.
         let rsd = make_rsd(Some(&[("app", "greeter")]), "greeter:v1");
-        let selector = latest_version_label_selector(&rsd).expect("selector is set");
+        let selector = latest_version_label_selector(&rsd, None).expect("selector is set");
 
         let versioned_name = format!("{}-{}", rsd.name_any(), latest_hash(&rsd));
         let hash = versioned_name
@@ -1448,19 +1469,49 @@ mod tests {
     }
 
     #[test]
+    fn label_selector_tracks_in_process_tunnel_params() {
+        // The #139 guarantee must hold for tunnelMode: in-process too: the selector
+        // hash incorporates the same tunnel params as the latest ReplicaSet's hash —
+        // computed without them it would scope the HPA to a hash no RS has.
+        use crate::resources::restatecloudenvironments::InProcessTunnelParams;
+
+        let rsd = make_rsd(Some(&[("app", "greeter")]), "greeter:v1");
+        let params = InProcessTunnelParams {
+            environment_id: "env_123".into(),
+            region: "us".into(),
+            signing_public_key: "publickeyv1_abc".into(),
+        };
+
+        let annotation = reconcilers::replicaset::pod_template_annotation(&rsd);
+        let rs_hash =
+            reconcilers::replicaset::generate_pod_template_hash(&rsd, &annotation, Some(&params));
+
+        let selector = latest_version_label_selector(&rsd, Some(&params)).expect("selector is set");
+        assert!(
+            selector.contains(&format!("{}={}", POD_TEMPLATE_HASH_LABEL, rs_hash)),
+            "selector {selector:?} does not scope to the in-process RS hash {rs_hash}"
+        );
+        assert_ne!(
+            selector,
+            latest_version_label_selector(&rsd, None).expect("selector without params"),
+            "params must change the selector, or the two hash sites have diverged"
+        );
+    }
+
+    #[test]
     fn label_selector_changes_with_pod_template() {
         // A different pod template => different version => different selector,
         // so the status selector actually tracks the current version.
         let v1 = make_rsd(Some(&[("app", "greeter")]), "greeter:v1");
         let v2 = make_rsd(Some(&[("app", "greeter")]), "greeter:v2");
 
-        let s1 = latest_version_label_selector(&v1).expect("v1 selector");
-        let s2 = latest_version_label_selector(&v2).expect("v2 selector");
+        let s1 = latest_version_label_selector(&v1, None).expect("v1 selector");
+        let s2 = latest_version_label_selector(&v2, None).expect("v2 selector");
 
         assert_ne!(s1, s2, "selector should differ across pod templates");
 
         // ...and it is deterministic for the same template.
-        let s1_again = latest_version_label_selector(&v1).expect("v1 selector again");
+        let s1_again = latest_version_label_selector(&v1, None).expect("v1 selector again");
         assert_eq!(s1, s1_again, "selector should be deterministic");
     }
 }

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -35,7 +35,7 @@ use url::Url;
 use crate::controllers::{Diagnostics, State, prewarmed_reflector};
 use crate::metrics::Metrics;
 use crate::resources::knative::{Configuration, Revision, Route};
-use crate::resources::restatecloudenvironments::RestateCloudEnvironment;
+use crate::resources::restatecloudenvironments::{InProcessTunnelParams, RestateCloudEnvironment};
 use crate::resources::restateclusters::RestateCluster;
 use crate::resources::restatedeployments::{
     RESTATE_DEPLOYMENT_FINALIZER, RestateAdminEndpoint, RestateDeployment,
@@ -47,7 +47,9 @@ use crate::{Error, Result};
 // Import our reconcilers
 use crate::controllers::restatedeployment::reconcilers;
 
-use super::reconcilers::replicaset::{POD_TEMPLATE_HASH_LABEL, RESTATE_POD_TEMPLATE_ANNOTATION};
+use super::reconcilers::replicaset::{
+    POD_TEMPLATE_HASH_LABEL, RESTATE_POD_TEMPLATE_ANNOTATION, RESTATE_TUNNEL_NAME_ANNOTATION,
+};
 
 pub(super) const RESTATE_DEPLOYMENT_ID_ANNOTATION: &str = "restate.dev/deployment-id";
 pub(super) const OWNED_BY_LABEL: &str = "restate.dev/owned-by";
@@ -215,11 +217,32 @@ impl RestateDeployment {
         let rs_api = Api::<ReplicaSet>::namespaced(ctx.client.clone(), namespace);
         let svc_api = Api::<Service>::namespaced(ctx.client.clone(), namespace);
 
+        // tunnelMode: in-process needs the RestateCloudEnvironment values up front:
+        // they feed the revision hash, the env vars injected into the pods, and the
+        // registered URL, all of which must agree within one reconcile.
+        let in_process_tunnel = if self.spec.restate.is_in_process_tunnel() {
+            let Some(cloud) = self.spec.restate.register.cloud.as_deref() else {
+                return Err(Error::InvalidRestateConfig(
+                    "tunnelMode: in-process requires registering against a RestateCloudEnvironment (spec.restate.register.cloud)"
+                        .into(),
+                ));
+            };
+            let Some(rce) = ctx.rce_store.get(&ObjectRef::new(cloud)) else {
+                return Err(Error::RestateCloudEnvironmentNotFound(cloud.into()));
+            };
+            Some(InProcessTunnelParams::from_rce(rce.as_ref())?)
+        } else {
+            None
+        };
+
         let pod_template_annotation = reconcilers::replicaset::pod_template_annotation(self);
 
         // Generate a hash for the pod template
-        let hash =
-            reconcilers::replicaset::generate_pod_template_hash(self, &pod_template_annotation);
+        let hash = reconcilers::replicaset::generate_pod_template_hash(
+            self,
+            &pod_template_annotation,
+            in_process_tunnel.as_ref(),
+        );
         let deployment_name = self.name_any();
         let versioned_name = format!("{deployment_name}-{hash}");
 
@@ -240,6 +263,9 @@ impl RestateDeployment {
         let mut annotations = self.annotations().clone();
         // if this is set on the rsd, don't propagate it
         annotations.remove("kubectl.kubernetes.io/last-applied-configuration");
+        // reserved for the operator: set on the ReplicaSet at creation in in-process
+        // tunnel mode; a value on the rsd must not propagate over it
+        annotations.remove(RESTATE_TUNNEL_NAME_ANNOTATION);
 
         // Create/update the ReplicaSet for this version
         let reconcile_result = reconcilers::replicaset::reconcile_replicaset(
@@ -255,9 +281,19 @@ impl RestateDeployment {
                     RESTATE_POD_TEMPLATE_ANNOTATION.to_string(),
                     pod_template_annotation.to_string(),
                 );
+                if in_process_tunnel.is_some() {
+                    // persist the tunnel name the pods were created with, so the
+                    // registered URL keeps matching them even if a future operator
+                    // version computes the hash differently
+                    annotations.insert(
+                        RESTATE_TUNNEL_NAME_ANNOTATION.to_string(),
+                        versioned_name.clone(),
+                    );
+                }
                 annotations
             },
             &hash,
+            in_process_tunnel.as_ref(),
         )
         .await;
 
@@ -344,13 +380,27 @@ impl RestateDeployment {
         )
         .await?;
 
-        let service_endpoint = self.spec.restate.register.service_url(
-            &ctx.rce_store,
-            &versioned_name,
-            namespace,
-            self.spec.restate.service_path.as_deref(),
-            &ctx.cluster_dns,
-        )?;
+        let service_endpoint = match &in_process_tunnel {
+            Some(params) => {
+                // The pods hold their own tunnel connections, registered under the
+                // versioned name; the Service plays no part in routing. Prefer the
+                // name persisted on the ReplicaSet at creation — that is the value
+                // injected into the pods.
+                let tunnel_name = replicaset
+                    .annotations()
+                    .get(RESTATE_TUNNEL_NAME_ANNOTATION)
+                    .map(String::as_str)
+                    .unwrap_or(versioned_name.as_str());
+                params.tunnel_url(tunnel_name, self.spec.restate.service_path.as_deref())?
+            }
+            None => self.spec.restate.register.service_url(
+                &ctx.rce_store,
+                &versioned_name,
+                namespace,
+                self.spec.restate.service_path.as_deref(),
+                &ctx.cluster_dns,
+            )?,
+        };
 
         let mut deployments = self.list_deployments(&ctx).await?;
 
@@ -490,9 +540,19 @@ impl RestateDeployment {
 
         let (result, message, reason, status) = if is_knative {
             // Delegate to Knative reconciler
-            match reconcilers::knative::reconcile_knative(&ctx, self, namespace, &mut rsd_status)
-                .await
-            {
+            let knative_result = if self.spec.restate.is_in_process_tunnel() {
+                // An in-process tunnel carries no traffic the Knative autoscaler can
+                // see, so scale-to-zero would take the deployment down permanently.
+                // Raised here rather than before the status machinery, so the Ready
+                // condition reflects the misconfiguration.
+                Err(Error::InvalidRestateConfig(
+                    "tunnelMode: in-process is not supported in Knative mode".into(),
+                ))
+            } else {
+                reconcilers::knative::reconcile_knative(&ctx, self, namespace, &mut rsd_status)
+                    .await
+            };
+            match knative_result {
                 Ok(next_removal) => {
                     let action = match next_removal {
                         Some(next_removal) if next_removal < now => Action::requeue(Duration::ZERO),

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -260,11 +260,14 @@ impl RestateDeployment {
             }
         };
 
+        // The rsd's annotations are copied onto the ReplicaSet/Service below; drop
+        // the ones the operator manages itself so a user-set value on the rsd can't
+        // shadow them on the way through.
         let mut annotations = self.annotations().clone();
-        // if this is set on the rsd, don't propagate it
+        // kubectl bookkeeping; meaningful only on the object it was applied to
         annotations.remove("kubectl.kubernetes.io/last-applied-configuration");
-        // reserved for the operator: set on the ReplicaSet at creation in in-process
-        // tunnel mode; a value on the rsd must not propagate over it
+        // recorded by the operator on the ReplicaSet at creation (in-process tunnel
+        // mode) and read back when building the registration URL
         annotations.remove(RESTATE_TUNNEL_NAME_ANNOTATION);
 
         // Create/update the ReplicaSet for this version

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -240,8 +240,9 @@ fn determine_tag(rsd: &RestateDeployment) -> Result<String> {
         Ok(tag.clone())
     } else {
         // Default: template hash (enables versioned updates)
+        // (tunnelMode: in-process is rejected in Knative mode, so no tunnel params here)
         let pod_template = serde_json::to_string(&rsd.spec.template)?;
-        Ok(generate_pod_template_hash(rsd, &pod_template))
+        Ok(generate_pod_template_hash(rsd, &pod_template, None))
     }
 }
 

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -15,14 +15,26 @@ use tracing::*;
 use crate::controllers::restatedeployment::controller::{
     APP_MANAGED_BY_LABEL, Context, OWNED_BY_LABEL, RESTATE_DEPLOYMENT_ID_ANNOTATION,
 };
+use crate::resources::restatecloudenvironments::InProcessTunnelParams;
 use crate::resources::restatedeployments::RestateDeployment;
 use crate::{Error, Result};
 
 pub const POD_TEMPLATE_HASH_LABEL: &str = "pod-template-hash";
 pub const RESTATE_POD_TEMPLATE_ANNOTATION: &str = "restate.dev/pod-template";
 pub const RESTATE_REMOVE_VERSION_AT_ANNOTATION: &str = "restate.dev/remove-version-at";
+/// Records the tunnel name a `tunnelMode: in-process` ReplicaSet was created with —
+/// the same value injected into its pods as RESTATE_INPROC_TUNNEL_NAME.
+pub const RESTATE_TUNNEL_NAME_ANNOTATION: &str = "restate.dev/tunnel-name";
+
+// The environment variables in-process tunnel clients (e.g.
+// @restatedev/restate-sdk-tunnel) resolve their configuration from.
+pub const INPROC_TUNNEL_NAME_ENV: &str = "RESTATE_INPROC_TUNNEL_NAME";
+pub const INPROC_ENVIRONMENT_ID_ENV: &str = "RESTATE_INPROC_ENVIRONMENT_ID";
+pub const INPROC_CLOUD_REGION_ENV: &str = "RESTATE_INPROC_CLOUD_REGION";
+pub const INPROC_SIGNING_PUBLIC_KEY_ENV: &str = "RESTATE_INPROC_SIGNING_PUBLIC_KEY";
 
 /// Ensure a ReplicaSet exists for the latest RestateDeployment version
+#[allow(clippy::too_many_arguments)]
 pub async fn reconcile_replicaset(
     client: &kube::Client,
     rsd: &RestateDeployment,
@@ -31,6 +43,7 @@ pub async fn reconcile_replicaset(
     match_labels: BTreeMap<String, String>,
     annotations: BTreeMap<String, String>,
     hash: &str,
+    in_process_tunnel: Option<&InProcessTunnelParams>,
 ) -> Result<ReplicaSet> {
     // Add version and hash to pod template
     let mut template_metadata = rsd.spec.template.metadata.clone();
@@ -57,6 +70,18 @@ pub async fn reconcile_replicaset(
     // Create replicaset ownership reference
     let owner_reference = rsd.controller_owner_ref(&()).unwrap();
 
+    // Like the pod-template-hash label, the RESTATE_INPROC_* env vars are injected after
+    // hashing — but every injected value derives from hash inputs (the versioned name and
+    // the RestateCloudEnvironment values), so a change in any of them mints a new revision.
+    let template_spec = match (&rsd.spec.template.spec, in_process_tunnel) {
+        (Some(spec), Some(params)) => Some(inject_in_process_tunnel_env(
+            spec.clone(),
+            versioned_name,
+            params,
+        )?),
+        (spec, _) => spec.clone(),
+    };
+
     // Create the replicaset - the pod template should be passed through directly so we can't use the proper type
     let rs_resource = ApiResource::erase::<ReplicaSet>(&());
     let mut replicaset = DynamicObject::new(versioned_name, &rs_resource).within(namespace);
@@ -74,7 +99,7 @@ pub async fn reconcile_replicaset(
             },
             "template": {
                 "metadata": template_metadata,
-                "spec": rsd.spec.template.spec,
+                "spec": template_spec,
             },
             "minReadySeconds": rsd.spec.min_ready_seconds,
         }
@@ -97,12 +122,78 @@ pub async fn reconcile_replicaset(
     Ok(applied_rs)
 }
 
+/// Inject the RESTATE_INPROC_* environment variables that in-process tunnel clients
+/// resolve their configuration from, into every container of the pod template —
+/// including initContainers, so native sidecars (restartPolicy: Always) are covered.
+/// A container that already declares one of them is an error: silently keeping the
+/// user value would desync the pods from the URL the operator registers.
+fn inject_in_process_tunnel_env(
+    mut spec: serde_json::Value,
+    tunnel_name: &str,
+    params: &InProcessTunnelParams,
+) -> Result<serde_json::Value> {
+    let vars = [
+        (INPROC_TUNNEL_NAME_ENV, tunnel_name),
+        (INPROC_ENVIRONMENT_ID_ENV, params.environment_id.as_str()),
+        (INPROC_CLOUD_REGION_ENV, params.region.as_str()),
+        (
+            INPROC_SIGNING_PUBLIC_KEY_ENV,
+            params.signing_public_key.as_str(),
+        ),
+    ];
+
+    // a pod spec without containers is invalid; let the api server report that
+    for field in ["containers", "initContainers"] {
+        let Some(containers) = spec.get_mut(field).and_then(|c| c.as_array_mut()) else {
+            continue;
+        };
+
+        for container in containers.iter_mut() {
+            let Some(container) = container.as_object_mut() else {
+                continue;
+            };
+            let container_name = container
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("<unnamed>")
+                .to_owned();
+
+            let env = container
+                .entry("env")
+                .or_insert_with(|| serde_json::Value::Array(Vec::new()));
+            let Some(env) = env.as_array_mut() else {
+                return Err(Error::InvalidRestateConfig(format!(
+                    "container '{container_name}' has a non-array `env` field"
+                )));
+            };
+
+            for (var, value) in vars {
+                if env
+                    .iter()
+                    .any(|entry| entry.get("name").and_then(|n| n.as_str()) == Some(var))
+                {
+                    return Err(Error::InvalidRestateConfig(format!(
+                        "tunnelMode: in-process injects the environment variable `{var}`, but container '{container_name}' already declares it; remove it from the pod template"
+                    )));
+                }
+                env.push(json!({"name": var, "value": value}));
+            }
+        }
+    }
+
+    Ok(spec)
+}
+
 pub fn pod_template_annotation(rs: &RestateDeployment) -> String {
     serde_json::to_string(&rs.spec.template).expect("PodTemplateSpec to serialize")
 }
 
 /// Generate a hash for a pod template to uniquely identify versions
-pub fn generate_pod_template_hash(rsd: &RestateDeployment, pod_template: &str) -> String {
+pub fn generate_pod_template_hash(
+    rsd: &RestateDeployment,
+    pod_template: &str,
+    in_process_tunnel: Option<&InProcessTunnelParams>,
+) -> String {
     use std::hash::Hasher;
 
     let mut hasher = fnv::FnvHasher::default();
@@ -123,6 +214,23 @@ pub fn generate_pod_template_hash(rsd: &RestateDeployment, pod_template: &str) -
     if let Some(true) = rsd.spec.restate.use_http11 {
         hasher.write(b"use_http11");
     }
+
+    // In-process tunnel mode injects these values into the pods and bakes the versioned
+    // name into the registered URL, so changing any of them must mint a new revision.
+    // Folded in only when the mode is set, so existing deployments keep their hashes.
+    if let Some(params) = in_process_tunnel {
+        hasher.write(b"tunnel_mode=in-process");
+        for value in [
+            &params.environment_id,
+            &params.region,
+            &params.signing_public_key,
+        ] {
+            // length-prefixed so distinct tuples can't concatenate identically
+            hasher.write(&(value.len() as u64).to_be_bytes());
+            hasher.write(value.as_bytes());
+        }
+    }
+
     if let Some(collision_count) = rsd.status.as_ref().and_then(|s| s.collision_count) {
         hasher.write(&collision_count.to_be_bytes());
     }
@@ -414,4 +522,195 @@ pub async fn cleanup_old_replicasets(
     }
 
     Ok((active_count, next_removal))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::resources::restatedeployments::{
+        PodTemplateSpec, RestateAdminEndpoint, RestateDeploymentSpec, RestateSpec, TunnelMode,
+    };
+    use serde_json::json;
+
+    fn test_rsd(tunnel_mode: Option<TunnelMode>) -> RestateDeployment {
+        RestateDeployment::new(
+            "greeter",
+            RestateDeploymentSpec {
+                deployment_mode: None,
+                knative: None,
+                replicas: 1,
+                revision_history_limit: 10,
+                min_ready_seconds: None,
+                selector: None,
+                template: PodTemplateSpec {
+                    metadata: None,
+                    spec: Some(json!({"containers": [{"name": "app", "image": "greeter:1"}]})),
+                },
+                restate: RestateSpec {
+                    register: RestateAdminEndpoint {
+                        cluster: None,
+                        cloud: Some("my-env".into()),
+                        service: None,
+                        url: None,
+                    },
+                    service_path: None,
+                    use_http11: None,
+                    tunnel_mode,
+                    drain_delay_seconds: None,
+                },
+            },
+        )
+    }
+
+    fn test_params() -> InProcessTunnelParams {
+        InProcessTunnelParams {
+            environment_id: "env_123".into(),
+            region: "us".into(),
+            signing_public_key: "publickeyv1_abc".into(),
+        }
+    }
+
+    #[test]
+    fn hash_unchanged_without_in_process_tunnel() {
+        // the only-when-set property: deployments that don't use the mode must keep
+        // their hashes across operator upgrades
+        let rsd = test_rsd(None);
+        let template = pod_template_annotation(&rsd);
+        assert_eq!(
+            generate_pod_template_hash(&rsd, &template, None),
+            generate_pod_template_hash(&rsd, &template, None),
+        );
+    }
+
+    #[test]
+    fn hash_incorporates_in_process_tunnel_params() {
+        let rsd = test_rsd(Some(TunnelMode::InProcess));
+        let template = pod_template_annotation(&rsd);
+
+        let without = generate_pod_template_hash(&rsd, &template, None);
+        let with = generate_pod_template_hash(&rsd, &template, Some(&test_params()));
+        assert_ne!(without, with);
+
+        let mut repointed = test_params();
+        repointed.environment_id = "env_456".into();
+        assert_ne!(
+            generate_pod_template_hash(&rsd, &template, Some(&repointed)),
+            with
+        );
+
+        let mut rotated = test_params();
+        rotated.signing_public_key = "publickeyv1_xyz".into();
+        assert_ne!(
+            generate_pod_template_hash(&rsd, &template, Some(&rotated)),
+            with
+        );
+
+        let mut moved = test_params();
+        moved.region = "eu".into();
+        assert_ne!(
+            generate_pod_template_hash(&rsd, &template, Some(&moved)),
+            with
+        );
+
+        // deterministic for equal inputs
+        assert_eq!(
+            generate_pod_template_hash(&rsd, &template, Some(&test_params())),
+            with
+        );
+    }
+
+    #[test]
+    fn inject_appends_env_to_every_container() {
+        let spec = json!({
+            "containers": [
+                {"name": "app", "image": "greeter:1", "env": [{"name": "USER_VAR", "value": "kept"}]},
+                {"name": "sidecar", "image": "proxy:1"},
+            ],
+            "serviceAccountName": "greeter",
+        });
+
+        let injected =
+            inject_in_process_tunnel_env(spec, "greeter-abc123", &test_params()).unwrap();
+
+        // untouched fields pass through
+        assert_eq!(injected["serviceAccountName"], "greeter");
+
+        for (container, expected_len) in [(0, 5), (1, 4)] {
+            let env = injected["containers"][container]["env"].as_array().unwrap();
+            assert_eq!(env.len(), expected_len, "container {container}");
+            let get = |name: &str| {
+                env.iter()
+                    .find(|e| e["name"] == name)
+                    .unwrap_or_else(|| panic!("{name} missing in container {container}"))["value"]
+                    .clone()
+            };
+            assert_eq!(get(INPROC_TUNNEL_NAME_ENV), "greeter-abc123");
+            assert_eq!(get(INPROC_ENVIRONMENT_ID_ENV), "env_123");
+            assert_eq!(get(INPROC_CLOUD_REGION_ENV), "us");
+            assert_eq!(get(INPROC_SIGNING_PUBLIC_KEY_ENV), "publickeyv1_abc");
+        }
+
+        // user env is preserved
+        assert_eq!(injected["containers"][0]["env"][0]["name"], "USER_VAR");
+    }
+
+    #[test]
+    fn inject_covers_init_containers() {
+        // native sidecars (initContainers with restartPolicy: Always) may host the
+        // tunnel client too — they get the same env vars and the same conflict check
+        let spec = json!({
+            "containers": [{"name": "app"}],
+            "initContainers": [{"name": "sidecar", "restartPolicy": "Always"}],
+        });
+        let injected =
+            inject_in_process_tunnel_env(spec, "greeter-abc123", &test_params()).unwrap();
+        let env = injected["initContainers"][0]["env"].as_array().unwrap();
+        assert_eq!(env.len(), 4);
+        assert_eq!(env[0]["name"], INPROC_TUNNEL_NAME_ENV);
+
+        let conflicting = json!({
+            "containers": [{"name": "app"}],
+            "initContainers": [
+                {"name": "sidecar", "env": [{"name": INPROC_ENVIRONMENT_ID_ENV, "value": "mine"}]},
+            ],
+        });
+        let err = inject_in_process_tunnel_env(conflicting, "greeter-abc123", &test_params())
+            .expect_err("user-declared RESTATE_INPROC_* in an initContainer must be rejected");
+        assert!(err.to_string().contains("sidecar"));
+    }
+
+    #[test]
+    fn inject_rejects_user_declared_inproc_var() {
+        let spec = json!({
+            "containers": [
+                {"name": "app", "env": [{"name": INPROC_TUNNEL_NAME_ENV, "value": "mine"}]},
+            ],
+        });
+
+        let err = inject_in_process_tunnel_env(spec, "greeter-abc123", &test_params())
+            .expect_err("user-declared RESTATE_INPROC_* must be rejected");
+        assert!(matches!(err, Error::InvalidRestateConfig(_)));
+        assert!(err.to_string().contains(INPROC_TUNNEL_NAME_ENV));
+        assert!(err.to_string().contains("app"));
+    }
+
+    #[test]
+    fn inject_rejects_non_array_env() {
+        let spec = json!({
+            "containers": [{"name": "app", "env": "oops"}],
+        });
+
+        let err = inject_in_process_tunnel_env(spec, "greeter-abc123", &test_params())
+            .expect_err("non-array env must be rejected");
+        assert!(matches!(err, Error::InvalidRestateConfig(_)));
+    }
+
+    #[test]
+    fn inject_passes_through_invalid_pod_specs() {
+        // a pod spec without containers is invalid; the api server reports that better
+        let spec = json!({"volumes": []});
+        let injected =
+            inject_in_process_tunnel_env(spec.clone(), "greeter-abc123", &test_params()).unwrap();
+        assert_eq!(injected, spec);
+    }
 }

--- a/src/resources/restatecloudenvironments.rs
+++ b/src/resources/restatecloudenvironments.rs
@@ -70,27 +70,24 @@ impl schemars::JsonSchema for RestateCloudEnvironment {
 }
 
 impl RestateCloudEnvironment {
-    pub fn admin_url(&self) -> Result<Url, url::ParseError> {
-        let unprefixed_env = self
-            .spec
+    pub fn unprefixed_environment_id(&self) -> &str {
+        self.spec
             .environment_id
             .strip_prefix("env_")
             // if there is no env_ prefix just use it as is
-            .unwrap_or(self.spec.environment_id.as_str());
+            .unwrap_or(self.spec.environment_id.as_str())
+    }
 
+    pub fn admin_url(&self) -> Result<Url, url::ParseError> {
         Url::parse(&format!(
             "https://{}.env.{}.restate.cloud:9070",
-            unprefixed_env, self.spec.region
+            self.unprefixed_environment_id(),
+            self.spec.region
         ))
     }
 
     pub fn tunnel_url(&self, service_url: Url) -> Result<Url, url::ParseError> {
-        let unprefixed_env = self
-            .spec
-            .environment_id
-            .strip_prefix("env_")
-            // if there is no env_ prefix just use it as is
-            .unwrap_or(self.spec.environment_id.as_str());
+        let unprefixed_env = self.unprefixed_environment_id();
 
         let tunnel_name = self
             .metadata
@@ -146,6 +143,111 @@ impl RestateCloudEnvironment {
         match String::from_utf8(bytes) {
             Ok(token) => Ok(token),
             Err(_) => Err(crate::Error::InvalidBearerToken),
+        }
+    }
+}
+
+/// The RestateCloudEnvironment-derived values a `tunnelMode: in-process` deployment
+/// needs. They serve three purposes that must stay consistent within one revision:
+/// they are injected into the pods as `RESTATE_INPROC_*` environment variables, folded
+/// into the revision hash (so a change mints a new revision), and used to build the
+/// tunnel URL the revision is registered under.
+#[derive(Clone, Debug)]
+pub struct InProcessTunnelParams {
+    pub environment_id: String,
+    pub region: String,
+    pub signing_public_key: String,
+}
+
+impl InProcessTunnelParams {
+    /// Resolve and validate the values from a RestateCloudEnvironment. In-process
+    /// tunnel clients (e.g. @restatedev/restate-sdk-tunnel) validate these strictly,
+    /// so an RCE field that deviates from its documented shape must fail the
+    /// reconcile here — the alternative is pods that crash-loop on the injected
+    /// values while the RestateDeployment shows nothing but "not ready".
+    pub fn from_rce(rce: &RestateCloudEnvironment) -> Result<Self, crate::Error> {
+        let rce_name = rce.metadata.name.as_deref().unwrap_or("<unnamed>");
+
+        // Normalized to the env_-prefixed spelling: the RCE tolerates an unprefixed
+        // id, but the injected value and the tunnel handshake use the prefixed form.
+        let unprefixed = rce.unprefixed_environment_id();
+        if unprefixed.is_empty()
+            || !unprefixed
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        {
+            return Err(crate::Error::InvalidRestateConfig(format!(
+                "tunnelMode: in-process requires RestateCloudEnvironment '{rce_name}' to have an environmentId of the form env_<alphanumerics>, got {:?}",
+                rce.spec.environment_id,
+            )));
+        }
+        let environment_id = format!("env_{unprefixed}");
+
+        let region = rce.spec.region.clone();
+        if region.is_empty()
+            || !region
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+        {
+            return Err(crate::Error::InvalidRestateConfig(format!(
+                "tunnelMode: in-process requires RestateCloudEnvironment '{rce_name}' to have a lowercase region (letters, digits, '-'), got {:?}",
+                rce.spec.region,
+            )));
+        }
+
+        let signing_public_key = rce.spec.signing_public_key.clone();
+        if !signing_public_key.starts_with("publickeyv1_") {
+            return Err(crate::Error::InvalidRestateConfig(format!(
+                "tunnelMode: in-process requires RestateCloudEnvironment '{rce_name}' to have a signingPublicKey starting with publickeyv1_, got {:?}",
+                rce.spec.signing_public_key,
+            )));
+        }
+
+        Ok(Self {
+            environment_id,
+            region,
+            signing_public_key,
+        })
+    }
+
+    pub fn unprefixed_environment_id(&self) -> &str {
+        self.environment_id
+            .strip_prefix("env_")
+            // if there is no env_ prefix just use it as is
+            .unwrap_or(self.environment_id.as_str())
+    }
+
+    /// The URL to register for a deployment whose pods hold their own tunnel
+    /// connections under `tunnel_name`. The tunnel server routes purely by the
+    /// `{environment}/{tunnel_name}` key; the `/http/in-process/9080/` destination
+    /// segment is a constant shared with in-process tunnel clients (e.g.
+    /// @restatedev/restate-sdk-tunnel), which strip it without ever dialing it.
+    pub fn tunnel_url(
+        &self,
+        tunnel_name: &str,
+        service_path: Option<&str>,
+    ) -> Result<Url, crate::Error> {
+        let url = Url::parse(&format!(
+            "https://tunnel.{}.restate.cloud:9080/{}/{tunnel_name}/http/in-process/9080/",
+            self.region,
+            self.unprefixed_environment_id(),
+        ))?;
+
+        match service_path {
+            Some(path) => {
+                let joined = url.join(path.trim_start_matches('/'))?;
+                // Url::join resolves dot-segments and absolute references, so a
+                // hostile-but-CRD-valid servicePath ("http://elsewhere", "../..")
+                // could silently rewrite the base — and with it the rendezvous
+                // key the pods actually hold. The path may only append.
+                if !joined.as_str().starts_with(url.as_str()) {
+                    return Err(crate::Error::InvalidRestateConfig(format!(
+                        "spec.restate.servicePath {path:?} escapes the tunnel URL; it must be a plain path to append"
+                    )));
+                }
+                Ok(joined)
+            }
+            None => Ok(url),
         }
     }
 }
@@ -216,4 +318,118 @@ fn node_selector_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
         "type": "object",
         "x-kubernetes-map-type": "atomic"
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn params() -> InProcessTunnelParams {
+        InProcessTunnelParams {
+            environment_id: "env_123abc".into(),
+            region: "us".into(),
+            signing_public_key: "publickeyv1_abc".into(),
+        }
+    }
+
+    #[test]
+    fn in_process_tunnel_url() {
+        assert_eq!(
+            params()
+                .tunnel_url("greeter-5b8c7d", None)
+                .unwrap()
+                .as_str(),
+            "https://tunnel.us.restate.cloud:9080/123abc/greeter-5b8c7d/http/in-process/9080/"
+        );
+    }
+
+    #[test]
+    fn in_process_tunnel_url_tolerates_unprefixed_environment_id() {
+        let mut params = params();
+        params.environment_id = "123abc".into();
+        assert_eq!(
+            params.tunnel_url("greeter-5b8c7d", None).unwrap().as_str(),
+            "https://tunnel.us.restate.cloud:9080/123abc/greeter-5b8c7d/http/in-process/9080/"
+        );
+    }
+
+    #[test]
+    fn in_process_tunnel_url_appends_service_path() {
+        for service_path in ["/api/restate", "api/restate"] {
+            assert_eq!(
+                params()
+                    .tunnel_url("greeter-5b8c7d", Some(service_path))
+                    .unwrap()
+                    .as_str(),
+                "https://tunnel.us.restate.cloud:9080/123abc/greeter-5b8c7d/http/in-process/9080/api/restate"
+            );
+        }
+    }
+
+    #[test]
+    fn in_process_tunnel_url_rejects_escaping_service_paths() {
+        // Url::join resolves these into a different base — the registered URL
+        // would no longer contain the rendezvous key the pods hold
+        for service_path in [
+            "http://elsewhere.example",
+            "../..",
+            "../../../otherenv/othertunnel/http/in-process/9080/",
+        ] {
+            let err = params()
+                .tunnel_url("greeter-5b8c7d", Some(service_path))
+                .expect_err(service_path);
+            assert!(matches!(err, crate::Error::InvalidRestateConfig(_)));
+        }
+    }
+
+    fn rce(
+        environment_id: &str,
+        region: &str,
+        signing_public_key: &str,
+    ) -> RestateCloudEnvironment {
+        RestateCloudEnvironment::new(
+            "my-env",
+            RestateCloudEnvironmentSpec {
+                environment_id: environment_id.into(),
+                region: region.into(),
+                signing_public_key: signing_public_key.into(),
+                authentication: RestateCloudEnvironmentAuthentication {
+                    secret: SecretReference {
+                        name: "secret".into(),
+                        key: "token".into(),
+                    },
+                },
+                tunnel: None,
+            },
+        )
+    }
+
+    #[test]
+    fn from_rce_normalizes_the_environment_id() {
+        // both spellings inject the env_-prefixed form the tunnel handshake uses
+        for id in ["env_123abc", "123abc"] {
+            let params =
+                InProcessTunnelParams::from_rce(&rce(id, "us", "publickeyv1_abc")).unwrap();
+            assert_eq!(params.environment_id, "env_123abc");
+        }
+    }
+
+    #[test]
+    fn from_rce_rejects_values_in_process_clients_would_crash_on() {
+        // in-process tunnel clients validate these on startup; a bad value must
+        // fail the reconcile instead of crash-looping the pods
+        for (id, region, key) in [
+            ("", "us", "publickeyv1_abc"),
+            ("env_", "us", "publickeyv1_abc"),
+            ("env_a b", "us", "publickeyv1_abc"),
+            ("env_123abc", "", "publickeyv1_abc"),
+            ("env_123abc", "US", "publickeyv1_abc"),
+            ("env_123abc", "us/extra", "publickeyv1_abc"),
+            ("env_123abc", "us", "not-a-key"),
+        ] {
+            let err = InProcessTunnelParams::from_rce(&rce(id, region, key))
+                .expect_err(&format!("({id:?}, {region:?}, {key:?})"));
+            assert!(matches!(err, crate::Error::InvalidRestateConfig(_)));
+        }
+    }
 }

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -26,6 +26,23 @@ pub enum DeploymentMode {
     Knative,
 }
 
+/// Tunnel mode determines how Restate Cloud reaches a deployment registered
+/// against a RestateCloudEnvironment
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq, Eq)]
+pub enum TunnelMode {
+    /// External mode (default): invocations are forwarded to this deployment's
+    /// Service by the tunnel-client pods managed by the RestateCloudEnvironment
+    #[serde(rename = "external")]
+    External,
+    /// In-process mode: the deployment's pods hold their own outbound tunnel
+    /// connections (e.g. with @restatedev/restate-sdk-tunnel), so no inbound
+    /// networking to them is needed. The operator injects RESTATE_INPROC_*
+    /// environment variables into the pod template and registers the
+    /// per-revision tunnel URL directly
+    #[serde(rename = "in-process")]
+    InProcess,
+}
+
 /// Knative-specific deployment configuration
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -248,6 +265,19 @@ pub struct RestateSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub use_http11: Option<bool>,
 
+    /// How Restate Cloud reaches this deployment. Only takes effect with
+    /// `register.cloud` (`in-process` requires it, and is not supported in Knative
+    /// mode).
+    /// - `external` (default): invocations are forwarded to this deployment's Service
+    ///   by the tunnel-client pods managed by the RestateCloudEnvironment.
+    /// - `in-process`: the deployment's pods hold their own outbound tunnel connections
+    ///   (e.g. with @restatedev/restate-sdk-tunnel), so no inbound networking to them is
+    ///   needed. The operator injects RESTATE_INPROC_* environment variables identifying
+    ///   the revision into the pod template and registers the per-revision tunnel URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "tunnel_mode_schema")]
+    pub tunnel_mode: Option<TunnelMode>,
+
     /// Seconds to wait before removing old versions after they are drained.
     /// Defaults to 300 (5 minutes).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -259,6 +289,19 @@ impl RestateSpec {
     pub fn drain_delay_seconds(&self) -> i64 {
         self.drain_delay_seconds.unwrap_or(300).max(0)
     }
+
+    pub fn is_in_process_tunnel(&self) -> bool {
+        matches!(self.tunnel_mode, Some(TunnelMode::InProcess))
+    }
+}
+
+fn tunnel_mode_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "description": "How Restate Cloud reaches this deployment. Only takes effect with `register.cloud` (`in-process` requires it, and is not supported in Knative mode). `external` (default): invocations are forwarded to this deployment's Service by the tunnel-client pods managed by the RestateCloudEnvironment. `in-process`: the deployment's pods hold their own outbound tunnel connections (e.g. with @restatedev/restate-sdk-tunnel), so no inbound networking to them is needed; the operator injects RESTATE_INPROC_* environment variables identifying the revision into the pod template and registers the per-revision tunnel URL.",
+        "enum": ["external", "in-process"],
+        "type": "string",
+        "nullable": true
+    })
 }
 
 /// The location of the Restate Admin API to register this deployment against
@@ -375,7 +418,13 @@ impl RestateAdminEndpoint {
         cluster_dns: &str,
     ) -> crate::Result<Url> {
         self.validate_exactly_one_set()?;
-        let url = service_url(service_name, service_namespace, 9080, service_path, cluster_dns)?;
+        let url = service_url(
+            service_name,
+            service_namespace,
+            9080,
+            service_path,
+            cluster_dns,
+        )?;
         self.maybe_tunnel_url(rce_store, url)
     }
 

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -29,17 +29,16 @@ pub enum DeploymentMode {
 /// Tunnel mode determines how Restate Cloud reaches a deployment registered
 /// against a RestateCloudEnvironment
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
 pub enum TunnelMode {
     /// External mode (default): invocations are forwarded to this deployment's
     /// Service by the tunnel-client pods managed by the RestateCloudEnvironment
-    #[serde(rename = "external")]
     External,
     /// In-process mode: the deployment's pods hold their own outbound tunnel
     /// connections (e.g. with @restatedev/restate-sdk-tunnel), so no inbound
     /// networking to them is needed. The operator injects RESTATE_INPROC_*
     /// environment variables into the pod template and registers the
     /// per-revision tunnel URL directly
-    #[serde(rename = "in-process")]
     InProcess,
 }
 


### PR DESCRIPTION
## What

A new `spec.restate.tunnelMode: in-process` field on `RestateDeployment` (only with `register.cloud`, replicaset mode). In this mode the deployment's pods hold their own outbound tunnel connections — e.g. with the upcoming [`@restatedev/restate-sdk-tunnel`](https://github.com/restatedev/sdk-typescript/pull/742) package — so invocations reach them with **no inbound networking** and no tunnel-client pods on the invocation path, while keeping the operator's full versioning/draining/auto-registration lifecycle.

```yaml
spec:
  restate:
    register:
      cloud: my-cloud-environment
    tunnelMode: in-process
```

## How it works

- **Per-revision identity = the versioned name.** The tunnel server keys connections by `{environment}/{tunnel-name}` and load-balances across all connections under one key. The operator uses `{rsd-name}-{template-hash}` as the tunnel name: replicas of a revision pool (HA), distinct revisions stay distinct, and the name is content-derived so recreating an identical RSD re-deduplicates to the same Restate deployment.
- **Mode-gated env injection (post-hash, like the `pod-template-hash` label):** `RESTATE_INPROC_TUNNEL_NAME`, `RESTATE_INPROC_ENVIRONMENT_ID` (normalized to its `env_`-prefixed form), `RESTATE_INPROC_CLOUD_REGION`, `RESTATE_INPROC_SIGNING_PUBLIC_KEY` — into every container and initContainer (native sidecars). A container that already declares one of these fails the reconcile loudly: silently keeping the user value would desync the pods from the registered URL. Credentials are deliberately **not** injected; `RESTATE_INPROC_AUTH_TOKEN_FILE` is reserved for the user's own Secret mount.
- **Registration** uses `https://tunnel.{region}.restate.cloud:9080/{unprefixed-env}/{versioned-name}/http/in-process/9080/` instead of the Service URL. The `/http/in-process/9080/` destination segment is a shared constant with the in-process clients — it is never dialed; routing is purely by the tunnel name.
- **Hash inputs grow only-when-set:** the mode marker and the resolved RCE values (length-prefixed) are folded into the revision hash only when the mode is enabled, so every existing deployment keeps its hash across this upgrade. A rotated signing key or repointed environment mints a new revision, exactly like a template change. The tunnel name is also persisted as a `restate.dev/tunnel-name` annotation on the ReplicaSet (and that annotation is reserved — a value on the RSD is not propagated).
- **Validation:** the RCE's `environmentId`/`region`/`signingPublicKey` are validated against the same rules the in-process clients enforce, and a `servicePath` that would escape the tunnel URL base via URL reference-resolution is rejected — both as `InvalidRestateConfig` reconcile failures rather than crash-looping pods. Knative mode rejects `in-process` (an in-process tunnel carries no traffic the autoscaler can see; scale-to-zero would never wake), surfaced through the Ready condition.

Everything else — readiness-gated registration, deployment-id annotation idempotency, drain scheduling, history limits, teardown, the per-revision Service — is unchanged and shared with the existing modes.

## Notes for reviewers

- `crd/restatedeployments.yaml` is regenerated (`just generate`). The Pkl artifacts (`crd/*.pkl`, `crd/examples/*`) are **not** regenerated: they are already stale on `main` (they predate the Knative fields), and pkl 0.31 rejects the pinned pantry generator's relative `file:` source URI — regenerating would mix a pile of unrelated churn into this PR. Happy to do that as a separate chore PR.
- First unit tests for the restatedeployment controller area: hash only-when-set/sensitivity, env injection (incl. initContainers, conflict, malformed specs), URL construction/escape-rejection, RCE-value validation/normalization.
- Known limitations, documented in the README: an RCE edit is only picked up on the next periodic reconcile (~5 min — the RCE watch has no reverse index to dependent RSDs, pre-existing); pods become Ready slightly before the first tunnel handshake, so registration can race once and retry after 30s (an npm-side readiness signal is a planned follow-up); same-name+same-content RSDs across namespaces/clusters registering against one environment intentionally merge into one pool (content-derived identity — documented, with distinct names as the isolation escape hatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)