### PR TITLE
Align generated Pkl bindings; pin and fix the Pkl generator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,32 @@
 
 Instructions for AI coding agents working on this repository.
 
+## Making CRD / Schema Changes
+
+CRD types are Rust structs in `src/resources/*.rs`. Everything under `crd/` is generated from them.
+Never hand-edit files in `crd/` -- always regenerate.
+
+After changing a CRD struct, regenerate in this order (or run `just generate-all`):
+
+1. `just generate` -- regenerates the CRD YAML (`crd/*.yaml`). This is the authoritative schema and the
+   only artifact shipped to users (the Helm chart symlinks it). Pure Rust; no external tools. Always
+   run and commit it.
+2. `just generate-pkl` -- regenerates the Pkl bindings (`crd/*.pkl`), a convenience for Pkl users.
+   Requires the `pkl` CLI on PATH; reads the CRD YAML, so run step 1 first.
+3. `just generate-examples` -- regenerates `crd/examples/*.yaml` from the Pkl examples. Requires `pkl`.
+
+### Pkl toolchain notes
+
+- The `k8s.contrib.crd` generator package is pinned by version **and sha256** in each
+  `crd/pklgen/generate-*.pkl`. Keep it pinned: generator versions differ in class naming and output
+  layout, so an unpinned bump silently churns or breaks the committed bindings. To bump it, change the
+  version in all three files, regenerate, and update the sha256 (pkl prints the expected checksum on a
+  mismatch).
+- The generators set `source = "./crd/<name>.yaml"` (a CWD-relative path; the recipe runs from the repo
+  root). pkl rewrites this to an absolute `file://` URI in the generated header comment, so the recipe
+  normalizes it back to the repo-relative form -- keep that `sed` step.
+- Tested with pkl 0.31.1.
+
 ## Release Notes
 
 When making changes, check whether the change warrants a release note by reviewing the guidelines in `release-notes/README.md`. If it does, create a release note file in `release-notes/unreleased/` as part of the same change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,10 @@ After changing a CRD struct, regenerate in this order (or run `just generate-all
 - The generators set `source = "./crd/<name>.yaml"` (a CWD-relative path; the recipe runs from the repo
   root). pkl rewrites this to an absolute `file://` URI in the generated header comment, so the recipe
   normalizes it back to the repo-relative form -- keep that `sed` step.
-- Tested with pkl 0.31.1.
+- Use **pkl 0.31.x** (the committed bindings were generated with 0.31.1). The generator *package* is
+  hash-pinned, but the pkl CLI is not, and other CLI versions can emit spurious diffs. The pinned
+  version lives in the justfile as `pkl_version`, and `just generate-pkl` / `generate-examples` warn
+  if your CLI differs.
 
 ## Release Notes
 

--- a/crd/RestateCluster.pkl
+++ b/crd/RestateCluster.pkl
@@ -1,6 +1,7 @@
 /// RestateCluster describes the configuration and status of a Restate cluster.
 ///
-/// This module was generated from the CustomResourceDefinition at <file:./crd/restateclusters.yaml>.
+/// This module was generated from the CustomResourceDefinition at
+/// <file:./crd/restateclusters.yaml>.
 module dev.restate.v1.RestateCluster
 
 extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
@@ -31,11 +32,11 @@ status: Status?
 
 /// Represents the configuration of a Restate Cluster
 class Spec {
-  /// clusterName sets the RESTATE_CLUSTER_NAME environment variable. Defaults to the object name.
-  clusterName: String?
-
   /// Cluster-wide configuration options
   cluster: Cluster?
+
+  /// clusterName sets the RESTATE_CLUSTER_NAME environment variable. Defaults to the object name.
+  clusterName: String?
 
   /// Compute configuration
   compute: Compute
@@ -52,9 +53,11 @@ class Spec {
 
 /// Cluster-wide configuration options
 class Cluster {
-  /// Whether the operator should automatically provision the cluster.
-  /// When enabled, the operator will call the Restate gRPC ProvisionCluster API after pods are running.
-  /// Defaults to false for backwards compatibility.
+  /// Whether the operator should automatically provision the cluster. When enabled, the operator will
+  /// call the Restate gRPC ProvisionCluster API after pods are running. Defaults to false for backwards
+  /// compatibility.
+  ///
+  /// Default if undefined: `false`
   autoProvision: Boolean?
 }
 
@@ -62,6 +65,10 @@ class Cluster {
 class Compute {
   /// If specified, pod affinity
   affinity: PodSpec.Affinity?
+
+  /// Annotations to set on the Restate pod template. These are merged with any annotations the operator
+  /// sets internally (e.g. for workload identity, trusted CA certs).
+  annotations: Mapping<String, String>?
 
   /// Arguments to the entrypoint. The container image's CMD is used if this is not provided.
   args: Listing<String>?
@@ -94,8 +101,16 @@ class Compute {
   /// info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets: Listing<LocalObjectReference>?
 
+  /// Labels to set on the Restate pod template. These are merged with the standard labels the operator
+  /// sets (app.kubernetes.io/name, etc.).
+  labels: Mapping<String, String>?
+
   /// If specified, a node selector for the pod
   nodeSelector: Mapping<String, String>?
+
+  /// If specified, the pod's priority. PriorityClassName indicates the name of the PriorityClass that
+  /// should be applied to the Restate pods.
+  priorityClassName: String?
 
   /// replicas is the desired number of Restate nodes. If unspecified, defaults to 1.
   replicas: Int?
@@ -110,10 +125,6 @@ class Compute {
   /// TopologySpreadConstraints describes how a group of pods ought to spread across topology domains.
   /// Scheduler will schedule pods in a way which abides by the constraints.
   topologySpreadConstraints: Listing<PodSpec.TopologySpreadConstraint>?
-
-  /// If specified, the pod's priority. PriorityClassName indicates the name of the PriorityClass that
-  /// should be applied to the Restate pods.
-  priorityClassName: String?
 }
 
 /// Security configuration
@@ -150,12 +161,12 @@ class Security {
   /// Annotations to set on the ServiceAccount created for Restate
   serviceAccountAnnotations: Mapping<String, String>?
 
-  /// Optional list of Secrets containing trusted CA certificates.
-  /// Each cert is appended to the system CA bundle via an init container.
-  trustedCaCerts: Listing<TrustedCACert>?
-
   /// Annotations to set on the Service created for Restate
   serviceAnnotations: Mapping<String, String>?
+
+  /// Optional list of Secrets containing trusted CA certificates. Each cert is appended to the system CA
+  /// bundle via an init container.
+  trustedCaCerts: Listing<TrustedCaCert>?
 }
 
 /// Network peers to allow inbound access to restate ports If unset, will not allow any new traffic. Set
@@ -165,12 +176,12 @@ class NetworkPeers {
 
   ingress: Listing<NetworkPolicy.NetworkPolicyPeer>?
 
-  /// Network peers to allow inbound access to the node port (5122).
-  /// This is used for inter-cluster communication and operator access for provisioning.
-  node: Listing<NetworkPolicy.NetworkPolicyPeer>?
-
   /// Deprecated: use `node` instead. If both are set, `node` takes precedence.
   metrics: Listing<NetworkPolicy.NetworkPolicyPeer>?
+
+  /// Network peers to allow inbound access to the node port (5122). This is used for inter-cluster
+  /// communication and operator access for provisioning.
+  node: Listing<NetworkPolicy.NetworkPolicyPeer>?
 }
 
 /// If set, configure the use of a private key to sign outbound requests from this cluster
@@ -206,13 +217,12 @@ class SecretProvider {
   provider: String?
 }
 
-/// A reference to a Secret containing a trusted CA certificate.
-class TrustedCACert {
-  /// Name of the Secret containing the CA certificate
-  secretName: String
-
+class TrustedCaCert {
   /// Key within the Secret that contains the PEM-encoded certificate
   key: String
+
+  /// Name of the Secret containing the CA certificate
+  secretName: String
 }
 
 /// Storage configuration
@@ -234,8 +244,8 @@ class Storage {
 class Status {
   conditions: Listing<Condition>?
 
-  /// Whether the cluster has been provisioned by the operator.
-  /// This is set to true after successful provisioning to avoid repeated provisioning attempts.
+  /// Whether the cluster has been provisioned by the operator. This is set to true after successful
+  /// provisioning to avoid repeated provisioning attempts.
   provisioned: Boolean?
 }
 

--- a/crd/RestateDeployment.pkl
+++ b/crd/RestateDeployment.pkl
@@ -1,6 +1,7 @@
 /// Auto-generated derived type for RestateDeploymentSpec via `CustomResource`
 ///
-/// This module was generated from the CustomResourceDefinition at <file:./crd/restatedeployments.yaml>.
+/// This module was generated from the CustomResourceDefinition at
+/// <file:./crd/restatedeployments.yaml>.
 module dev.restate.v1beta1.RestateDeployment
 
 extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
@@ -30,10 +31,35 @@ status: Status?
 /// maintains ReplicaSets and Services for each version to support Restate's versioning requirements,
 /// ensuring old versions remain available until all invocations against them are complete.
 class Spec {
-  /// Minimum number of seconds for which a newly created pod should be ready.
+  /// Optional autoscaling for draining (non-latest) versions. ReplicaSet mode only.
+  ///
+  /// When set, the operator creates one HorizontalPodAutoscaler per non-latest version that still has
+  /// active invocations, so old versions shed compute as their load falls instead of holding full
+  /// replicas for the entire (possibly multi-hour) drain window. The HPA is removed — and the version
+  /// then scaled to zero by the operator — once Restate reports the version has no remaining
+  /// invocations.
+  ///
+  /// This is a pass-through HorizontalPodAutoscaler `.spec`: provide `minReplicas`, `maxReplicas`,
+  /// `metrics` and optionally `behavior`. The operator injects `scaleTargetRef` per version, so it must
+  /// be omitted.
+  ///
+  /// Notes: - The latest version is autoscaled separately, via an HPA targeting the RestateDeployment
+  /// scale subresource; it is not covered here. - `minReplicas` is floored at 1 (there is no
+  /// scale-to-zero in ReplicaSet mode); a value below 1 is raised to 1. - CPU/memory metrics require
+  /// container resource `requests` to be set; prefer CPU over memory (memory does not scale back down).
+  autoscaling: Dynamic?
+
+  /// Deployment mode: replicaset (default) or knative. This field is immutable after creation.
+  deploymentMode: ("replicaset"|"knative")?
+
+  /// Knative-specific configuration. When specified, enables Knative Serving mode.
+  knative: Knative?
+
+  /// Minimum number of seconds for which a newly created pod should be ready. Only used in ReplicaSet
+  /// mode.
   minReadySeconds: Int(isPositive)?
 
-  /// Number of desired pods. Defaults to 1.
+  /// Number of desired pods. Defaults to 1. Only used in ReplicaSet mode.
   ///
   /// Default if undefined: `1`
   replicas: Int(isPositive)?
@@ -41,20 +67,55 @@ class Spec {
   /// Restate specific configuration
   restate: Restate
 
-  /// The number of old ReplicaSets to retain to allow rollback. Defaults to 10.
+  /// The number of old ReplicaSets to retain to allow rollback. Defaults to 10. Only used in ReplicaSet
+  /// mode.
   ///
   /// Default if undefined: `10`
   revisionHistoryLimit: Int(isPositive)?
 
-  /// Label selector for pods. Must match the pod template's labels.
-  selector: LabelSelector
+  /// Label selector for pods. Must match the pod template's labels. Only used in ReplicaSet mode.
+  selector: LabelSelector?
 
   /// Template describes the pods that will be created.
   template: PodTemplateSpec
 }
 
+/// Knative-specific configuration. When specified, enables Knative Serving mode.
+class Knative {
+  /// Maximum number of replicas (default: unlimited)
+  maxScale: Int(isPositive)?
+
+  /// Minimum number of replicas (default: 0 for scale-to-zero)
+  minScale: Int(isPositive)?
+
+  /// Deployment tag - determines Restate deployment identity.
+  ///
+  /// A Restate deployment is a specific, versioned instance of your service code. Each deployment is
+  /// immutable: once registered with Restate, its endpoint and identity (deployment ID) must not change.
+  ///
+  /// The tag acts as a stable label that groups multiple Knative Revisions under a single Restate
+  /// deployment: - **Same tag**: In-place updates create new Knative Revisions within the same Restate
+  /// deployment (no new registration) - **Changed tag**: Creates a new Restate deployment with a new
+  /// deployment ID (versioned update) - **No tag specified**: Uses template hash as tag, causing every
+  /// template change to create a new Restate deployment
+  ///
+  /// The tag must be a valid DNS-1035 label: a lowercase RFC 1123 label that consists of lower case
+  /// alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g.
+  /// 'my-name', or '123-abc', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?').
+  ///
+  /// Example: tag "v1-0" → Configuration "my-service-v1-0" → Restate deployment "dp_abc123" Multiple
+  /// Knative Revisions (00001, 00002, ...) all serve this deployment.
+  tag: String(matches(Regex("^[a-z]([-a-z0-9]*[a-z0-9])?$")))?
+
+  /// Target concurrent requests per replica (default: 100)
+  target: Int(isPositive)?
+}
+
 /// Restate specific configuration
 class Restate {
+  /// Seconds to wait before removing old versions after they are drained. Defaults to 300 (5 minutes).
+  drainDelaySeconds: Int(isPositive)?
+
   /// The location of the Restate Admin API to register this deployment against
   register: Register
 
@@ -62,12 +123,17 @@ class Restate {
   /// service will be registered at the root path "/".
   servicePath: String?
 
+  /// How Restate Cloud reaches this deployment. Only takes effect with `register.cloud` (`in-process`
+  /// requires it, and is not supported in Knative mode). - `external` (default): invocations are
+  /// forwarded to this deployment's Service by the tunnel-client pods managed by the
+  /// RestateCloudEnvironment. - `in-process`: the deployment's pods hold their own outbound tunnel
+  /// connections (e.g. with @restatedev/restate-sdk-tunnel), so no inbound networking to them is needed.
+  /// The operator injects RESTATE_INPROC_* environment variables identifying the revision into the pod
+  /// template and registers the per-revision tunnel URL.
+  tunnelMode: ("external"|"in-process")?
+
   /// Force the use of HTTP/1.1 when registering with Restate
   useHttp11: Boolean?
-
-  /// Seconds to wait before removing old versions after they are drained. Defaults to 300 (5
-  /// minutes).
-  drainDelaySeconds: Int?
 }
 
 /// The location of the Restate Admin API to register this deployment against
@@ -113,11 +179,21 @@ class Status {
   availableReplicas: Int?
 
   /// Count of hash collisions for the RestateDeployment. The controller uses this field as a collision
-  /// avoidance mechanism when it needs to create the name for the newest ReplicaSet.
+  /// avoidance mechanism when it needs to create the name for the newest ReplicaSet or Configuration.
   collisionCount: Int?
 
   /// Represents the latest available observations of current state
   conditions: Listing<Condition>?
+
+  /// Restate deployment ID for the current tag
+  deploymentId: String?
+
+  /// Desired number of replicas. - For ReplicaSet mode: reflects spec.replicas - For Knative mode:
+  /// reflects revision.status.desired_replicas from latest revision
+  desiredReplicas: Int?
+
+  /// Knative-specific status
+  knative: StatusKnative?
 
   /// The label selector of the RestateDeployment as a string, for `kubectl get rsd -o wide`
   labelSelector: String?
@@ -151,4 +227,19 @@ class Condition {
 
   /// Type of condition (Ready, Progressing, Available)
   type: String
+}
+
+/// Knative-specific status
+class StatusKnative {
+  /// Name of the active Configuration for the current tag
+  configurationName: String?
+
+  /// Latest ready revision name for the current Configuration
+  latestRevision: String?
+
+  /// Name of the active Route for the current tag
+  routeName: String?
+
+  /// Default URL for the current deployment
+  url: String?
 }

--- a/crd/pklgen/generate-cloud.pkl
+++ b/crd/pklgen/generate-cloud.pkl
@@ -1,4 +1,4 @@
-amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@1.0.13#/generate.pkl"
+amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@2.0.2::sha256:8e07ae25589d38613ce466d2af1cec7609721c34c7e7e5fe301e9efd4de2d462#/generate.pkl"
 
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/ResourceRequirements.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/PodSpec.pkl"
@@ -6,18 +6,18 @@ import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/networking/v1/NetworkP
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/EnvVar.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Toleration.pkl"
 
-source = "file:./crd/restatecloudenvironments.yaml"
+source = "./crd/restatecloudenvironments.yaml"
 
 converters {
   ["restatecloudenvironments.restate.dev"] {
-    [List("spec", "tunnel", "env", "env")] = EnvVar
+    [List("spec", "tunnel", "env", "[]")] = EnvVar
     [List("spec", "tunnel", "resources")] = ResourceRequirements
     [List("spec", "tunnel", "dnsConfig")] = PodSpec.PodDNSConfig
     [List("spec", "tunnel", "affinity")] = PodSpec.Affinity
-    [List("spec", "tunnel", "tolerations", "toleration")] = Toleration
-    [List("spec", "security", "networkEgressRules", "networkEgressRule")] = NetworkPolicy.NetworkPolicyEgressRule
-    [List("spec", "security", "networkPeers", "admin", "admin")] = NetworkPolicy.NetworkPolicyPeer
-    [List("spec", "security", "networkPeers", "ingress", "ingres")] = NetworkPolicy.NetworkPolicyPeer
-    [List("spec", "security", "networkPeers", "metrics", "metric")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "tunnel", "tolerations", "[]")] = Toleration
+    [List("spec", "security", "networkEgressRules", "[]")] = NetworkPolicy.NetworkPolicyEgressRule
+    [List("spec", "security", "networkPeers", "admin", "[]")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "security", "networkPeers", "ingress", "[]")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "security", "networkPeers", "metrics", "[]")] = NetworkPolicy.NetworkPolicyPeer
   }
 }

--- a/crd/pklgen/generate-cluster.pkl
+++ b/crd/pklgen/generate-cluster.pkl
@@ -1,4 +1,4 @@
-amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@1.0.13#/generate.pkl"
+amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@2.0.2::sha256:8e07ae25589d38613ce466d2af1cec7609721c34c7e7e5fe301e9efd4de2d462#/generate.pkl"
 
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/ResourceRequirements.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/PodSpec.pkl"
@@ -7,20 +7,21 @@ import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/EnvVar.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Toleration.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/LocalObjectReference.pkl"
 
-source = "file:./crd/restateclusters.yaml"
+source = "./crd/restateclusters.yaml"
 
 converters {
   ["restateclusters.restate.dev"] {
-    [List("spec", "compute", "env", "env")] = EnvVar
-    [List("spec", "compute", "imagePullSecrets", "imagePullSecret")] = LocalObjectReference
+    [List("spec", "compute", "env", "[]")] = EnvVar
+    [List("spec", "compute", "imagePullSecrets", "[]")] = LocalObjectReference
     [List("spec", "compute", "resources")] = ResourceRequirements
     [List("spec", "compute", "dnsConfig")] = PodSpec.PodDNSConfig
     [List("spec", "compute", "affinity")] = PodSpec.Affinity
-    [List("spec", "compute", "tolerations", "toleration")] = Toleration
-    [List("spec", "compute", "topologySpreadConstraints", "topologySpreadConstraint")] = PodSpec.TopologySpreadConstraint
-    [List("spec", "security", "networkEgressRules", "networkEgressRule")] = NetworkPolicy.NetworkPolicyEgressRule
-    [List("spec", "security", "networkPeers", "admin", "admin")] = NetworkPolicy.NetworkPolicyPeer
-    [List("spec", "security", "networkPeers", "ingress", "ingres")] = NetworkPolicy.NetworkPolicyPeer
-    [List("spec", "security", "networkPeers", "metrics", "metric")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "compute", "tolerations", "[]")] = Toleration
+    [List("spec", "compute", "topologySpreadConstraints", "[]")] = PodSpec.TopologySpreadConstraint
+    [List("spec", "security", "networkEgressRules", "[]")] = NetworkPolicy.NetworkPolicyEgressRule
+    [List("spec", "security", "networkPeers", "admin", "[]")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "security", "networkPeers", "ingress", "[]")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "security", "networkPeers", "node", "[]")] = NetworkPolicy.NetworkPolicyPeer
+    [List("spec", "security", "networkPeers", "metrics", "[]")] = NetworkPolicy.NetworkPolicyPeer
   }
 }

--- a/crd/pklgen/generate-deployment.pkl
+++ b/crd/pklgen/generate-deployment.pkl
@@ -1,9 +1,9 @@
-amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@1.0.13#/generate.pkl"
+amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@2.0.2::sha256:8e07ae25589d38613ce466d2af1cec7609721c34c7e7e5fe301e9efd4de2d462#/generate.pkl"
 
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/PodTemplateSpec.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/LabelSelector.pkl"
 
-source = "file:./crd/restatedeployments.yaml"
+source = "./crd/restatedeployments.yaml"
 
 converters {
   ["restatedeployments.restate.dev"] {

--- a/justfile
+++ b/justfile
@@ -48,9 +48,18 @@ _target-option := if _resolved_target != "" { "--target " + _resolved_target } e
 # Code generation. Everything under crd/ is generated from the Rust structs in src/resources/*.rs.
 # Never hand-edit files under crd/ -- always regenerate. See AGENTS.md for the full workflow.
 
+# The pkl CLI version the committed Pkl bindings/examples were generated with. The generator *package*
+# is hash-pinned in crd/pklgen/*.pkl, but the pkl CLI that runs it is not, and other versions may emit
+# spurious diffs (formatting, type naming). Regenerate with this version, or bump this pin deliberately.
+pkl_version := "0.31.1"
+
 # Regenerate every generated artifact after a CRD struct change (CRD YAML, then Pkl, then examples).
 # Requires `pkl` on PATH for the pkl/examples steps.
 generate-all: generate generate-pkl generate-examples
+
+# Warn (don't fail) if the local pkl CLI differs from the pinned version used to generate the bindings.
+_check-pkl:
+  @pkl --version | grep -q "{{pkl_version}}" || echo "WARNING: this repo's Pkl artifacts were generated with pkl {{pkl_version}}; you have '$(pkl --version)'. Regenerated output may differ -- see AGENTS.md."
 
 # Regenerate the CRD YAML schemas -- the authoritative contract shipped in the Helm chart.
 # Always run and commit this after changing a CRD struct. Pure Rust codegen; no external tools.
@@ -61,8 +70,8 @@ generate:
 
 # Regenerate the Pkl bindings (a convenience for Pkl users) from the CRD YAML. Requires `pkl`;
 # run `just generate` first so the YAML is current. The generator package is pinned by version and
-# sha256 in crd/pklgen/*.pkl for reproducibility.
-generate-pkl:
+# sha256 in crd/pklgen/*.pkl for reproducibility. Use the pinned pkl CLI (see pkl_version above).
+generate-pkl: _check-pkl
   pkl eval crd/pklgen/generate-cluster.pkl -m crd
   pkl eval crd/pklgen/generate-deployment.pkl -m crd
   pkl eval crd/pklgen/generate-cloud.pkl -m crd
@@ -71,7 +80,7 @@ generate-pkl:
   sed -i.bak -E 's#<file://[^ ]*/\./crd/#<file:./crd/#' crd/RestateCluster.pkl crd/RestateDeployment.pkl crd/RestateCloudEnvironment.pkl
   rm -f crd/*.pkl.bak
 
-generate-examples:
+generate-examples: _check-pkl
   pkl eval crd/examples/restatedeployment.pkl > crd/examples/restatedeployment.yaml
   pkl eval crd/examples/restatecluster.pkl > crd/examples/restatecluster.yaml
 

--- a/justfile
+++ b/justfile
@@ -45,15 +45,31 @@ target := _arch + "-" + _os_target + if _os == "linux" { "-" + libc } else { "" 
 _resolved_target := if target != _default_target { target } else { "" }
 _target-option := if _resolved_target != "" { "--target " + _resolved_target } else { "" }
 
+# Code generation. Everything under crd/ is generated from the Rust structs in src/resources/*.rs.
+# Never hand-edit files under crd/ -- always regenerate. See AGENTS.md for the full workflow.
+
+# Regenerate every generated artifact after a CRD struct change (CRD YAML, then Pkl, then examples).
+# Requires `pkl` on PATH for the pkl/examples steps.
+generate-all: generate generate-pkl generate-examples
+
+# Regenerate the CRD YAML schemas -- the authoritative contract shipped in the Helm chart.
+# Always run and commit this after changing a CRD struct. Pure Rust codegen; no external tools.
 generate:
   cargo run --bin cluster_crdgen | grep -vF 'categories: []' > crd/restateclusters.yaml
   cargo run --bin deployment_crdgen | grep -vF 'categories: []' > crd/restatedeployments.yaml
   cargo run --bin cloud_crdgen | grep -vF 'categories: []' > crd/restatecloudenvironments.yaml
 
+# Regenerate the Pkl bindings (a convenience for Pkl users) from the CRD YAML. Requires `pkl`;
+# run `just generate` first so the YAML is current. The generator package is pinned by version and
+# sha256 in crd/pklgen/*.pkl for reproducibility.
 generate-pkl:
-  cargo run --bin cluster_schemagen | pkl eval crd/pklgen/generate-cluster.pkl -m crd
-  cargo run --bin deployment_schemagen | pkl eval crd/pklgen/generate-deployment.pkl -m crd
-  cargo run --bin cloud_schemagen | pkl eval crd/pklgen/generate-cloud.pkl -m crd
+  pkl eval crd/pklgen/generate-cluster.pkl -m crd
+  pkl eval crd/pklgen/generate-deployment.pkl -m crd
+  pkl eval crd/pklgen/generate-cloud.pkl -m crd
+  # pkl resolves the relative `source` to an absolute file:// URI in the generated header comment;
+  # rewrite it back to the repo-relative form so the committed files stay portable.
+  sed -i.bak -E 's#<file://[^ ]*/\./crd/#<file:./crd/#' crd/RestateCluster.pkl crd/RestateDeployment.pkl crd/RestateCloudEnvironment.pkl
+  rm -f crd/*.pkl.bak
 
 generate-examples:
   pkl eval crd/examples/restatedeployment.pkl > crd/examples/restatedeployment.yaml


### PR DESCRIPTION
Regenerates the committed Pkl bindings (`crd/*.pkl`) from a pinned generator and fixes the generation tooling. The Pkl files had been hand-maintained and drifted from generator output; this realigns them and makes regeneration reproducible. Also updates agent notes to avoid future drift.

## Changes
- **Pin the generator**: `k8s.contrib.crd` is pinned by version **and sha256** (`@2.0.2::sha256:8e07ae...`) in all three `crd/pklgen/*.pkl`.
- **Fixes a broken binding**: under the old `1.0.13`, `RestateDeployment.pkl` was invalid (duplicate `class Knative` from `spec.knative` + `status.knative`). `2.0.2` resolves it (`Knative` + `StatusKnative`) while keeping the flat output layout (3.x/4.x nest into versioned subdirs).
- **Converter syntax**: list items are now addressed with `"[]"` (2.0.2 changed this from singularized names); without it the converters silently stop matching and k8s types expand inline. Also maps the previously-missing `networkPeers.node`.
- **Recipe fixes** (`justfile`): dropped the vestigial `*_schemagen | pkl eval` pipe (caused intermittent SIGPIPE); fixed the `source` URI (modern pkl rejects relative `file:` URIs) and normalize the absolute header URI back to repo-relative. Added `just generate-all`.
- **Docs**: AGENTS.md now documents the CRD/schema regeneration workflow.

## Consumer impact
- **CRD YAML is unchanged** — no impact on cluster operators applying the CRDs. This PR touches only the Pkl bindings, the generators, and docs.
- **One backwards-incompatible change for Pkl authors**: the generated class `TrustedCACert` is renamed to `TrustedCaCert` (2.0.2's acronym-casing rule). Only affects anyone who vendored `crd/RestateCluster.pkl` and referenced that nested class by name; the bindings are not a published package.

`just generate-all` is reproducible (idempotent), and both Pkl examples evaluate.