### PR TITLE
Add Held registration policy

### DIFF
--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -39,7 +39,7 @@ use crate::resources::knative::{Configuration, Revision, Route};
 use crate::resources::restatecloudenvironments::{InProcessTunnelParams, RestateCloudEnvironment};
 use crate::resources::restateclusters::RestateCluster;
 use crate::resources::restatedeployments::{
-    RESTATE_DEPLOYMENT_FINALIZER, RestateAdminEndpoint, RestateDeployment,
+    RESTATE_DEPLOYMENT_FINALIZER, RegisterPolicy, RestateAdminEndpoint, RestateDeployment,
     RestateDeploymentCondition, RestateDeploymentStatus,
 };
 use crate::telemetry;
@@ -55,6 +55,10 @@ use super::reconcilers::replicaset::{
 pub(super) const RESTATE_DEPLOYMENT_ID_ANNOTATION: &str = "restate.dev/deployment-id";
 pub(super) const OWNED_BY_LABEL: &str = "restate.dev/owned-by";
 pub(super) const APP_MANAGED_BY_LABEL: &str = "app.kubernetes.io/managed-by";
+
+pub(super) fn registration_is_held(policy: RegisterPolicy) -> bool {
+    policy == RegisterPolicy::Held
+}
 
 pub(super) struct Context {
     /// Kubernetes client
@@ -438,6 +442,10 @@ impl RestateDeployment {
             .annotations()
             .get(RESTATE_DEPLOYMENT_ID_ANNOTATION);
 
+        if registration_is_held(self.spec.restate.register.policy) {
+            return Err(Error::RegistrationHeld);
+        }
+
         // if the repliceset doesn't have a deployment id, or its deployment id is not active, register it
         if existing_deployment_id.is_none_or(|existing_deployment_id| {
             !deployments
@@ -695,6 +703,12 @@ impl RestateDeployment {
                         "False".into(),
                     )
                 }
+                Err(Error::RegistrationHeld) => (
+                    Ok(Action::await_change()),
+                    "Workload is ready; registration is held by policy".into(),
+                    "Held".into(),
+                    "False".into(),
+                ),
                 Err(err) => {
                     let message = err.to_string();
                     (
@@ -774,6 +788,12 @@ impl RestateDeployment {
                         "False".into(),
                     )
                 }
+                Err(Error::RegistrationHeld) => (
+                    Ok(Action::await_change()),
+                    "Workload is ready; registration is held by policy".into(),
+                    "Held".into(),
+                    "False".into(),
+                ),
                 Err(Error::AdminCallFailed(ref err)) => {
                     let message = format!("Failed to make Restate admin API call: {}", err);
                     let requeue_after = Duration::from_secs(30);
@@ -1410,6 +1430,14 @@ pub async fn run(client: Client, metrics: Metrics, state: State) {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn registration_policy_defaults_to_auto_and_holds_explicitly() {
+        let rsd = make_rsd(None, "greeter:v1");
+        assert_eq!(rsd.spec.restate.register.policy, RegisterPolicy::Auto);
+        assert!(!registration_is_held(rsd.spec.restate.register.policy));
+        assert!(registration_is_held(RegisterPolicy::Held));
+    }
 
     /// Build a minimal ReplicaSet-mode RestateDeployment for selector tests.
     fn make_rsd(match_labels: Option<&[(&str, &str)]>, image: &str) -> RestateDeployment {

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -9,7 +9,7 @@ use tracing::*;
 use url::Url;
 
 use crate::controllers::restatedeployment::controller::{
-    Context, RESTATE_DEPLOYMENT_ID_ANNOTATION,
+    Context, RESTATE_DEPLOYMENT_ID_ANNOTATION, registration_is_held,
 };
 use crate::controllers::restatedeployment::reconcilers::replicaset::generate_pod_template_hash;
 use crate::resources::knative::{
@@ -640,6 +640,10 @@ async fn register_or_lookup_deployment(
     config: &Configuration,
     route: &Route,
 ) -> Result<String> {
+    if registration_is_held(rsd.spec.restate.register.policy) {
+        return Err(Error::RegistrationHeld);
+    }
+
     // Check if Configuration already has deployment-id annotation
     if let Some(annotations) = &config.metadata.annotations
         && let Some(deployment_id) = annotations.get(RESTATE_DEPLOYMENT_ID_ANNOTATION)

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -642,6 +642,7 @@ mod tests {
                 },
                 restate: RestateSpec {
                     register: RestateAdminEndpoint {
+                        policy: Default::default(),
                         cluster: None,
                         cloud: Some("my-env".into()),
                         service: None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@ pub enum Error {
     #[error("Encountered a hash collision, will retry with a new template hash")]
     HashCollision,
 
+    #[error("RestateDeployment registration is held")]
+    RegistrationHeld,
+
     #[error(
         "This RestateDeployment is backing active versions in Restate. If you want to delete the RestateDeployment, either register new endpoints for the relevant services or delete the Restate versions."
     )]
@@ -114,6 +117,7 @@ impl Error {
             Error::AdminCallFailed(_) => "AdminCallFailed",
             Error::AdminCallRejected { .. } => "AdminCallRejected",
             Error::HashCollision => "HashCollision",
+            Error::RegistrationHeld => "RegistrationHeld",
             Error::DeploymentInUse => "DeploymentInUse",
             Error::DeploymentDraining { .. } => "DeploymentDraining",
             Error::ConfigurationNotReady { .. } => "ConfigurationNotReady",

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -348,6 +348,9 @@ fn tunnel_mode_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct RestateAdminEndpoint {
+    /// Controls whether a ready workload is registered with Restate.
+    #[serde(default)]
+    pub policy: RegisterPolicy,
     /// The name of a RestateCluster against which to register the deployment.
     /// Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
     pub cluster: Option<String>,
@@ -360,6 +363,13 @@ pub struct RestateAdminEndpoint {
     /// A url of the restate admin endpoint against which to register the deployment
     /// Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
     pub url: Option<Url>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, Default, JsonSchema, PartialEq, Eq)]
+pub enum RegisterPolicy {
+    #[default]
+    Auto,
+    Held,
 }
 
 impl Display for RestateAdminEndpoint {
@@ -387,6 +397,12 @@ impl JsonSchema for RestateAdminEndpoint {
         schemars::json_schema!({
             "description": "The location of the Restate Admin API to register this deployment against",
             "properties": {
+                "policy": {
+                    "default": "Auto",
+                    "description": "Auto registers ready versions; Held keeps a ready version unregistered until explicitly flipped.",
+                    "enum": ["Auto", "Held"],
+                    "type": "string"
+                },
                 "cluster": {
                     "description": "The name of a RestateCluster against which to register the deployment. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified",
                     "type": "string"


### PR DESCRIPTION
Adds an explicit Auto/Held registration policy to RestateDeployment. Held keeps a ready version unregistered, reports Ready=False with reason Held, and allows a deployment controller to release registration only after its external preflight gates pass. Auto remains the default. Includes controller and CRD coverage for the default and explicit hold.