### PR TITLE
ci: build the release image on PRs (+ dev-tools 1.17.0 for Rust 1.95.0, Node 24 actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Install the toolchain pinned in rust-toolchain.toml (channel + components), so lint runs
       # on the same version the release image builds with -- not whatever `stable` happens to be.
       - name: Install pinned Rust toolchain
@@ -26,11 +26,11 @@ jobs:
     name: Build release Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Install just
-        uses: extractions/setup-just@v2
+        uses: extractions/setup-just@v4
       # Build the exact release Dockerfile build-only (--load, no push, no registry secrets).
       # This exercises the dev-tools base image + musl cross-compile at the pinned
       # rust-toolchain.toml, so a toolchain/dev-tools/musl-std mismatch fails the PR instead

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   clippy:
@@ -10,10 +11,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
+      # Install the toolchain pinned in rust-toolchain.toml (channel + components), so lint runs
+      # on the same version the release image builds with -- not whatever `stable` happens to be.
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup show active-toolchain || rustup toolchain install
+          rustup component add clippy
       - name: Install protoc
         uses: restatedev/restate/.github/actions/install-protoc@main
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  build-image:
+    name: Build release Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Install just
+        uses: extractions/setup-just@v2
+      # Build the exact release Dockerfile build-only (--load, no push, no registry secrets).
+      # This exercises the dev-tools base image + musl cross-compile at the pinned
+      # rust-toolchain.toml, so a toolchain/dev-tools/musl-std mismatch fails the PR instead
+      # of only surfacing during the tagged release build.
+      - name: Build the release image (build-only, no push)
+        run: just docker

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.16.1 AS planner
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.17.0 AS planner
 COPY .. .
 RUN just chef-prepare
 
-FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.16.1 AS base
+FROM --platform=$BUILDPLATFORM ghcr.io/restatedev/dev-tools:1.17.0 AS base
 COPY --from=planner /restate/recipe.json recipe.json
 COPY ../justfile justfile
 


### PR DESCRIPTION
## The gap

The v2.8.0 release docker build failed with `error[E0463]` (musl `std` missing). Root cause: `rust-toolchain.toml` was bumped to 1.95.0 (#162) while the release Dockerfile's base image `ghcr.io/restatedev/dev-tools:1.16.1` bakes an *older* toolchain's musl std, so the cross-compile had no matching `std` for `x86_64-unknown-linux-musl`.

This slipped through PR CI entirely because the only PR job was `clippy`, and it:

- ran on `dtolnay/rust-toolchain@stable` — the **host** target, and **not the pinned toolchain** from `rust-toolchain.toml`, so it never saw 1.95.0;
- **never built the musl release image**. That build (dev-tools base + musl cross-compile) lives only in `docker.yml` (a thin `workflow_call`/`dispatch` wrapper around `restatedev/restate/.github/workflows/docker.yml@main`), which is invoked solely by `release.yml` on a tag.

Net: the class of breakage "pinned toolchain drifts from the dev-tools base image's baked musl std" was only observable at release time.

## Change

**New `build-image` job in `ci.yml`** — builds the release image **build-only** on PRs:

- sets up buildx and runs `just docker`, which is exactly `docker build . -f docker/Dockerfile --tag=... --load`;
- `--load` (no push), no registry login, **no secrets** — safe for PRs including forks;
- builds the exact Dockerfile: dev-tools base + musl cross-compile at the pinned `rust-toolchain.toml`. A dev-tools/toolchain/musl mismatch now fails the PR instead of the release.

Builds the host platform (linux/amd64) only — the musl-std mismatch reproduces per-target, so one arch is enough to catch it and it's faster than the release's amd64+arm64 matrix.

### Why not reuse `docker.yml`?

I checked the upstream reusable workflow (`restatedev/restate/.github/workflows/docker.yml@main`). It is unsuitable for a build-only PR check: it targets WarpBuild runners (`warp-ubuntu-latest-x64-16x`), requires `secrets: inherit` (DockerHub creds, `PARCA_TOKEN`), logs into GHCR, pushes to a registry unless a tarball name is passed, and is coupled to the *server* Dockerfile (it greps for `FROM ... AS runtime`, a stage the operator Dockerfile doesn't have). A self-contained `just docker` job is cleaner and needs no credentials.

### Paths filter

**Not applied — runs on all PRs.** GitHub `paths` filters are workflow-level only; scoping a single job by changed paths needs either a separate workflow file or a changed-files action, and either way makes the job a *skippable* required check (a PR that doesn't touch build inputs would leave a required check permanently pending). Running on every PR avoids that footgun. Tradeoff: the image build is not layer-cached here (deliberately avoiding the reusable server workflow's WarpBuild + `type=gha` cache machinery), so each PR pays a full musl build; adding buildx `type=gha` caching is a reasonable follow-up if the cost becomes annoying.

### Clippy toolchain

`clippy` now installs the toolchain pinned in `rust-toolchain.toml` instead of `dtolnay/rust-toolchain@stable`. The dtolnay action has a *required* `toolchain` input and does not read `rust-toolchain.toml`, so pinning it to the file isn't possible without hardcoding the version in a second place. Instead the job runs `rustup show active-toolchain || rustup toolchain install` (rustup honors the toml's channel + components) plus an explicit `rustup component add clippy`. Lint now runs on 1.95.0, matching the release build.

Validated with `actionlint` (clean) and `just --dry-run docker`.