### PR TITLE
Version bump to 2.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "restate-operator"
-version = "2.6.0"
+version = "2.6.1"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "restate-operator"
-version = "2.6.0"
+version = "2.6.1"
 authors = ["restate.dev"]
 edition = "2024"
 rust-version = "1.92"

--- a/charts/restate-operator-helm/Chart.yaml
+++ b/charts/restate-operator-helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: restate-operator-helm
 description: An operator for Restate clusters
 type: application
-version: "2.6.0"
+version: "2.6.1"

--- a/release-notes/v2.6.1.md
+++ b/release-notes/v2.6.1.md
@@ -1,0 +1,47 @@
+# Restate Operator v2.6.1 Release Notes
+
+## Highlights
+
+- **Fix: in-process Restate Cloud tunnels now accept BYOC regions** - `RestateCloudEnvironment.spec.region` may now contain multiple DNS labels, such as `inl4edhpbxasp9yuz1n0yvvkme.byoc`, when used with `RestateDeployment` in `tunnelMode: in-process`.
+
+## Bug Fixes
+
+### In-process tunnel mode rejected multi-label BYOC regions
+
+The `tunnelMode: in-process` validation for `RestateCloudEnvironment` regions
+only allowed a single lowercase DNS label (`[a-z0-9-]`). This rejected BYOC
+Cloud environments whose regions are represented as multiple labels, for
+example:
+
+```yaml
+spec:
+  region: inl4edhpbxasp9yuz1n0yvvkme.byoc
+```
+
+Those regions are valid for the tunnel hostname
+`tunnel.<region>.restate.cloud`, and the centralized tunnel path already
+accepted them. The operator now allows dots in the region while still rejecting
+invalid dotted forms with empty labels, such as `.us`, `us.`, and `us..eu`.
+
+**Impact on Users:**
+- BYOC Restate Cloud environments using `RestateDeployment` with
+  `tunnelMode: in-process` can now reconcile and register successfully.
+- Standard single-label regions such as `us` and `eu` are unchanged.
+- Malformed region values are still rejected during reconciliation with an
+  `InvalidRestateConfig` error.
+
+**Migration Guidance:**
+No configuration changes are required. Upgrade the operator if you use
+in-process tunnels against BYOC Restate Cloud environments.
+
+*Related: PR [#147](https://github.com/restatedev/restate-operator/pull/147)*
+
+---
+
+## Upgrading
+
+No CRD changes in this release. Upgrade the operator via Helm:
+
+```bash
+helm upgrade restate-operator restatedev/restate-operator --version 2.6.1
+```


### PR DESCRIPTION
## Summary

Bugfix release **v2.6.1**. Bumps version `2.6.0` → `2.6.1` in `Chart.yaml`, `Cargo.toml`, and `Cargo.lock`, and adds the release notes.

This release contains a single bugfix already merged to `main`:
- in-process tunnel: accept multi-label (BYOC) regions (#147)

No CRD changes in this release.

## Release process (after merge)

1. Merge this PR to `main`.
2. Tag and push: `git tag v2.6.1 && git push origin v2.6.1`.
3. CI builds the Docker image, publishes the Helm chart, and creates a **draft** GitHub release.
4. Accept the draft release once CI completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)