### PR TITLE
RestateCluster: pod lifecycle, sidecars, termination grace period, and extra volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,11 @@ More examples are available just below the spec that follows.
 | `tolerations` | `array` | Standard Kubernetes tolerations. |
 | `dnsPolicy` | `string` | Pod DNS policy. |
 | `dnsConfig` | `object` | Pod DNS configuration. |
+| `lifecycle` | `object` | Lifecycle hooks (`postStart` / `preStop`) for the Restate container. Note: `postStart` runs concurrently with the entrypoint and is not a reliable pre-start hook. |
+| `sidecars` | `array` | Native sidecar containers run alongside Restate (appended as init containers with `restartPolicy: Always`). Requires Kubernetes 1.29+. |
+| `terminationGracePeriodSeconds` | `integer` | Pod termination grace period. Defaults to 60. `0` means immediate SIGKILL (skips `preStop`). |
+| `extraVolumes` | `array` | Additional pod volumes. Names must not collide with operator-managed volumes (`storage`, `tmp`, `config`, and the trusted-CA / request-signing volumes); a collision is rejected with a clear error. |
+| `extraVolumeMounts` | `array` | Additional volume mounts for the Restate container. Referenced volumes must be declared in `extraVolumes` (or be operator-managed). |
 
 **Pod annotation and label merge ordering**: User-specified `annotations` and `labels` are
 merged with values the operator sets internally (e.g. for workload identity hashes, trusted

--- a/crd/RestateCluster.pkl
+++ b/crd/RestateCluster.pkl
@@ -98,9 +98,10 @@ class Compute {
 
   /// Additional volumes to add to the Restate pod, on top of those the operator manages. These can be
   /// mounted into the Restate container via extraVolumeMounts or into sidecar containers. Names must not
-  /// collide with operator-managed volumes ("storage", "tmp", "config", and, when the respective
-  /// features are enabled, the trustedCaCerts and requestSigningPrivateKey volumes); a duplicate name is
-  /// rejected when the StatefulSet is applied.
+  /// collide with operator-managed volumes: "storage", "tmp", and "config" always, plus
+  /// "combined-ca-certs" and "trusted-ca-<n>" when trustedCaCerts is set, and
+  /// "request-signing-private-key-secret"/"request-signing-private-key-secret-provider" when
+  /// requestSigningPrivateKey is set. The operator rejects a colliding name with a clear error.
   extraVolumes: Listing<Volume>?
 
   /// Container image name. More info: https://kubernetes.io/docs/concepts/containers/images.
@@ -119,7 +120,10 @@ class Compute {
   /// sets (app.kubernetes.io/name, etc.).
   labels: Mapping<String, String>?
 
-  /// Lifecycle hooks (postStart / preStop) for the Restate container.
+  /// Lifecycle hooks (postStart / preStop) for the Restate container. Note: Kubernetes runs the
+  /// postStart hook concurrently with the container entrypoint and gives no ordering guarantee relative
+  /// to the Restate process starting, so it is not a reliable "before Restate starts" hook. For strict
+  /// pre-start ordering, wrap the entrypoint via command/args instead.
   lifecycle: Lifecycle?
 
   /// If specified, a node selector for the pod
@@ -138,10 +142,12 @@ class Compute {
 
   /// Native sidecar containers to run alongside the Restate container. Each is started before the
   /// Restate container and terminated after it. The operator forces restartPolicy to "Always" so these
-  /// behave as sidecars rather than plain init containers.
+  /// behave as sidecars rather than plain init containers. Native sidecars require Kubernetes 1.29+ (GA
+  /// in 1.33); older clusters reject restartPolicy on init containers.
   sidecars: Listing<PodSpec.Container>?
 
-  /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
+  /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60. A value of 0
+  /// terminates immediately (SIGKILL, skipping any preStop hook).
   terminationGracePeriodSeconds: Int?
 
   /// If specified, the pod's tolerations.

--- a/crd/RestateCluster.pkl
+++ b/crd/RestateCluster.pkl
@@ -10,6 +10,7 @@ import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/PodSpec.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/EnvVar.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/LocalObjectReference.pkl"
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Lifecycle.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/ResourceRequirements.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Toleration.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/networking/v1/NetworkPolicy.pkl"
@@ -105,6 +106,9 @@ class Compute {
   /// sets (app.kubernetes.io/name, etc.).
   labels: Mapping<String, String>?
 
+  /// Lifecycle hooks (postStart / preStop) for the Restate container.
+  lifecycle: Lifecycle?
+
   /// If specified, a node selector for the pod
   nodeSelector: Mapping<String, String>?
 
@@ -118,6 +122,14 @@ class Compute {
   /// Compute Resources for the Restate container. More info:
   /// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
   resources: ResourceRequirements?
+
+  /// Native sidecar containers to run alongside the Restate container. Each is started before the
+  /// Restate container and terminated after it. The operator forces restartPolicy to "Always" so these
+  /// behave as sidecars rather than plain init containers.
+  sidecars: Listing<PodSpec.Container>?
+
+  /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
+  terminationGracePeriodSeconds: Int?
 
   /// If specified, the pod's tolerations.
   tolerations: Listing<Toleration>?

--- a/crd/RestateCluster.pkl
+++ b/crd/RestateCluster.pkl
@@ -9,6 +9,8 @@ extends "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/K8sResource.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/apimachinery/pkg/apis/meta/v1/ObjectMeta.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/PodSpec.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/EnvVar.pkl"
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/VolumeMount.pkl"
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Volume.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/LocalObjectReference.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Lifecycle.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/ResourceRequirements.pkl"
@@ -89,6 +91,17 @@ class Compute {
 
   /// List of environment variables to set in the container; these may override defaults
   env: Listing<EnvVar>?
+
+  /// Additional volume mounts for the Restate container. The referenced volumes must be declared in
+  /// extraVolumes (or be operator-managed).
+  extraVolumeMounts: Listing<VolumeMount>?
+
+  /// Additional volumes to add to the Restate pod, on top of those the operator manages. These can be
+  /// mounted into the Restate container via extraVolumeMounts or into sidecar containers. Names must not
+  /// collide with operator-managed volumes ("storage", "tmp", "config", and, when the respective
+  /// features are enabled, the trustedCaCerts and requestSigningPrivateKey volumes); a duplicate name is
+  /// rejected when the StatefulSet is applied.
+  extraVolumes: Listing<Volume>?
 
   /// Container image name. More info: https://kubernetes.io/docs/concepts/containers/images.
   image: String

--- a/crd/pklgen/generate-cluster.pkl
+++ b/crd/pklgen/generate-cluster.pkl
@@ -6,6 +6,7 @@ import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/networking/v1/NetworkP
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/EnvVar.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Toleration.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/LocalObjectReference.pkl"
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Lifecycle.pkl"
 
 source = "./crd/restateclusters.yaml"
 
@@ -16,6 +17,8 @@ converters {
     [List("spec", "compute", "resources")] = ResourceRequirements
     [List("spec", "compute", "dnsConfig")] = PodSpec.PodDNSConfig
     [List("spec", "compute", "affinity")] = PodSpec.Affinity
+    [List("spec", "compute", "lifecycle")] = Lifecycle
+    [List("spec", "compute", "sidecars", "[]")] = PodSpec.Container
     [List("spec", "compute", "tolerations", "[]")] = Toleration
     [List("spec", "compute", "topologySpreadConstraints", "[]")] = PodSpec.TopologySpreadConstraint
     [List("spec", "security", "networkEgressRules", "[]")] = NetworkPolicy.NetworkPolicyEgressRule

--- a/crd/pklgen/generate-cluster.pkl
+++ b/crd/pklgen/generate-cluster.pkl
@@ -7,6 +7,8 @@ import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/EnvVar.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Toleration.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/LocalObjectReference.pkl"
 import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Lifecycle.pkl"
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/Volume.pkl"
+import "package://pkg.pkl-lang.org/pkl-k8s/k8s@1.0.1#/api/core/v1/VolumeMount.pkl"
 
 source = "./crd/restateclusters.yaml"
 
@@ -19,6 +21,8 @@ converters {
     [List("spec", "compute", "affinity")] = PodSpec.Affinity
     [List("spec", "compute", "lifecycle")] = Lifecycle
     [List("spec", "compute", "sidecars", "[]")] = PodSpec.Container
+    [List("spec", "compute", "extraVolumes", "[]")] = Volume
+    [List("spec", "compute", "extraVolumeMounts", "[]")] = VolumeMount
     [List("spec", "compute", "tolerations", "[]")] = Toleration
     [List("spec", "compute", "topologySpreadConstraints", "[]")] = PodSpec.TopologySpreadConstraint
     [List("spec", "security", "networkEgressRules", "[]")] = NetworkPolicy.NetworkPolicyEgressRule

--- a/crd/restateclusters.yaml
+++ b/crd/restateclusters.yaml
@@ -763,11 +763,12 @@ spec:
                     type: array
                   extraVolumes:
                     description: |-
-                      Additional volumes to add to the Restate pod, on top of those the operator manages. These can
-                      be mounted into the Restate container via extraVolumeMounts or into sidecar containers.
-                      Names must not collide with operator-managed volumes ("storage", "tmp", "config", and, when the
-                      respective features are enabled, the trustedCaCerts and requestSigningPrivateKey volumes); a
-                      duplicate name is rejected when the StatefulSet is applied.
+                      Additional volumes to add to the Restate pod, on top of those the operator manages. These can be
+                      mounted into the Restate container via extraVolumeMounts or into sidecar containers. Names must
+                      not collide with operator-managed volumes: "storage", "tmp", and "config" always, plus
+                      "combined-ca-certs" and "trusted-ca-<n>" when trustedCaCerts is set, and
+                      "request-signing-private-key-secret"/"request-signing-private-key-secret-provider" when
+                      requestSigningPrivateKey is set. The operator rejects a colliding name with a clear error.
                     items:
                       description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                       properties:
@@ -2015,7 +2016,11 @@ spec:
                     nullable: true
                     type: object
                   lifecycle:
-                    description: Lifecycle hooks (postStart / preStop) for the Restate container.
+                    description: |-
+                      Lifecycle hooks (postStart / preStop) for the Restate container. Note: Kubernetes runs the
+                      postStart hook concurrently with the container entrypoint and gives no ordering guarantee
+                      relative to the Restate process starting, so it is not a reliable "before Restate starts" hook.
+                      For strict pre-start ordering, wrap the entrypoint via command/args instead.
                     nullable: true
                     properties:
                       postStart:
@@ -2216,7 +2221,8 @@ spec:
                     description: |-
                       Native sidecar containers to run alongside the Restate container. Each is started before the
                       Restate container and terminated after it. The operator forces restartPolicy to "Always" so
-                      these behave as sidecars rather than plain init containers.
+                      these behave as sidecars rather than plain init containers. Native sidecars require Kubernetes
+                      1.29+ (GA in 1.33); older clusters reject restartPolicy on init containers.
                     items:
                       description: A single application container that you want to run within a pod.
                       properties:
@@ -3112,7 +3118,9 @@ spec:
                     nullable: true
                     type: array
                   terminationGracePeriodSeconds:
-                    description: Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
+                    description: |-
+                      Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60. A value of 0
+                      terminates immediately (SIGKILL, skipping any preStop hook).
                     format: int64
                     nullable: true
                     type: integer

--- a/crd/restateclusters.yaml
+++ b/crd/restateclusters.yaml
@@ -749,6 +749,152 @@ spec:
                       the operator sets (app.kubernetes.io/name, etc.).
                     nullable: true
                     type: object
+                  lifecycle:
+                    description: Lifecycle hooks (postStart / preStop) for the Restate container.
+                    nullable: true
+                    properties:
+                      postStart:
+                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: Exec specifies a command to execute in the container.
+                            properties:
+                              command:
+                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies an HTTP GET request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          sleep:
+                            description: Sleep represents a duration that the container should sleep.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
+                          tcpSocket:
+                            description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      preStop:
+                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                        properties:
+                          exec:
+                            description: Exec specifies a command to execute in the container.
+                            properties:
+                              command:
+                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          httpGet:
+                            description: HTTPGet specifies an HTTP GET request to perform.
+                            properties:
+                              host:
+                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                type: string
+                              httpHeaders:
+                                description: Custom headers to set in the request. HTTP allows repeated headers.
+                                items:
+                                  description: HTTPHeader describes a custom header to be used in HTTP probes
+                                  properties:
+                                    name:
+                                      description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                      type: string
+                                    value:
+                                      description: The header field value
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              path:
+                                description: Path to access on the HTTP server.
+                                type: string
+                              port:
+                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                              scheme:
+                                description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                type: string
+                            required:
+                            - port
+                            type: object
+                          sleep:
+                            description: Sleep represents a duration that the container should sleep.
+                            properties:
+                              seconds:
+                                description: Seconds is the number of seconds to sleep.
+                                format: int64
+                                type: integer
+                            required:
+                            - seconds
+                            type: object
+                          tcpSocket:
+                            description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified.
+                            properties:
+                              host:
+                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                type: string
+                              port:
+                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                x-kubernetes-int-or-string: true
+                            required:
+                            - port
+                            type: object
+                        type: object
+                      stopSignal:
+                        description: StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name
+                        type: string
+                    type: object
                   nodeSelector:
                     additionalProperties:
                       type: string
@@ -801,6 +947,910 @@ spec:
                         description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                         type: object
                     type: object
+                  sidecars:
+                    description: |-
+                      Native sidecar containers to run alongside the Restate container. Each is started before the
+                      Restate container and terminated after it. The operator forces restartPolicy to "Always" so
+                      these behave as sidecars rather than plain init containers.
+                    items:
+                      description: A single application container that you want to run within a pod.
+                      properties:
+                        args:
+                          description: 'Arguments to the entrypoint. The container image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: 'Entrypoint array. Not executed within a shell. The container image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container. Cannot be updated.
+                          items:
+                            description: EnvVar represents an environment variable present in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. May consist of any printable ASCII characters except '='.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded using the previously defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    - name
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  fileKeyRef:
+                                    description: FileKeyRef selects a key of the env file. Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: The key within the env file. An invalid key will prevent the pod from starting. The keys defined within a source may consist of any printable ASCII characters except '='. During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key does not exist, then the env var is not published. If optional is set to true and the specified key does not exist, the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist, an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: The path within the volume from which to select the file. Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing the env file.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    - volumeName
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - key
+                                    - name
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables in the container. The keys defined within a source may consist of any printable ASCII characters except '='. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
+                          items:
+                            description: EnvFromSource represents the source of a set of ConfigMaps or Secrets
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must be defined
+                                    type: boolean
+                                required:
+                                - name
+                                type: object
+                              prefix:
+                                description: Optional text to prepend to the name of each environment variable. May consist of any printable ASCII characters except '='.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be defined
+                                    type: boolean
+                                required:
+                                - name
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                          type: string
+                        imagePullPolicy:
+                          description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                          type: string
+                        lifecycle:
+                          description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
+                          properties:
+                            postStart:
+                              description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute in the container.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request. HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The Pod''s termination grace period countdown begins before the PreStop hook is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period (unless delayed by finalizers). Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                              properties:
+                                exec:
+                                  description: Exec specifies a command to execute in the container.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  description: HTTPGet specifies an HTTP GET request to perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request. HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                sleep:
+                                  description: Sleep represents a duration that the container should sleep.
+                                  properties:
+                                    seconds:
+                                      description: Seconds is the number of seconds to sleep.
+                                      format: int64
+                                      type: integer
+                                  required:
+                                  - seconds
+                                  type: object
+                                tcpSocket:
+                                  description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept for backward compatibility. There is no validation of this field and lifecycle hooks will fail at runtime when it is specified.
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            stopSignal:
+                              description: StopSignal defines which signal will be sent to a container when it is being stopped. If not specified, the default is defined by the container runtime in use. StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
+                          type: object
+                        livenessProbe:
+                          description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.
+                          items:
+                            description: ContainerPort represents a network port in a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resizePolicy:
+                          description: Resources resize policy for the container.
+                          items:
+                            description: ContainerResizePolicy represents resource resize policy for the container.
+                            properties:
+                              resourceName:
+                                description: 'Name of the resource to which this resource resize policy applies. Supported values: cpu, memory.'
+                                type: string
+                              restartPolicy:
+                                description: Restart policy to apply when specified resource is resized. If not specified, it defaults to NotRequired.
+                                type: string
+                            required:
+                            - resourceName
+                            - restartPolicy
+                            type: object
+                          type: array
+                        resources:
+                          description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          properties:
+                            claims:
+                              description: |-
+                                Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+                                This field depends on the DynamicResourceAllocation feature gate.
+
+                                This field is immutable. It can only be set for containers.
+                              items:
+                                description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                properties:
+                                  name:
+                                    description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                    type: string
+                                  request:
+                                    description: Request is the name chosen for a request in the referenced claim. If empty, everything from the claim is made available, otherwise only the result of this request.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                            limits:
+                              additionalProperties:
+                                description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        restartPolicy:
+                          description: 'RestartPolicy defines the restart behavior of individual containers in a pod. This overrides the pod-level restart policy. When this field is not specified, the restart behavior is defined by the Pod''s restart policy and the container type. Additionally, setting the RestartPolicy as "Always" for the init container will have the following effect: this init container will be continually restarted on exit until all regular containers have terminated. Once all regular containers have completed, all init containers with restartPolicy "Always" will be shut down. This lifecycle differs from normal init containers and is often referred to as a "sidecar" container. Although this init container still starts in the init container sequence, it does not wait for the container to complete before proceeding to the next init container. Instead, the next init container starts immediately after this init container is started, or after any startupProbe has successfully completed.'
+                          type: string
+                        restartPolicyRules:
+                          description: 'Represents a list of rules to be checked to determine if the container should be restarted on exit. The rules are evaluated in order. Once a rule matches a container exit condition, the remaining rules are ignored. If no rule matches the container exit condition, the Container-level restart policy determines the whether the container is restarted or not. Constraints on the rules: - At most 20 rules are allowed. - Rules can have the same action. - Identical rules are not forbidden in validations. When rules are specified, container MUST set RestartPolicy explicitly even it if matches the Pod''s RestartPolicy.'
+                          items:
+                            description: ContainerRestartRule describes how a container exit is handled.
+                            properties:
+                              action:
+                                description: Specifies the action taken on a container exit if the requirements are satisfied. The only possible value is "Restart" to restart the container.
+                                type: string
+                              exitCodes:
+                                description: Represents the exit codes to check on container exits.
+                                properties:
+                                  operator:
+                                    description: |-
+                                      Represents the relationship between the container exit code(s) and the specified values. Possible values are: - In: the requirement is satisfied if the container exit code is in the
+                                        set of specified values.
+                                      - NotIn: the requirement is satisfied if the container exit code is
+                                        not in the set of specified values.
+                                    type: string
+                                  values:
+                                    description: Specifies the set of values to check for container exit codes. At most 255 elements are allowed.
+                                    items:
+                                      format: int32
+                                      type: integer
+                                    type: array
+                                required:
+                                - operator
+                                type: object
+                            required:
+                            - action
+                            type: object
+                          type: array
+                        securityContext:
+                          description: 'SecurityContext defines the security options the container should be run with. If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                          properties:
+                            allowPrivilegeEscalation:
+                              description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN Note that this field cannot be set when spec.os.name is windows.'
+                              type: boolean
+                            appArmorProfile:
+                              description: appArmorProfile is the AppArmor options to use by this container. If set, this profile overrides the pod's appArmorProfile. Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile loaded on the node that should be used. The profile must be preconfigured on the node to work. Must match the loaded name of the profile. Must be set if and only if type is "Localhost".
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of AppArmor profile will be applied. Valid options are:
+                                      Localhost - a profile pre-loaded on the node.
+                                      RuntimeDefault - the container runtime's default profile.
+                                      Unconfined - no AppArmor enforcement.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            capabilities:
+                              description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime. Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                add:
+                                  description: Added capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  description: Removed capabilities
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false. Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            procMount:
+                              description: procMount denotes the type of proc mount to use for the containers. The default value is Default which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled. Note that this field cannot be set when spec.os.name is windows.
+                              type: string
+                            readOnlyRootFilesystem:
+                              description: Whether this container has a read-only root filesystem. Default is false. Note that this field cannot be set when spec.os.name is windows.
+                              type: boolean
+                            runAsGroup:
+                              description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: boolean
+                            runAsUser:
+                              description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                level:
+                                  description: Level is SELinux level label that applies to the container.
+                                  type: string
+                                role:
+                                  description: Role is a SELinux role label that applies to the container.
+                                  type: string
+                                type:
+                                  description: Type is a SELinux type label that applies to the container.
+                                  type: string
+                                user:
+                                  description: User is a SELinux user label that applies to the container.
+                                  type: string
+                              type: object
+                            seccompProfile:
+                              description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                              properties:
+                                localhostProfile:
+                                  description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must be set if type is "Localhost". Must NOT be set for any other type.
+                                  type: string
+                                type:
+                                  description: |-
+                                    type indicates which kind of seccomp profile will be applied. Valid options are:
+
+                                    Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied.
+                                  type: string
+                              required:
+                              - type
+                              type: object
+                            windowsOptions:
+                              description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.
+                              properties:
+                                gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                  type: string
+                                hostProcess:
+                                  description: HostProcess determines if a container should be run as a 'Host Process' container. All of a Pod's containers must have the same effective HostProcess value (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers). In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                  type: boolean
+                                runAsUserName:
+                                  description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: Exec specifies a command to execute in the container.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            grpc:
+                              description: GRPC specifies a GRPC HealthCheckRequest.
+                              properties:
+                                port:
+                                  description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                  format: int32
+                                  type: integer
+                                service:
+                                  description: |-
+                                    Service is the name of the service to place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+                                    If this is not specified, the default behavior is defined by gRPC.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            httpGet:
+                              description: HTTPGet specifies an HTTP GET request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request. HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name. This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host. Defaults to HTTP.
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: TCPSocket specifies a connection to a TCP port.
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                  type: string
+                                port:
+                                  description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            terminationGracePeriodSeconds:
+                              description: Optional duration in seconds the pod needs to terminate gracefully upon probe failure. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this value overrides the value provided by the pod spec. Value must be non-negative integer. The value zero indicates stop immediately via the kill signal (no opportunity to shut down). This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                              format: int64
+                              type: integer
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
+                          type: boolean
+                        stdinOnce:
+                          description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
+                          type: boolean
+                        terminationMessagePath:
+                          description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                          type: string
+                        terminationMessagePolicy:
+                          description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
+                          type: string
+                        tty:
+                          description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
+                          type: boolean
+                        volumeDevices:
+                          description: volumeDevices is the list of block devices to be used by the container.
+                          items:
+                            description: volumeDevice describes a mapping of a raw block device within a container.
+                            properties:
+                              devicePath:
+                                description: devicePath is the path inside of the container that the device will be mapped to.
+                                type: string
+                              name:
+                                description: name must match the name of a persistentVolumeClaim in the pod
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem. Cannot be updated.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                                type: boolean
+                              recursiveReadOnly:
+                                description: |-
+                                  RecursiveReadOnly specifies whether read-only mounts should be handled recursively.
+
+                                  If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                  If ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.
+
+                                  If this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).
+
+                                  If this field is not specified, it is treated as an equivalent of Disabled.
+                                type: string
+                              subPath:
+                                description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    nullable: true
+                    type: array
+                  terminationGracePeriodSeconds:
+                    description: Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
+                    format: int64
+                    nullable: true
+                    type: integer
                   tolerations:
                     description: If specified, the pod's tolerations.
                     items:

--- a/crd/restateclusters.yaml
+++ b/crd/restateclusters.yaml
@@ -718,6 +718,1271 @@ spec:
                     x-kubernetes-list-map-keys:
                     - name
                     x-kubernetes-list-type: map
+                  extraVolumeMounts:
+                    description: |-
+                      Additional volume mounts for the Restate container. The referenced volumes must be declared in
+                      extraVolumes (or be operator-managed).
+                    items:
+                      description: VolumeMount describes a mounting of a Volume within a container.
+                      properties:
+                        mountPath:
+                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
+                          type: string
+                        mountPropagation:
+                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10. When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified (which defaults to None).
+                          type: string
+                        name:
+                          description: This must match the Name of a Volume.
+                          type: string
+                        readOnly:
+                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
+                          type: boolean
+                        recursiveReadOnly:
+                          description: |-
+                            RecursiveReadOnly specifies whether read-only mounts should be handled recursively.
+
+                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                            If ReadOnly is true, and this field is set to Disabled, the mount is not made recursively read-only.  If this field is set to IfPossible, the mount is made recursively read-only, if it is supported by the container runtime.  If this field is set to Enabled, the mount is made recursively read-only if it is supported by the container runtime, otherwise the pod will not be started and an error will be generated to indicate the reason.
+
+                            If this field is set to IfPossible or Enabled, MountPropagation must be set to None (or be unspecified, which defaults to None).
+
+                            If this field is not specified, it is treated as an equivalent of Disabled.
+                          type: string
+                        subPath:
+                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
+                          type: string
+                        subPathExpr:
+                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                          type: string
+                      required:
+                      - mountPath
+                      - name
+                      type: object
+                    nullable: true
+                    type: array
+                  extraVolumes:
+                    description: |-
+                      Additional volumes to add to the Restate pod, on top of those the operator manages. These can
+                      be mounted into the Restate container via extraVolumeMounts or into sidecar containers.
+                      Names must not collide with operator-managed volumes ("storage", "tmp", "config", and, when the
+                      respective features are enabled, the trustedCaCerts and requestSigningPrivateKey volumes); a
+                      duplicate name is rejected when the StatefulSet is applied.
+                    items:
+                      description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: boolean
+                            volumeID:
+                              description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: 'azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod. Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type are redirected to the disk.csi.azure.com CSI driver.'
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the blob storage
+                              type: string
+                            fsType:
+                              description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: 'azureFile represents an Azure File Service mount on the host and bind mount to the pod. Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type are redirected to the file.csi.azure.com CSI driver.'
+                          properties:
+                            readOnly:
+                              description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: 'cephFS represents a Ceph FS mount on the host that shares a pod''s lifetime. Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.'
+                          properties:
+                            monitors:
+                              description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: boolean
+                            secretFile:
+                              description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                            secretRef:
+                              description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            user:
+                              description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. Deprecated: Cinder is deprecated. All operations for the in-tree cinder type are redirected to the cinder.csi.openstack.org CSI driver. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                            readOnly:
+                              description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            volumeID:
+                              description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap or its keys must be defined
+                              type: boolean
+                          required:
+                          - name
+                          type: object
+                        csi:
+                          description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers.
+                          properties:
+                            driver:
+                              description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            readOnly:
+                              description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume file
+                              items:
+                                description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        description: Specifies the output format of the exposed resources, defaults to "1"
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                          properties:
+                            medium:
+                              description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              type: string
+                            sizeLimit:
+                              description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                            Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                            A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+                                      type: object
+                                    creationTimestamp:
+                                      description: |-
+                                        CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+                                        Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                      format: date-time
+                                      type: string
+                                    deletionGracePeriodSeconds:
+                                      description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                      format: int64
+                                      type: integer
+                                    deletionTimestamp:
+                                      description: |-
+                                        DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+                                        Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                      format: date-time
+                                      type: string
+                                    finalizers:
+                                      description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                      items:
+                                        type: string
+                                      type: array
+                                    generateName:
+                                      description: |-
+                                        GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                                        If this field is specified and the generated name exists, the server will return a 409.
+
+                                        Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                      type: string
+                                    generation:
+                                      description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                      format: int64
+                                      type: integer
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+                                      type: object
+                                    managedFields:
+                                      description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                      items:
+                                        description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+                                        properties:
+                                          apiVersion:
+                                            description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                            type: string
+                                          fieldsType:
+                                            description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                            type: string
+                                          fieldsV1:
+                                            description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                            type: object
+                                          manager:
+                                            description: Manager is an identifier of the workflow managing these fields.
+                                            type: string
+                                          operation:
+                                            description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                            type: string
+                                          subresource:
+                                            description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+                                            type: string
+                                          time:
+                                            description: Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
+                                            format: date-time
+                                            type: string
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+                                      type: string
+                                    namespace:
+                                      description: |-
+                                        Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                                        Must be a DNS_LABEL. Cannot be updated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces
+                                      type: string
+                                    ownerReferences:
+                                      description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                      items:
+                                        description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                                        properties:
+                                          apiVersion:
+                                            description: API version of the referent.
+                                            type: string
+                                          blockOwnerDeletion:
+                                            description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                            type: boolean
+                                          controller:
+                                            description: If true, this reference points to the managing controller.
+                                            type: boolean
+                                          kind:
+                                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#names'
+                                            type: string
+                                          uid:
+                                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids'
+                                            type: string
+                                        required:
+                                        - apiVersion
+                                        - kind
+                                        - name
+                                        - uid
+                                        type: object
+                                      type: array
+                                    resourceVersion:
+                                      description: |-
+                                        An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                                        Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                      type: string
+                                    selfLink:
+                                      description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
+                                      type: string
+                                    uid:
+                                      description: |-
+                                        UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                                        Populated by the system. Read-only. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names#uids
+                                      type: string
+                                  type: object
+                                spec:
+                                  description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                      items:
+                                        type: string
+                                      type: array
+                                    dataSource:
+                                      description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        * While dataSource only allows local objects, dataSourceRef allows objects
+                                          in any namespaces.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource being referenced
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                            x-kubernetes-int-or-string: true
+                                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    storageClassName:
+                                      description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: 'volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim. If specified, the CSI driver will create or update the volume with the attributes defined in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName, it can be changed after the claim is created. An empty string or nil value indicates that no VolumeAttributesClass will be applied to the claim. If the claim enters an Infeasible error state, this field can be reset to its previous value (including nil) to cancel the modification. If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/'
+                                      type: string
+                                    volumeMode:
+                                      description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          description: 'flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin. Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.'
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use for this volume.
+                              type: string
+                            fsType:
+                              description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: 'flocker represents a Flocker volume attached to a kubelet''s host machine. This depends on the Flocker control service being running. Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.'
+                          properties:
+                            datasetName:
+                              description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                          properties:
+                            fsType:
+                              description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            partition:
+                              description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: 'gitRepo represents a git repository at a particular revision. Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                          properties:
+                            directory:
+                              description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.'
+                          properties:
+                            endpoints:
+                              description: endpoints is the endpoint name that details Glusterfs topology.
+                              type: string
+                            path:
+                              description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                          properties:
+                            path:
+                              description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                            type:
+                              description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        image:
+                          description: |-
+                            image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine. The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                            - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present. - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                            The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation. A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message. The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field. The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images. The volume will be mounted read-only (ro) and non-executable files (noexec). Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33. The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                          properties:
+                            pullPolicy:
+                              description: 'Policy for pulling OCI objects. Possible values are: Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails. Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn''t present. IfNotPresent: the kubelet pulls if the reference isn''t already present on disk. Container creation will fail if the reference isn''t present and the pull fails. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.'
+                              type: string
+                            reference:
+                              description: 'Required: Image or artifact reference to be used. Behaves in the same way as pod.spec.containers[*].image. Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
+                              type: string
+                          type: object
+                        iscsi:
+                          description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes/#iscsi'
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                              type: string
+                            initiatorName:
+                              description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            targetPortal:
+                              description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        nfs:
+                          description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                          properties:
+                            path:
+                              description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: boolean
+                            server:
+                              description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            claimName:
+                              description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              type: string
+                            readOnly:
+                              description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: 'photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine. Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.'
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: 'portworxVolume represents a portworx volume attached and mounted on kubelets host machine. Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate is on.'
+                          properties:
+                            fsType:
+                              description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets, configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: sources is the list of volume projections. Each entry in this list handles one source.
+                              items:
+                                description: Projection that may be projected along with other supported volume types. Exactly one of these fields must be set.
+                                properties:
+                                  clusterTrustBundle:
+                                    description: |-
+                                      ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field of ClusterTrustBundle objects in an auto-updating file.
+
+                                      Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                      ClusterTrustBundle objects can either be selected by name, or by the combination of signer name and a label selector.
+
+                                      Kubelet performs aggressive normalization of the PEM contents written into the pod filesystem.  Esoteric PEM features such as inter-block comments and block headers are stripped.  Certificates are deduplicated. The ordering of certificates within the file is arbitrary, and Kubelet may change the order over time.
+                                    properties:
+                                      labelSelector:
+                                        description: Select all ClusterTrustBundles that match this label selector.  Only has effect if signerName is set.  Mutually-exclusive with name.  If unset, interpreted as "match nothing".  If set but empty, interpreted as "match everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      name:
+                                        description: Select a single ClusterTrustBundle by object name.  Mutually-exclusive with signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: If true, don't block pod startup if the referenced ClusterTrustBundle(s) aren't available.  If using name, then the named ClusterTrustBundle is allowed not to exist.  If using signerName, then the combination of signerName and labelSelector is allowed to match zero ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: Select all ClusterTrustBundles that match this signer name. Mutually-exclusive with name.  The contents of all selected ClusterTrustBundles will be unified and deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  configMap:
+                                    description: configMap information about the configMap data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the ConfigMap or its keys must be defined
+                                        type: boolean
+                                    required:
+                                    - name
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI information about the downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required for volumes, optional for env vars'
+                                                  type: string
+                                                divisor:
+                                                  description: Specifies the output format of the exposed resources, defaults to "1"
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  podCertificate:
+                                    description: |-
+                                      Projects an auto-rotating credential bundle (private key and certificate chain) that the pod can use either as a TLS client or server.
+
+                                      Kubelet generates a private key and uses it to send a PodCertificateRequest to the named signer.  Once the signer approves the request and issues a certificate chain, Kubelet writes the key and certificate chain to the pod filesystem.  The pod does not start until certificates have been issued for each podCertificate projected volume source in its spec.
+
+                                      Kubelet will begin trying to rotate the certificate at the time indicated by the signer using the PodCertificateRequest.Status.BeginRefreshAt timestamp.
+
+                                      Kubelet can write a single file, indicated by the credentialBundlePath field, or separate files, indicated by the keyPath and certificateChainPath fields.
+
+                                      The credential bundle is a single file in PEM format.  The first PEM entry is the private key (in PKCS#8 format), and the remaining PEM entries are the certificate chain issued by the signer (typically, signers will return their certificate chain in leaf-to-root order).
+
+                                      Prefer using the credential bundle format, since your application code can read it atomically.  If you use keyPath and certificateChainPath, your application must make two separate file reads. If these coincide with a certificate rotation, it is possible that the private key and leaf certificate you read may not correspond to each other.  Your application will need to check for this condition, and re-read until they are consistent.
+
+                                      The named signer controls chooses the format of the certificate it issues; consult the signer implementation's documentation to learn how to use the certificates it issues.
+                                    properties:
+                                      certificateChainPath:
+                                        description: |-
+                                          Write the certificate chain at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.
+                                        type: string
+                                      credentialBundlePath:
+                                        description: |-
+                                          Write the credential bundle at this path in the projected volume.
+
+                                          The credential bundle is a single file that contains multiple PEM blocks. The first PEM block is a PRIVATE KEY block, containing a PKCS#8 private key.
+
+                                          The remaining blocks are CERTIFICATE blocks, containing the issued certificate chain from the signer (leaf and any intermediates).
+
+                                          Using credentialBundlePath lets your Pod's application code make a single atomic read that retrieves a consistent key and certificate chain.  If you project them to separate files, your application code will need to additionally check that the leaf certificate was issued to the key.
+                                        type: string
+                                      keyPath:
+                                        description: |-
+                                          Write the key at this path in the projected volume.
+
+                                          Most applications should use credentialBundlePath.  When using keyPath and certificateChainPath, your application needs to check that the key and leaf certificate are consistent, because it is possible to read the files mid-rotation.
+                                        type: string
+                                      keyType:
+                                        description: |-
+                                          The type of keypair Kubelet will generate for the pod.
+
+                                          Valid values are "RSA3072", "RSA4096", "ECDSAP256", "ECDSAP384", "ECDSAP521", and "ED25519".
+                                        type: string
+                                      maxExpirationSeconds:
+                                        description: |-
+                                          maxExpirationSeconds is the maximum lifetime permitted for the certificate.
+
+                                          Kubelet copies this value verbatim into the PodCertificateRequests it generates for this projection.
+
+                                          If omitted, kube-apiserver will set it to 86400(24 hours). kube-apiserver will reject values shorter than 3600 (1 hour).  The maximum allowable value is 7862400 (91 days).
+
+                                          The signer implementation is then free to issue a certificate with any lifetime *shorter* than MaxExpirationSeconds, but no shorter than 3600 seconds (1 hour).  This constraint is enforced by kube-apiserver. `kubernetes.io` signers will never issue certificates with a lifetime longer than 24 hours.
+                                        format: int32
+                                        type: integer
+                                      signerName:
+                                        description: Kubelet's generated CSRs will be addressed to this signer.
+                                        type: string
+                                    required:
+                                    - keyType
+                                    - signerName
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret data to project
+                                    properties:
+                                      items:
+                                        description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether the Secret or its key must be defined
+                                        type: boolean
+                                    required:
+                                    - name
+                                    type: object
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: path is the path relative to the mount point of the file to project the token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          type: object
+                        quobyte:
+                          description: 'quobyte represents a Quobyte mount on the host that shares a pod''s lifetime. Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.'
+                          properties:
+                            group:
+                              description: group to map volume access to Default is no group
+                              type: string
+                            readOnly:
+                              description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                              type: boolean
+                            registry:
+                              description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: user to map volume access to Defaults to serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.'
+                          properties:
+                            fsType:
+                              description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                              type: string
+                            image:
+                              description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            keyring:
+                              description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            monitors:
+                              description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                            readOnly:
+                              description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: boolean
+                            secretRef:
+                              description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            user:
+                              description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          description: 'scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes. Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.'
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                          properties:
+                            defaultMode:
+                              description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              description: optional field specify whether the Secret or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                        storageos:
+                          description: 'storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes. Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.'
+                          properties:
+                            fsType:
+                              description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                              properties:
+                                name:
+                                  description: 'Name of the referent. This field is effectively required, but due to backwards compatibility is allowed to be empty. Instances of this type with an empty value here are almost certainly wrong. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            volumeName:
+                              description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: 'vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine. Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type are redirected to the csi.vsphere.vmware.com CSI driver.'
+                          properties:
+                            fsType:
+                              description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    nullable: true
+                    type: array
                   image:
                     description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images.'
                     type: string

--- a/release-notes/unreleased/restatecluster-pod-lifecycle.md
+++ b/release-notes/unreleased/restatecluster-pod-lifecycle.md
@@ -1,0 +1,44 @@
+# Release Notes: RestateCluster pod lifecycle, sidecars, and termination grace period
+
+## New Feature
+
+### What Changed
+
+Three new optional fields on `RestateCluster` `spec.compute` are passed through to
+the underlying StatefulSet pod template:
+
+- `lifecycle` — container lifecycle hooks (`postStart` / `preStop`) for the Restate
+  container.
+- `sidecars` — native sidecar containers. Each runs alongside the Restate container
+  (started before it, terminated after it); the operator forces `restartPolicy: Always`
+  so an entry behaves as a sidecar rather than a startup-blocking init container.
+- `terminationGracePeriodSeconds` — overrides the pod termination grace period
+  (previously hardcoded to 60 seconds).
+
+### Why This Matters
+
+These let operators wire in graceful-shutdown hooks, run companion containers (log
+shippers, proxies, metrics exporters) next to Restate with correct start/stop
+ordering, and tune the shutdown window for their workload.
+
+### Impact on Users
+
+- Existing deployments: no impact — all three fields are optional and omitting them
+  preserves today's behaviour (no lifecycle hooks, no sidecars, 60s grace period).
+- New deployments: opt in via `spec.compute`.
+
+### Usage
+
+```yaml
+spec:
+  compute:
+    image: docker.restate.dev/restatedev/restate:latest
+    terminationGracePeriodSeconds: 120
+    lifecycle:
+      preStop:
+        exec:
+          command: ["/bin/sh", "-c", "sleep 5"]
+    sidecars:
+      - name: log-shipper
+        image: log-shipper:latest
+```

--- a/release-notes/unreleased/restatecluster-pod-lifecycle.md
+++ b/release-notes/unreleased/restatecluster-pod-lifecycle.md
@@ -50,7 +50,7 @@ spec:
     lifecycle:
       preStop:
         exec:
-          command: ["/node-state-control/pre-stop.sh"]
+          command: ["/bin/sh", "/node-state-control/pre-stop.sh"]
     sidecars:
       - name: log-shipper
         image: log-shipper:latest

--- a/release-notes/unreleased/restatecluster-pod-lifecycle.md
+++ b/release-notes/unreleased/restatecluster-pod-lifecycle.md
@@ -4,7 +4,7 @@
 
 ### What Changed
 
-Three new optional fields on `RestateCluster` `spec.compute` are passed through to
+Five new optional fields on `RestateCluster` `spec.compute` are passed through to
 the underlying StatefulSet pod template:
 
 - `lifecycle` — container lifecycle hooks (`postStart` / `preStop`) for the Restate
@@ -14,6 +14,9 @@ the underlying StatefulSet pod template:
   so an entry behaves as a sidecar rather than a startup-blocking init container.
 - `terminationGracePeriodSeconds` — overrides the pod termination grace period
   (previously hardcoded to 60 seconds).
+- `extraVolumes` — additional pod volumes alongside the operator-managed ones.
+- `extraVolumeMounts` — additional volume mounts for the Restate container; sidecars
+  carry their own mounts and share these pod-level `extraVolumes`.
 
 ### Why This Matters
 
@@ -23,8 +26,9 @@ ordering, and tune the shutdown window for their workload.
 
 ### Impact on Users
 
-- Existing deployments: no impact — all three fields are optional and omitting them
-  preserves today's behaviour (no lifecycle hooks, no sidecars, 60s grace period).
+- Existing deployments: no impact — all five fields are optional and omitting them
+  preserves today's behaviour (no lifecycle hooks, no sidecars, no extra volumes,
+  60s grace period).
 - New deployments: opt in via `spec.compute`.
 
 ### Usage
@@ -34,11 +38,23 @@ spec:
   compute:
     image: docker.restate.dev/restatedev/restate:latest
     terminationGracePeriodSeconds: 120
+    extraVolumes:
+      - name: hooks
+        configMap:
+          name: node-state-control
+          defaultMode: 0755
+    extraVolumeMounts:
+      - name: hooks
+        mountPath: /node-state-control
+        readOnly: true
     lifecycle:
       preStop:
         exec:
-          command: ["/bin/sh", "-c", "sleep 5"]
+          command: ["/node-state-control/pre-stop.sh"]
     sidecars:
       - name: log-shipper
         image: log-shipper:latest
+        volumeMounts:
+          - name: hooks
+            mountPath: /node-state-control
 ```

--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -649,29 +649,58 @@ fn restate_pvc_resources(storage: &RestateClusterStorage) -> VolumeResourceRequi
     }
 }
 
-/// Reject duplicate pod volume names up front with a clear error instead of letting the API server
-/// reject the StatefulSet with an opaque "Duplicate value" message. This catches a user-supplied
-/// `extraVolumes` name colliding with an operator-managed volume (storage/tmp/config, the CA-cert
-/// volumes, or the signing-key volumes) as well as duplicates within `extraVolumes` itself.
-fn validate_unique_volume_names(stateful_set: &StatefulSet) -> Result<(), Error> {
-    let Some(volumes) = stateful_set
-        .spec
-        .as_ref()
-        .and_then(|s| s.template.spec.as_ref())
-        .and_then(|p| p.volumes.as_ref())
-    else {
+/// Reject colliding pod volumes/mounts up front with a clear error instead of letting the API server
+/// reject the StatefulSet with an opaque "Duplicate value" message.
+///
+/// Catches a user-supplied `extraVolumes` name colliding with an operator-managed volume
+/// (storage/tmp/config, the CA-cert volumes, or the signing-key volumes) or with another extra volume,
+/// and an `extraVolumeMounts` entry reusing an operator mountPath on the Restate container. Note that
+/// `storage` is a volumeClaimTemplate, not a `template.spec.volumes` entry, so its name is seeded
+/// explicitly. Duplicate mount *paths* (not names) are the API-server error for mounts, since the same
+/// volume may legitimately be mounted at multiple paths.
+fn validate_pod_volumes(stateful_set: &StatefulSet) -> Result<(), Error> {
+    let Some(spec) = stateful_set.spec.as_ref() else {
         return Ok(());
     };
 
-    let mut seen = HashSet::with_capacity(volumes.len());
-    for volume in volumes {
-        if !seen.insert(volume.name.as_str()) {
+    // volumeClaimTemplates inject a pod volume named after each claim (e.g. "storage") that never
+    // appears in template.spec.volumes; seed those so an extraVolume can't silently shadow them.
+    let mut volume_names: HashSet<&str> = HashSet::new();
+    for vct in spec.volume_claim_templates.iter().flatten() {
+        if let Some(name) = vct.metadata.name.as_deref() {
+            volume_names.insert(name);
+        }
+    }
+
+    let pod = spec.template.spec.as_ref();
+
+    for volume in pod.and_then(|p| p.volumes.as_ref()).into_iter().flatten() {
+        if !volume_names.insert(volume.name.as_str()) {
             return Err(Error::InvalidRestateConfig(format!(
                 "duplicate pod volume name {:?}: spec.compute.extraVolumes must not reuse a name \
                  already used by another volume (operator-managed names include \"storage\", \"tmp\", \
                  \"config\", \"combined-ca-certs\", \"trusted-ca-<n>\", and \
                  \"request-signing-private-key-secret\"/\"-provider\")",
                 volume.name
+            )));
+        }
+    }
+
+    // The Restate container is containers[0]; reject duplicate mountPaths there so an extraVolumeMount
+    // shadowing an operator mount (e.g. /restate-data, /tmp, /config) fails with a clear error.
+    let mut mount_paths: HashSet<&str> = HashSet::new();
+    for mount in pod
+        .and_then(|p| p.containers.first())
+        .and_then(|c| c.volume_mounts.as_ref())
+        .into_iter()
+        .flatten()
+    {
+        if !mount_paths.insert(mount.mount_path.as_str()) {
+            return Err(Error::InvalidRestateConfig(format!(
+                "duplicate volume mountPath {:?} on the Restate container: \
+                 spec.compute.extraVolumeMounts must not reuse a path the operator already mounts \
+                 (e.g. /restate-data, /tmp, /config)",
+                mount.mount_path
             )));
         }
     }
@@ -935,7 +964,7 @@ pub async fn reconcile_compute(
         cm_name,
         &ctx.canary_image,
     );
-    validate_unique_volume_names(&stateful_set)?;
+    validate_pod_volumes(&stateful_set)?;
     let ss = apply_stateful_set(name, &ss_api, stateful_set).await?;
 
     // Handle cluster provisioning if enabled
@@ -1778,20 +1807,25 @@ mod tests {
     }
 
     #[test]
-    fn extra_volume_name_collision_is_rejected() {
-        // unique names validate
+    fn extra_volume_collisions_are_rejected() {
+        // unique names/paths validate
         let ok = statefulset_for_compute(RestateClusterCompute {
             image: "restate".into(),
             extra_volumes: Some(vec![Volume {
                 name: "hooks".into(),
                 ..Default::default()
             }]),
+            extra_volume_mounts: Some(vec![VolumeMount {
+                name: "hooks".into(),
+                mount_path: "/hooks".into(),
+                ..Default::default()
+            }]),
             ..Default::default()
         });
-        assert!(validate_unique_volume_names(&ok).is_ok());
+        assert!(validate_pod_volumes(&ok).is_ok());
 
-        // colliding with an operator-managed volume ("config") is rejected with a clear error
-        let bad = statefulset_for_compute(RestateClusterCompute {
+        // colliding with an in-list operator volume ("config")
+        let dup_config = statefulset_for_compute(RestateClusterCompute {
             image: "restate".into(),
             extra_volumes: Some(vec![Volume {
                 name: "config".into(),
@@ -1799,9 +1833,40 @@ mod tests {
             }]),
             ..Default::default()
         });
-        let err = validate_unique_volume_names(&bad).expect_err("collision must be rejected");
+        let err = validate_pod_volumes(&dup_config).expect_err("config collision must be rejected");
         assert!(matches!(err, Error::InvalidRestateConfig(_)));
-        assert!(err.to_string().contains("config"));
+
+        // colliding with "storage" -- which is a volumeClaimTemplate, not a template.spec.volumes
+        // entry, so this is the case the earlier name-only check missed.
+        let dup_storage = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            extra_volumes: Some(vec![Volume {
+                name: "storage".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let err =
+            validate_pod_volumes(&dup_storage).expect_err("storage collision must be rejected");
+        assert!(err.to_string().contains("storage"));
+
+        // reusing an operator mountPath ("/config") on the Restate container
+        let dup_path = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            extra_volumes: Some(vec![Volume {
+                name: "hooks".into(),
+                ..Default::default()
+            }]),
+            extra_volume_mounts: Some(vec![VolumeMount {
+                name: "hooks".into(),
+                mount_path: "/config".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let err =
+            validate_pod_volumes(&dup_path).expect_err("mountPath collision must be rejected");
+        assert!(err.to_string().contains("/config"));
     }
 
     #[test]

--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -520,6 +520,16 @@ fn restate_statefulset(
 
     let init_containers = (!init_containers.is_empty()).then_some(init_containers);
 
+    // Append user-defined extras last, so they can reference (but not shadow) the operator-managed
+    // volumes/mounts. extraVolumeMounts apply to the Restate container; sidecars carry their own
+    // mounts and share these pod-level extraVolumes.
+    if let Some(extra) = spec.compute.extra_volume_mounts.clone() {
+        volume_mounts.extend(extra);
+    }
+    if let Some(extra) = spec.compute.extra_volumes.clone() {
+        volumes.extend(extra);
+    }
+
     StatefulSet {
         metadata,
         spec: Some(StatefulSetSpec {
@@ -1697,6 +1707,47 @@ mod tests {
         let sidecar = &pod.init_containers.as_ref().unwrap()[0];
         assert_eq!(sidecar.name, "logger");
         assert_eq!(sidecar.restart_policy.as_deref(), Some("Always"));
+    }
+
+    #[test]
+    fn extra_volumes_and_mounts_passed_through() {
+        let ss = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            extra_volumes: Some(vec![Volume {
+                name: "hooks".into(),
+                config_map: Some(ConfigMapVolumeSource {
+                    name: "node-state-control".into(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }]),
+            extra_volume_mounts: Some(vec![VolumeMount {
+                name: "hooks".into(),
+                mount_path: "/node-state-control".into(),
+                read_only: Some(true),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let pod = pod_spec(&ss);
+
+        // extra volume is present alongside the operator-managed ones
+        assert!(
+            pod.volumes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|v| v.name == "hooks")
+        );
+        // and the Restate container mounts it
+        let mount = pod.containers[0]
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|m| m.name == "hooks")
+            .expect("hooks mount present on restate container");
+        assert_eq!(mount.mount_path, "/node-state-control");
     }
 
     #[test]

--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -649,6 +649,36 @@ fn restate_pvc_resources(storage: &RestateClusterStorage) -> VolumeResourceRequi
     }
 }
 
+/// Reject duplicate pod volume names up front with a clear error instead of letting the API server
+/// reject the StatefulSet with an opaque "Duplicate value" message. This catches a user-supplied
+/// `extraVolumes` name colliding with an operator-managed volume (storage/tmp/config, the CA-cert
+/// volumes, or the signing-key volumes) as well as duplicates within `extraVolumes` itself.
+fn validate_unique_volume_names(stateful_set: &StatefulSet) -> Result<(), Error> {
+    let Some(volumes) = stateful_set
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.spec.as_ref())
+        .and_then(|p| p.volumes.as_ref())
+    else {
+        return Ok(());
+    };
+
+    let mut seen = HashSet::with_capacity(volumes.len());
+    for volume in volumes {
+        if !seen.insert(volume.name.as_str()) {
+            return Err(Error::InvalidRestateConfig(format!(
+                "duplicate pod volume name {:?}: spec.compute.extraVolumes must not reuse a name \
+                 already used by another volume (operator-managed names include \"storage\", \"tmp\", \
+                 \"config\", \"combined-ca-certs\", \"trusted-ca-<n>\", and \
+                 \"request-signing-private-key-secret\"/\"-provider\")",
+                volume.name
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 pub async fn reconcile_compute(
     ctx: &Context,
     // name of the RestateCluster is also the namespace
@@ -897,19 +927,16 @@ pub async fn reconcile_compute(
     )
     .await?;
 
-    let ss = apply_stateful_set(
-        name,
-        &ss_api,
-        restate_statefulset(
-            base_metadata,
-            spec,
-            pod_annotations,
-            signing_key,
-            cm_name,
-            &ctx.canary_image,
-        ),
-    )
-    .await?;
+    let stateful_set = restate_statefulset(
+        base_metadata,
+        spec,
+        pod_annotations,
+        signing_key,
+        cm_name,
+        &ctx.canary_image,
+    );
+    validate_unique_volume_names(&stateful_set)?;
+    let ss = apply_stateful_set(name, &ss_api, stateful_set).await?;
 
     // Handle cluster provisioning if enabled
     // This must happen BEFORE validate_stateful_set_status because pods only become Ready
@@ -1748,6 +1775,33 @@ mod tests {
             .find(|m| m.name == "hooks")
             .expect("hooks mount present on restate container");
         assert_eq!(mount.mount_path, "/node-state-control");
+    }
+
+    #[test]
+    fn extra_volume_name_collision_is_rejected() {
+        // unique names validate
+        let ok = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            extra_volumes: Some(vec![Volume {
+                name: "hooks".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        assert!(validate_unique_volume_names(&ok).is_ok());
+
+        // colliding with an operator-managed volume ("config") is rejected with a clear error
+        let bad = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            extra_volumes: Some(vec![Volume {
+                name: "config".into(),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let err = validate_unique_volume_names(&bad).expect_err("collision must be rejected");
+        assert!(matches!(err, Error::InvalidRestateConfig(_)));
+        assert!(err.to_string().contains("config"));
     }
 
     #[test]

--- a/src/controllers/restatecluster/reconcilers/compute.rs
+++ b/src/controllers/restatecluster/reconcilers/compute.rs
@@ -484,7 +484,12 @@ fn restate_statefulset(
         .and_then(|s| s.trusted_ca_certs.as_deref())
         .unwrap_or_default();
 
-    let init_containers = if !trusted_ca_certs.is_empty() {
+    // init_containers holds (in order) the trusted-CA setup container followed by any user-defined
+    // native sidecars. Sidecars get restartPolicy: Always forced so they run alongside the Restate
+    // container rather than degrading into startup-blocking plain init containers.
+    let mut init_containers = Vec::new();
+
+    if !trusted_ca_certs.is_empty() {
         let (ca_volumes, init_container) =
             trusted_ca_init_container(trusted_ca_certs, canary_image);
         volumes.extend(ca_volumes);
@@ -503,10 +508,17 @@ fn restate_statefulset(
             value_from: None,
         });
 
-        Some(vec![init_container])
-    } else {
-        None
-    };
+        init_containers.push(init_container);
+    }
+
+    if let Some(sidecars) = spec.compute.sidecars.clone() {
+        init_containers.extend(sidecars.into_iter().map(|mut sidecar| {
+            sidecar.restart_policy = Some("Always".into());
+            sidecar
+        }));
+    }
+
+    let init_containers = (!init_containers.is_empty()).then_some(init_containers);
 
     StatefulSet {
         metadata,
@@ -533,6 +545,7 @@ fn restate_statefulset(
                         image_pull_policy: spec.compute.image_pull_policy.clone(),
                         command: spec.compute.command.clone(),
                         args: spec.compute.args.clone(),
+                        lifecycle: spec.compute.lifecycle.clone(),
                         env: Some(env),
                         ports: Some(vec![
                             ContainerPort {
@@ -581,7 +594,9 @@ fn restate_statefulset(
                         ..Default::default()
                     }),
                     service_account_name: Some("restate".into()),
-                    termination_grace_period_seconds: Some(60),
+                    termination_grace_period_seconds: Some(
+                        spec.compute.termination_grace_period_seconds.unwrap_or(60),
+                    ),
                     volumes: Some(volumes),
                     tolerations: spec.compute.tolerations.clone(),
                     node_selector: spec.compute.node_selector.clone(),
@@ -1584,6 +1599,105 @@ mod tests {
     use crate::resources::iampolicymembers::{IAMPolicyMemberCondition, IAMPolicyMemberStatus};
     use crate::resources::restateclusters::RestateClusterCompute;
     use k8s_openapi::api::batch::v1::{JobCondition, JobStatus};
+    use k8s_openapi::api::core::v1::{ExecAction, Lifecycle, LifecycleHandler};
+
+    fn statefulset_for_compute(compute: RestateClusterCompute) -> StatefulSet {
+        let base_metadata = ObjectMeta {
+            name: Some("test".into()),
+            namespace: Some("test".into()),
+            ..Default::default()
+        };
+        let spec = RestateClusterSpec {
+            compute,
+            ..Default::default()
+        };
+        restate_statefulset(
+            &base_metadata,
+            &spec,
+            None,
+            None,
+            "test-config".into(),
+            "alpine:3.21",
+        )
+    }
+
+    fn pod_spec(ss: &StatefulSet) -> &PodSpec {
+        ss.spec.as_ref().unwrap().template.spec.as_ref().unwrap()
+    }
+
+    #[test]
+    fn pod_lifecycle_fields_default_when_unset() {
+        let ss = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            ..Default::default()
+        });
+        let pod = pod_spec(&ss);
+
+        assert_eq!(pod.termination_grace_period_seconds, Some(60));
+        assert!(pod.init_containers.is_none());
+        assert!(pod.containers[0].lifecycle.is_none());
+    }
+
+    #[test]
+    fn pod_lifecycle_fields_passed_through() {
+        let lifecycle = Lifecycle {
+            post_start: Some(LifecycleHandler {
+                exec: Some(ExecAction {
+                    command: Some(vec!["/bin/true".into()]),
+                }),
+                ..Default::default()
+            }),
+            pre_stop: Some(LifecycleHandler {
+                exec: Some(ExecAction {
+                    command: Some(vec!["/bin/sleep".into(), "5".into()]),
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let ss = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            lifecycle: Some(lifecycle.clone()),
+            termination_grace_period_seconds: Some(120),
+            sidecars: Some(vec![Container {
+                name: "logger".into(),
+                image: Some("busybox".into()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let pod = pod_spec(&ss);
+
+        assert_eq!(pod.termination_grace_period_seconds, Some(120));
+        assert_eq!(pod.containers[0].lifecycle.as_ref(), Some(&lifecycle));
+
+        let init_containers = pod.init_containers.as_ref().expect("sidecar present");
+        let sidecar = init_containers
+            .iter()
+            .find(|c| c.name == "logger")
+            .expect("logger sidecar present");
+        assert_eq!(sidecar.restart_policy.as_deref(), Some("Always"));
+    }
+
+    #[test]
+    fn sidecar_restart_policy_is_forced_to_always() {
+        let ss = statefulset_for_compute(RestateClusterCompute {
+            image: "restate".into(),
+            sidecars: Some(vec![Container {
+                name: "logger".into(),
+                image: Some("busybox".into()),
+                restart_policy: Some("Never".into()),
+                ..Default::default()
+            }]),
+            ..Default::default()
+        });
+        let pod = pod_spec(&ss);
+
+        let sidecar = &pod.init_containers.as_ref().unwrap()[0];
+        assert_eq!(sidecar.name, "logger");
+        assert_eq!(sidecar.restart_policy.as_deref(), Some("Always"));
+    }
 
     #[test]
     fn test_parse_gcp_project_from_sa_email() {

--- a/src/resources/restateclusters.rs
+++ b/src/resources/restateclusters.rs
@@ -155,19 +155,25 @@ pub struct RestateClusterCompute {
     pub topology_spread_constraints: Option<Vec<TopologySpreadConstraint>>,
     /// If specified, the pod's priority. PriorityClassName indicates the name of the PriorityClass that should be applied to the Restate pods.
     pub priority_class_name: Option<String>,
-    /// Lifecycle hooks (postStart / preStop) for the Restate container.
+    /// Lifecycle hooks (postStart / preStop) for the Restate container. Note: Kubernetes runs the
+    /// postStart hook concurrently with the container entrypoint and gives no ordering guarantee
+    /// relative to the Restate process starting, so it is not a reliable "before Restate starts" hook.
+    /// For strict pre-start ordering, wrap the entrypoint via command/args instead.
     pub lifecycle: Option<Lifecycle>,
     /// Native sidecar containers to run alongside the Restate container. Each is started before the
     /// Restate container and terminated after it. The operator forces restartPolicy to "Always" so
-    /// these behave as sidecars rather than plain init containers.
+    /// these behave as sidecars rather than plain init containers. Native sidecars require Kubernetes
+    /// 1.29+ (GA in 1.33); older clusters reject restartPolicy on init containers.
     pub sidecars: Option<Vec<Container>>,
-    /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
+    /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60. A value of 0
+    /// terminates immediately (SIGKILL, skipping any preStop hook).
     pub termination_grace_period_seconds: Option<i64>,
-    /// Additional volumes to add to the Restate pod, on top of those the operator manages. These can
-    /// be mounted into the Restate container via extraVolumeMounts or into sidecar containers.
-    /// Names must not collide with operator-managed volumes ("storage", "tmp", "config", and, when the
-    /// respective features are enabled, the trustedCaCerts and requestSigningPrivateKey volumes); a
-    /// duplicate name is rejected when the StatefulSet is applied.
+    /// Additional volumes to add to the Restate pod, on top of those the operator manages. These can be
+    /// mounted into the Restate container via extraVolumeMounts or into sidecar containers. Names must
+    /// not collide with operator-managed volumes: "storage", "tmp", and "config" always, plus
+    /// "combined-ca-certs" and "trusted-ca-<n>" when trustedCaCerts is set, and
+    /// "request-signing-private-key-secret"/"request-signing-private-key-secret-provider" when
+    /// requestSigningPrivateKey is set. The operator rejects a colliding name with a clear error.
     pub extra_volumes: Option<Vec<Volume>>,
     /// Additional volume mounts for the Restate container. The referenced volumes must be declared in
     /// extraVolumes (or be operator-managed).

--- a/src/resources/restateclusters.rs
+++ b/src/resources/restateclusters.rs
@@ -3,8 +3,8 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use k8s_openapi::api::core::v1::{
-    Affinity, EnvVar, LocalObjectReference, PodDNSConfig, ResourceRequirements, Toleration,
-    TopologySpreadConstraint,
+    Affinity, Container, EnvVar, Lifecycle, LocalObjectReference, PodDNSConfig,
+    ResourceRequirements, Toleration, TopologySpreadConstraint,
 };
 use k8s_openapi::api::networking::v1;
 use k8s_openapi::api::networking::v1::{NetworkPolicyPeer, NetworkPolicyPort};
@@ -155,6 +155,14 @@ pub struct RestateClusterCompute {
     pub topology_spread_constraints: Option<Vec<TopologySpreadConstraint>>,
     /// If specified, the pod's priority. PriorityClassName indicates the name of the PriorityClass that should be applied to the Restate pods.
     pub priority_class_name: Option<String>,
+    /// Lifecycle hooks (postStart / preStop) for the Restate container.
+    pub lifecycle: Option<Lifecycle>,
+    /// Native sidecar containers to run alongside the Restate container. Each is started before the
+    /// Restate container and terminated after it. The operator forces restartPolicy to "Always" so
+    /// these behave as sidecars rather than plain init containers.
+    pub sidecars: Option<Vec<Container>>,
+    /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
+    pub termination_grace_period_seconds: Option<i64>,
 }
 
 fn env_schema(g: &mut schemars::SchemaGenerator) -> Schema {

--- a/src/resources/restateclusters.rs
+++ b/src/resources/restateclusters.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use k8s_openapi::api::core::v1::{
     Affinity, Container, EnvVar, Lifecycle, LocalObjectReference, PodDNSConfig,
-    ResourceRequirements, Toleration, TopologySpreadConstraint,
+    ResourceRequirements, Toleration, TopologySpreadConstraint, Volume, VolumeMount,
 };
 use k8s_openapi::api::networking::v1;
 use k8s_openapi::api::networking::v1::{NetworkPolicyPeer, NetworkPolicyPort};
@@ -163,6 +163,15 @@ pub struct RestateClusterCompute {
     pub sidecars: Option<Vec<Container>>,
     /// Optional duration in seconds the pod needs to terminate gracefully. Defaults to 60.
     pub termination_grace_period_seconds: Option<i64>,
+    /// Additional volumes to add to the Restate pod, on top of those the operator manages. These can
+    /// be mounted into the Restate container via extraVolumeMounts or into sidecar containers.
+    /// Names must not collide with operator-managed volumes ("storage", "tmp", "config", and, when the
+    /// respective features are enabled, the trustedCaCerts and requestSigningPrivateKey volumes); a
+    /// duplicate name is rejected when the StatefulSet is applied.
+    pub extra_volumes: Option<Vec<Volume>>,
+    /// Additional volume mounts for the Restate container. The referenced volumes must be declared in
+    /// extraVolumes (or be operator-managed).
+    pub extra_volume_mounts: Option<Vec<VolumeMount>>,
 }
 
 fn env_schema(g: &mut schemars::SchemaGenerator) -> Schema {


### PR DESCRIPTION
Exposes five additional optional pass-through fields to `RestateCluster` `spec.compute`, surfaced on the underlying StatefulSet pod template. All are optional; defaults are unchanged, so existing clusters are unaffected.

## New fields
- `lifecycle` — `postStart` / `preStop` hooks for the Restate container. Note: Kubernetes runs `postStart` concurrently with the entrypoint, so it is **not** a reliable "before Restate starts" hook — use `command`/`args` (an entrypoint wrapper) for strict pre-start ordering.
- `sidecars` — native sidecar containers (appended to `initContainers` with `restartPolicy: Always` forced, so they start before and terminate after the Restate container). Requires native sidecar support (Kubernetes 1.29+, GA 1.33).
- `terminationGracePeriodSeconds` — overrides the previously hardcoded 60s. `0` means immediate SIGKILL (skips `preStop`).
- `extraVolumes` — additional pod volumes alongside the operator-managed ones.
- `extraVolumeMounts` — additional mounts for the Restate container; sidecars carry their own mounts and share these pod-level volumes.

Together these enable graceful-shutdown hooks, companion containers, and mounting reusable content (e.g. a ConfigMap of hook scripts) rather than only inline shell.

## Volume-name collisions
`extraVolumes` names must not collide with operator-managed volumes: `storage`, `tmp`, `config` (always), `combined-ca-certs` and `trusted-ca-<n>` (when `trustedCaCerts` is set), and `request-signing-private-key-secret` / `request-signing-private-key-secret-provider` (when `requestSigningPrivateKey` is set). The operator validates this and rejects a collision with a clear `InvalidRestateConfig` error rather than letting the API server reject the StatefulSet with an opaque message.

## Notes
- All fields reuse the `k8s_openapi` types; the Pkl bindings map them to the pkl-k8s `Lifecycle`/`Container`/`Volume`/`VolumeMount` types so the bindings reference imports rather than expanding inline.

CRD YAML changes are purely additive (no existing field touched). Tests pass; `just generate-all` reproducible; examples evaluate.