### PR TITLE
Update Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.95.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Bumps the pinned Rust toolchain from 1.93.0 to 1.95.0, aligning with restate-server's 1.95.0 pin.

`cargo check` and `cargo clippy` both pass on 1.95.0 with no changes required.