### PR TITLE
CRDs: wait for CRDs instead of exiting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,8 @@ cargo run
 ### Viewing Logs
 
 The operator exposes HTTP endpoints on port 8080:
-- `/health` - Health check
+- `/health` - Liveness; always 200 once the web server is up. Says nothing about the controllers
+- `/ready` - Readiness; 200 once every controller has its CRD and is reconciling, otherwise 503 with the list of controllers still waiting (`{"ready":false,"pendingControllers":["RestateCluster"]}`)
 - `/metrics` - Prometheus metrics
 - `/` - Diagnostics (last event timestamp)
 

--- a/charts/restate-operator-helm/Chart.yaml
+++ b/charts/restate-operator-helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: restate-operator-helm
 description: An operator for Restate clusters
 type: application
-version: "2.8.1"
+version: "2.9.0"
 
 dependencies:
   - name: restate-operator-crds

--- a/charts/restate-operator-helm/templates/deployment.yaml
+++ b/charts/restate-operator-helm/templates/deployment.yaml
@@ -60,6 +60,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.labels['app']
+            # Identifies this pod so operator-level events (eg WaitingForCRD) can be
+            # attached to it; the uid is what makes them show up in `kubectl describe pod`.
+            - name: OPERATOR_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: OPERATOR_POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
           {{- if .Values.awsPodIdentityAssociationCluster }}
             - name: AWS_POD_IDENTITY_ASSOCIATION_CLUSTER
               value: {{ .Values.awsPodIdentityAssociationCluster }}
@@ -79,9 +89,19 @@ spec:
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          readinessProbe:
+          # /health only says the process is serving; restarting the operator will not make
+          # a missing CRD appear, so it is a liveness probe and nothing more.
+          livenessProbe:
             httpGet:
               path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          # /ready is 503 until every controller has its CRD and is reconciling, so an
+          # operator whose CRDs were never installed shows up as NotReady.
+          readinessProbe:
+            httpGet:
+              path: /ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5

--- a/charts/restate-operator-helm/templates/service.yaml
+++ b/charts/restate-operator-helm/templates/service.yaml
@@ -12,6 +12,10 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  # This service exists to scrape /metrics and read /, and the operator is NotReady exactly
+  # when its CRDs are missing — which is when restate_operator_crd_missing matters most. Keep
+  # the endpoint published so that ServiceMonitor targets do not disappear at that point.
+  publishNotReadyAddresses: true
   ports:
     - port: {{ .Values.service.port }}
       targetPort: 8080

--- a/release-notes/unreleased/166-poll-for-crds-on-startup.md
+++ b/release-notes/unreleased/166-poll-for-crds-on-startup.md
@@ -1,0 +1,50 @@
+# Release Notes for Issue #166: Poll for CRDs on startup instead of exiting
+
+## Behavioral Change
+
+### What Changed
+
+Previously, if a required CRD (`RestateCluster`, `RestateDeployment`, or `RestateCloudEnvironment`) was not installed in the cluster when the operator started, the operator would log an error and exit immediately. The same applied to the optional `PodIdentityAssociation` CRD when an AWS pod identity association cluster was configured.
+
+Now, on startup the operator polls the apiserver's discovery endpoint for each required CRD and loops until the resource appears, emitting a warning every 10 seconds while it is missing. The operator no longer exits when a required CRD is absent — it waits for it to be applied and then begins reconciling.
+
+Discovery is used rather than listing the resource or reading the `CustomResourceDefinition` object: it needs no RBAC beyond what every authenticated client has, and a resource only shows up there once its CRD is established and the version is served.
+
+All of these now mean "not ready yet, keep waiting": a missing group/version (`404`), a missing resource within a served group/version, the responses that mean the apiserver cannot answer right now (`429` and `5xx`), and a failure to reach the apiserver at all (connection refused, timeouts). Every one of those routinely happens while a cluster is coming up, and exiting fixes none of them — it just turns a wait into a crashloop. This also covers the API-group listing the `RestateCluster` controller uses to detect which *optional* CRDs are installed, which previously exited on any failure and so ran before (and defeated) the CRD wait.
+
+Any other failure — a `401` or `403`, a bad kubeconfig — still logs an error and exits, since those need someone to change something. The corollary is that a permanently unreachable apiserver (a wrong CA, say) is now waited on rather than crashlooped; that is deliberate, because waiting is no longer silent (see below).
+
+Because a CRD that never arrives would otherwise leave the operator idle but healthy, the wait is now surfaced in three ways beyond the log line:
+
+- **A readiness endpoint.** The new `/ready` endpoint returns `200` only once every controller has its CRD and has started reconciling, and `503` otherwise, with the controllers still waiting listed in the body:
+
+  ```json
+  {"ready":false,"pendingControllers":["RestateCluster","RestateDeployment"]}
+  ```
+
+  `/health` keeps its old always-`200` behaviour and is now used as a liveness probe: restarting the operator does not make a missing CRD appear, so waiting for a CRD must not get the pod killed.
+- **A metric.** `restate_operator_crd_missing{crd="<plural>.<group>"}` is `1` while the operator is waiting for that CRD and `0` once it is available, so a CRD that never arrives can be alerted on (e.g. `restate_operator_crd_missing > 0 for 5m`).
+- **A Kubernetes event.** A single `Warning` event with reason `WaitingForCRD` is recorded against the operator's own pod, naming every CRD being waited for at once:
+
+  > Waiting for 3 CRDs to be installed before reconciling them: restateclusters.restate.dev, restatecloudenvironments.restate.dev, restatedeployments.restate.dev.
+
+  The controllers wait independently, so this is reported centrally rather than from each of them — one event series for the operator instead of one per CRD. It is re-published every 10 seconds, which the API folds into that series' count, and a `Normal` `CRDsAvailable` event closes it out once everything is reconciling. Nothing is emitted at all if the CRDs land within the first 10 seconds, which is the common case for the GitOps race this change exists to handle.
+
+While waiting, the operator remains responsive to `SIGTERM`/`SIGINT`: the wait is aborted and the process shuts down promptly rather than running until the kubelet's grace period expires. The signal handlers are installed once, before the poll loop, so there is no window in which a signal would terminate the process outright.
+
+The `PodIdentityAssociation` check (when `aws-pod-identity-association-cluster` is set) still exits, since that is a configuration error rather than a missing-CRD race.
+
+### Why This Matters
+
+In GitOps and automated install flows the operator and the CRDs are often applied together, and the operator can come up before the CRDs are admitted. The old behaviour required careful ordering (or restarts) to get the operator running. With this change the operator simply waits for the CRDs to arrive, which matches how most Kubernetes operators behave and removes the need to restart the operator after installing the CRDs.
+
+### Impact on Users
+
+- **New deployments:** The operator can be installed in any order relative to its CRDs. It will start and begin reconciling as soon as the CRDs are available. Until then the pod is `NotReady`, so `kubectl get pods` and `kubectl describe pod` both say what is being waited on.
+- **Existing deployments:** No change once the CRDs are present. If the CRDs are removed while the operator is running, the controller for that resource will keep retrying its watches (existing kube-rs behaviour) rather than exiting; readiness is not revoked once a controller has started.
+- **Observability:** While waiting for a CRD, the operator logs a `WARN` line every 10 seconds naming the missing CRD, serves `503` on `/ready`, sets `restate_operator_crd_missing` to `1` for that CRD, and records one `WaitingForCRD` event on its own pod listing all of them (`kubectl describe pod -n <operator namespace> <operator pod>`).
+- **RBAC:** No new permissions are required. The discovery endpoint is readable by any authenticated client, and the operator already holds `create`/`patch` on `events.k8s.io` for the events it emits on the resources it manages.
+- **Chart:**
+  - The readiness probe now targets `/ready` and a liveness probe targeting `/health` has been added. **Upgrade note:** the chart's `version` defaults to the chart version, so chart and image move together. If you pin `version` to an operator image older than this release, pin the chart too — an older image has no `/ready`, and the resulting `404` would keep the pod `NotReady` forever.
+  - The Deployment passes `OPERATOR_POD_NAME` and `OPERATOR_POD_UID` via the downward API so that operator-level events can be attached to the right pod. If you deploy the operator without the chart, set both (or neither — without them the operator logs and reports the metric as usual, but emits no events).
+  - The operator `Service` sets `publishNotReadyAddresses: true`. It exists only to serve `/metrics` and `/`, and a `NotReady` operator is exactly when `restate_operator_crd_missing` needs scraping, so its endpoint must not drop out of the `ServiceMonitor`'s targets.

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,18 +1,29 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
+use k8s_openapi::api::core::v1::ObjectReference;
 use kube::Resource;
+use kube::client::Client;
 use kube::runtime::WatchStreamExt;
+use kube::runtime::events::{Event, EventType, Recorder};
 use kube::runtime::{reflector, watcher};
 use serde::Serialize;
 use tokio::sync::RwLock;
-use tracing::debug;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
 use url::Url;
+
+use crate::Metrics;
 
 pub mod restatecloudenvironment;
 pub mod restatecluster;
 pub mod restatedeployment;
+
+/// How often each controller re-checks for its missing CRD, and how often the aggregate
+/// `WaitingForCRD` event is re-published while any are missing.
+const CRD_POLL_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Diagnostics to be exposed by the web server
 #[derive(Clone, Serialize)]
@@ -29,11 +40,132 @@ impl Default for Diagnostics {
     }
 }
 
+/// The controllers whose startup gates the operator's readiness.
+///
+/// Until a controller's CRD exists it cannot reconcile anything, so the operator is not
+/// meaningfully ready; see [`Readiness`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReadinessGate {
+    RestateCluster,
+    RestateCloudEnvironment,
+    RestateDeployment,
+}
+
+impl ReadinessGate {
+    /// Every gate. The order is the order flags are stored in [`Readiness`], so a gate's
+    /// position here must match its discriminant; there is a test for that.
+    pub const ALL: [Self; 3] = [
+        Self::RestateCluster,
+        Self::RestateCloudEnvironment,
+        Self::RestateDeployment,
+    ];
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::RestateCluster => "RestateCluster",
+            Self::RestateCloudEnvironment => "RestateCloudEnvironment",
+            Self::RestateDeployment => "RestateDeployment",
+        }
+    }
+}
+
+/// How far a controller has got towards reconciling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum GateState {
+    /// The controller has not reported anything yet.
+    Starting,
+    /// The controller cannot reconcile until this CRD (`<plural>.<group>`) appears.
+    WaitingForCrd(String),
+    /// The controller has its CRD and has started reconciling.
+    Ready,
+}
+
+/// Tracks how far each controller has got towards reconciling.
+///
+/// This is the single source of truth for two things that would otherwise drift apart: what
+/// `/ready` reports, and which CRDs the aggregate `WaitingForCRD` event names. The operator
+/// serves `/health` from the moment the web server binds, so on its own that endpoint cannot
+/// distinguish "running and reconciling" from "running, but waiting forever for a CRD that is
+/// never going to arrive".
+#[derive(Debug)]
+pub struct Readiness {
+    /// One entry per gate, positionally matching [`ReadinessGate::ALL`]. The set of gates is
+    /// fixed up front so that `/ready` reports the truth from the first scrape, before any
+    /// controller has had a chance to run.
+    gates: RwLock<[GateState; ReadinessGate::ALL.len()]>,
+}
+
+impl Readiness {
+    fn new() -> Self {
+        Self {
+            gates: RwLock::new(std::array::from_fn(|_| GateState::Starting)),
+        }
+    }
+
+    /// Records that a controller cannot reconcile until `crd_name` shows up.
+    pub async fn mark_waiting_for_crd(&self, gate: ReadinessGate, crd_name: &str) {
+        self.gates.write().await[gate as usize] = GateState::WaitingForCrd(crd_name.to_owned());
+    }
+
+    /// Records that a controller has its CRD and is about to start reconciling.
+    pub async fn mark_ready(&self, gate: ReadinessGate) {
+        let mut gates = self.gates.write().await;
+        if gates[gate as usize] != GateState::Ready {
+            gates[gate as usize] = GateState::Ready;
+            info!("{} controller is ready", gate.name());
+        }
+    }
+
+    /// The CRDs controllers are currently waiting for, in gate order.
+    ///
+    /// Each controller waits for a different CRD, so these are naturally distinct.
+    pub async fn pending_crds(&self) -> Vec<String> {
+        self.gates
+            .read()
+            .await
+            .iter()
+            .filter_map(|state| match state {
+                GateState::WaitingForCrd(crd_name) => Some(crd_name.clone()),
+                GateState::Starting | GateState::Ready => None,
+            })
+            .collect()
+    }
+
+    /// A snapshot of readiness, as served by `/ready`.
+    pub async fn report(&self) -> ReadinessReport {
+        let gates = self.gates.read().await;
+
+        let pending_controllers: Vec<&'static str> = ReadinessGate::ALL
+            .into_iter()
+            .filter(|gate| gates[*gate as usize] != GateState::Ready)
+            .map(ReadinessGate::name)
+            .collect();
+
+        ReadinessReport {
+            ready: pending_controllers.is_empty(),
+            pending_controllers,
+        }
+    }
+}
+
+/// The body served by the `/ready` endpoint.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReadinessReport {
+    /// True once every controller has its CRD and has started reconciling.
+    pub ready: bool,
+    /// The controllers still waiting for their CRD, so that a failing readiness probe says
+    /// which CRD to go and install.
+    pub pending_controllers: Vec<&'static str>,
+}
+
 /// State shared between the controller and the web server
 #[derive(Clone)]
 pub struct State {
     /// Diagnostics populated by the reconciler
     pub diagnostics: Arc<RwLock<Diagnostics>>,
+    /// Which controllers have started reconciling, served by the web server's `/ready` endpoint
+    pub readiness: Arc<Readiness>,
     /// Metrics registry
     pub registry: prometheus::Registry,
     /// If set, watch AWS PodIdentityAssociation resources, and if requested create them against this cluster
@@ -56,6 +188,11 @@ pub struct State {
 
     /// The container image to use for canary jobs
     pub canary_image: String,
+
+    /// A reference to the operator's own pod, used as the target for events that are about
+    /// the operator itself rather than about a resource it manages. `None` when the pod name
+    /// was not supplied, eg when running outside the cluster.
+    operator_object_ref: Option<ObjectReference>,
 }
 
 /// State wrapper around the controller outputs for the web server
@@ -70,9 +207,21 @@ impl State {
         tunnel_client_default_image: String,
         cluster_dns: String,
         canary_image: String,
+        operator_pod_name: Option<String>,
+        operator_pod_uid: Option<String>,
     ) -> Self {
+        let operator_object_ref = operator_pod_name.map(|name| ObjectReference {
+            api_version: Some("v1".into()),
+            kind: Some("Pod".into()),
+            name: Some(name),
+            namespace: Some(operator_namespace.clone()),
+            uid: operator_pod_uid,
+            ..Default::default()
+        });
+
         Self {
             diagnostics: Arc::new(RwLock::new(Diagnostics::default())),
+            readiness: Arc::new(Readiness::new()),
             registry: prometheus::Registry::default(),
             aws_pod_identity_association_cluster,
             gcp_workload_identity,
@@ -82,6 +231,7 @@ impl State {
             tunnel_client_default_image,
             cluster_dns,
             canary_image,
+            operator_object_ref,
         }
     }
 
@@ -158,4 +308,415 @@ where
     debug!("{} store ready", kind);
 
     stream
+}
+
+/// Watches for the termination signals (SIGTERM, SIGINT) that mean the process should stop.
+///
+/// The controller runtimes install their own handlers via `shutdown_on_signal`, but those
+/// are only registered once the controller is built; this lets the startup path bail out
+/// too, instead of keeping the process alive until the kubelet SIGKILLs it.
+///
+/// The handlers are registered once, when this is constructed, rather than around each
+/// individual wait: recreating the signal streams would leave a brief window with no
+/// handler installed, during which a signal would terminate the process outright.
+struct ShutdownSignals {
+    #[cfg(unix)]
+    sigterm: tokio::signal::unix::Signal,
+    #[cfg(unix)]
+    sigint: tokio::signal::unix::Signal,
+}
+
+impl ShutdownSignals {
+    fn new() -> Self {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{SignalKind, signal};
+            Self {
+                sigterm: signal(SignalKind::terminate())
+                    .expect("failed to register SIGTERM handler"),
+                sigint: signal(SignalKind::interrupt()).expect("failed to register SIGINT handler"),
+            }
+        }
+        #[cfg(not(unix))]
+        Self {}
+    }
+
+    /// Resolves once a termination signal has been received.
+    async fn recv(&mut self) {
+        #[cfg(unix)]
+        {
+            let Self { sigterm, sigint } = self;
+            tokio::select! {
+                _ = sigterm.recv() => {}
+                _ = sigint.recv() => {}
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+}
+
+/// Whether a failure to read the apiserver's discovery information is one that waiting might
+/// resolve.
+///
+/// True for `429` and `5xx` (the apiserver is there but cannot answer right now), for a `404`
+/// (the group or version is not served yet), and for any transport failure (it could not be
+/// reached at all). Every one of those routinely happens while a cluster is coming up, and
+/// exiting fixes none of them — it just turns a wait into a crashloop.
+///
+/// False for anything that needs someone to change something: a `401` or `403`, a bad
+/// kubeconfig, an unparseable response.
+///
+/// The corollary is that a permanently unreachable apiserver — a wrong CA, say — is waited on
+/// rather than crashlooped. That is deliberate now that waiting is not silent: it surfaces as a
+/// `NotReady` pod, a `restate_operator_crd_missing` gauge stuck at 1, and a repeated event.
+fn is_retryable_discovery_error(error: &kube::Error) -> bool {
+    match error {
+        kube::Error::Api(resp) => resp.code == 404 || resp.code == 429 || resp.code >= 500,
+        kube::Error::Service(_) | kube::Error::HyperError(_) => true,
+        _ => false,
+    }
+}
+
+/// Reads the apiserver's list of API groups, waiting through the failures that waiting can
+/// resolve instead of exiting and crashlooping.
+///
+/// This is how the RestateCluster controller detects which *optional* CRDs are installed, so it
+/// runs before [`wait_for_crd`] and has to survive the same cluster-still-coming-up conditions.
+///
+/// Returns `None` if the process was asked to shut down while waiting.
+pub async fn wait_for_api_groups(
+    client: &Client,
+) -> Result<Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::APIGroupList>, kube::Error> {
+    let mut signals = ShutdownSignals::new();
+
+    loop {
+        match client.list_api_groups().await {
+            Ok(list) => return Ok(Some(list)),
+            Err(ref e) if is_retryable_discovery_error(e) => {
+                warn!(
+                    "Could not list api groups ({e}). Is the apiserver reachable? \
+                     Retrying in {CRD_POLL_INTERVAL:?}..."
+                );
+            }
+            Err(e) => return Err(e),
+        }
+
+        tokio::select! {
+            _ = sleep(CRD_POLL_INTERVAL) => {}
+            _ = signals.recv() => {
+                info!("Shutting down while waiting to list api groups");
+                return Ok(None);
+            }
+        }
+    }
+}
+
+/// The outcome of waiting for a CRD to become available.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CrdWait {
+    /// The CRD is registered and served; the caller may start its controller.
+    Available,
+    /// A termination signal arrived while waiting; the caller must not start its controller.
+    ShuttingDown,
+}
+
+/// Polls the apiserver's discovery endpoint until the CRD for the given resource type is
+/// registered and served.
+///
+/// This replaces the previous behaviour of exiting the operator when a required CRD was
+/// not yet present, so that the operator can start before the CRDs are applied and pick
+/// them up once they appear. Discovery (rather than a `list` of the resource, or a read
+/// of the CRD object itself) is used because it is readable without any additional RBAC,
+/// and because a resource only appears there once its CRD is established and the version
+/// is served.
+///
+/// These are all treated as "not ready yet, keep waiting": a `404` for the whole group/version,
+/// a missing resource within a served group/version, the responses that mean the apiserver
+/// cannot answer right now (`429` and `5xx`), and a failure to reach the apiserver at all. Each
+/// of those routinely happens while a cluster is coming up, and exiting fixes none of them.
+///
+/// Anything else — a `401` or `403`, a bad kubeconfig — needs someone to change something, so it
+/// is returned as an error for the caller to act on.
+///
+/// The corollary is that a permanently unreachable apiserver (a wrong CA, say) is waited on
+/// rather than crashlooped. That is deliberate: the wait is no longer silent, so it surfaces as
+/// a `NotReady` pod, a `restate_operator_crd_missing` gauge stuck at 1, and a repeated event.
+///
+/// Because a CRD that never arrives would otherwise leave the operator silently idle while
+/// still reporting healthy, every failed poll bumps the `restate_operator_crd_missing` gauge
+/// and records the wait against `gate`, which is what `/ready` reports and what
+/// [`report_pending_crds`] turns into a Kubernetes event.
+pub async fn wait_for_crd<K>(
+    gate: ReadinessGate,
+    client: &Client,
+    metrics: &Metrics,
+    state: &State,
+) -> Result<CrdWait, kube::Error>
+where
+    K: Resource<DynamicType = ()>,
+{
+    let api_version = K::api_version(&());
+    let plural = K::plural(&());
+    let crd_name = format!("{}.{}", plural, K::group(&()));
+
+    let missing = metrics.crd_missing.with_label_values(&[crd_name.as_str()]);
+    missing.set(0);
+
+    let mut signals = ShutdownSignals::new();
+    let mut waited = false;
+
+    loop {
+        let note = match client.list_api_group_resources(&api_version).await {
+            Ok(list) if list.resources.iter().any(|r| r.name == plural) => {
+                missing.set(0);
+                if waited {
+                    info!("CRD {crd_name} is now available");
+                } else {
+                    debug!("CRD {crd_name} is available");
+                }
+                state.readiness.mark_ready(gate).await;
+                return Ok(CrdWait::Available);
+            }
+            // the group/version is served, but not (yet) this resource
+            Ok(_) => format!("CRD {crd_name} is not yet available. Is it installed?"),
+            // the whole group/version is missing, so the CRD cannot be there either
+            Err(kube::Error::Api(resp)) if resp.code == 404 => format!(
+                "API version {api_version} is not yet available, so neither is CRD {crd_name}. Is it installed?"
+            ),
+            // too busy, unhealthy, or unreachable: all worth another go in a moment
+            Err(ref e) if is_retryable_discovery_error(e) => format!(
+                "Could not confirm CRD {crd_name} from the apiserver ({e}). Is it reachable?"
+            ),
+            // anything else needs someone to change something, so let the caller decide what to
+            // do rather than waiting for it to fix itself
+            Err(e) => return Err(e),
+        };
+
+        waited = true;
+        missing.set(1);
+        warn!("{note} Retrying in {CRD_POLL_INTERVAL:?}...");
+        state.readiness.mark_waiting_for_crd(gate, &crd_name).await;
+
+        tokio::select! {
+            _ = sleep(CRD_POLL_INTERVAL) => {}
+            _ = signals.recv() => {
+                info!("Shutting down while waiting for CRD {crd_name}");
+                return Ok(CrdWait::ShuttingDown);
+            }
+        }
+    }
+}
+
+/// Publishes one aggregate Kubernetes event naming every CRD the controllers are waiting for,
+/// until they all have theirs or the process is asked to shut down.
+///
+/// The controllers wait independently, so emitting from inside [`wait_for_crd`] would produce a
+/// separate event series per CRD. Reporting centrally instead means `kubectl describe pod` shows
+/// a single line listing everything that is missing.
+///
+/// The first check happens one interval in, so a CRD that lands shortly after the operator
+/// starts — the usual GitOps race, and the whole reason for waiting rather than exiting — does
+/// not produce an event at all.
+pub async fn report_pending_crds(client: Client, state: State) {
+    let recorder = Recorder::new(client, "restate-operator".into());
+    let mut signals = ShutdownSignals::new();
+    let mut reported_waiting = false;
+
+    loop {
+        tokio::select! {
+            _ = sleep(CRD_POLL_INTERVAL) => {}
+            _ = signals.recv() => return,
+        }
+
+        let Some(note) = pending_crds_note(&state.readiness.pending_crds().await) else {
+            if state.readiness.report().await.ready {
+                // Nothing is waiting and every controller has started, so there is nothing left
+                // to report; say so if we ever complained, then stop polling.
+                if reported_waiting {
+                    publish_crd_wait_event(
+                        &recorder,
+                        &state,
+                        EventType::Normal,
+                        "CRDsAvailable",
+                        "All CRDs are now available; every controller is reconciling.".to_owned(),
+                    )
+                    .await;
+                }
+                return;
+            }
+            // no controller has reported a missing CRD yet, but they have not all started either
+            continue;
+        };
+
+        reported_waiting = true;
+        publish_crd_wait_event(&recorder, &state, EventType::Warning, "WaitingForCRD", note).await;
+    }
+}
+
+/// The note for the aggregate `WaitingForCRD` event, or `None` if nothing is being waited for.
+fn pending_crds_note(pending: &[String]) -> Option<String> {
+    match pending {
+        [] => None,
+        [crd_name] => Some(format!(
+            "Waiting for CRD {crd_name} to be installed before reconciling it."
+        )),
+        crd_names => Some(format!(
+            "Waiting for {} CRDs to be installed before reconciling them: {}.",
+            crd_names.len(),
+            crd_names.join(", ")
+        )),
+    }
+}
+
+/// Publishes an event about the operator itself, against the operator's own pod.
+///
+/// This is best effort: if we don't know which pod we are, or the apiserver rejects the
+/// event, the log line is all the caller gets. Failing to record an event is never a
+/// reason to stop what we were doing.
+async fn publish_crd_wait_event(
+    recorder: &Recorder,
+    state: &State,
+    type_: EventType,
+    reason: &str,
+    note: String,
+) {
+    let Some(reference) = state.operator_object_ref.as_ref() else {
+        return;
+    };
+
+    let event = Event {
+        type_,
+        reason: reason.into(),
+        note: Some(note),
+        action: "WaitForCRD".into(),
+        secondary: None,
+    };
+
+    if let Err(e) = recorder.publish(&event, reference).await {
+        // Worth a warning rather than a debug: if this is failing, the events an operator
+        // would alert on are not being recorded at all.
+        warn!("Could not publish {reason} event; {e:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Readiness, ReadinessGate, pending_crds_note};
+
+    /// One event has to describe every controller's wait, so the note is the only place the
+    /// missing CRDs get named.
+    #[test]
+    fn pending_crds_note_names_every_waited_for_crd() {
+        assert_eq!(pending_crds_note(&[]), None);
+
+        assert_eq!(
+            pending_crds_note(&["restateclusters.restate.dev".to_owned()]).unwrap(),
+            "Waiting for CRD restateclusters.restate.dev to be installed before reconciling it."
+        );
+
+        assert_eq!(
+            pending_crds_note(&[
+                "restateclusters.restate.dev".to_owned(),
+                "restatedeployments.restate.dev".to_owned(),
+            ])
+            .unwrap(),
+            "Waiting for 2 CRDs to be installed before reconciling them: \
+             restateclusters.restate.dev, restatedeployments.restate.dev."
+        );
+    }
+
+    /// `Readiness` indexes its gates by `gate as usize`, which is only the right slot if each
+    /// gate sits at its own discriminant in `ALL`. Reordering one without the other would
+    /// silently mark the wrong controller ready.
+    #[test]
+    fn readiness_gate_indices_match_declaration_order() {
+        for (index, gate) in ReadinessGate::ALL.into_iter().enumerate() {
+            assert_eq!(
+                index, gate as usize,
+                "{gate:?} is not at its own index in ALL"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn readiness_reports_pending_controllers_until_all_gates_are_marked() {
+        let readiness = Readiness::new();
+
+        let report = readiness.report().await;
+        assert!(!report.ready);
+        assert_eq!(
+            report.pending_controllers,
+            vec![
+                "RestateCluster",
+                "RestateCloudEnvironment",
+                "RestateDeployment"
+            ]
+        );
+
+        readiness.mark_ready(ReadinessGate::RestateCluster).await;
+        // marking twice must not affect the other gates
+        readiness.mark_ready(ReadinessGate::RestateCluster).await;
+        readiness.mark_ready(ReadinessGate::RestateDeployment).await;
+
+        let report = readiness.report().await;
+        assert!(!report.ready);
+        assert_eq!(report.pending_controllers, vec!["RestateCloudEnvironment"]);
+
+        readiness
+            .mark_ready(ReadinessGate::RestateCloudEnvironment)
+            .await;
+
+        let report = readiness.report().await;
+        assert!(report.ready);
+        assert!(report.pending_controllers.is_empty());
+    }
+
+    /// The aggregate event names the CRDs recorded here, so this is what decides whether one
+    /// event can describe every controller's wait.
+    #[tokio::test]
+    async fn pending_crds_lists_only_the_crds_still_being_waited_for() {
+        let readiness = Readiness::new();
+
+        // nothing is waiting until a controller says so, even though nothing is ready either
+        assert!(readiness.pending_crds().await.is_empty());
+        assert!(!readiness.report().await.ready);
+
+        readiness
+            .mark_waiting_for_crd(
+                ReadinessGate::RestateDeployment,
+                "restatedeployments.restate.dev",
+            )
+            .await;
+        readiness
+            .mark_waiting_for_crd(ReadinessGate::RestateCluster, "restateclusters.restate.dev")
+            .await;
+
+        // in gate order, not the order they were reported
+        assert_eq!(
+            readiness.pending_crds().await,
+            vec![
+                "restateclusters.restate.dev",
+                "restatedeployments.restate.dev"
+            ]
+        );
+
+        // re-reporting the same wait must not duplicate it
+        readiness
+            .mark_waiting_for_crd(ReadinessGate::RestateCluster, "restateclusters.restate.dev")
+            .await;
+        assert_eq!(readiness.pending_crds().await.len(), 2);
+
+        // becoming ready clears the wait
+        readiness.mark_ready(ReadinessGate::RestateCluster).await;
+        assert_eq!(
+            readiness.pending_crds().await,
+            vec!["restatedeployments.restate.dev"]
+        );
+
+        readiness.mark_ready(ReadinessGate::RestateDeployment).await;
+        assert!(readiness.pending_crds().await.is_empty());
+    }
 }

--- a/src/controllers/restatecloudenvironment/controller.rs
+++ b/src/controllers/restatecloudenvironment/controller.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 
 use k8s_openapi::api::apps::v1::Deployment;
 
-use kube::api::{Api, ListParams, ObjectMeta};
+use kube::api::{Api, ObjectMeta};
 use kube::client::Client;
 use kube::runtime::controller;
 use kube::runtime::controller::Action;
@@ -18,7 +18,7 @@ use kube::{Resource, ResourceExt};
 use tokio::sync::RwLock;
 use tracing::*;
 
-use crate::controllers::{Diagnostics, State};
+use crate::controllers::{CrdWait, Diagnostics, ReadinessGate, State, wait_for_crd};
 use crate::metrics::Metrics;
 use crate::resources::restatecloudenvironments::{
     RESTATE_CLOUD_ENVIRONMENT_FINALIZER, RestateCloudEnvironment,
@@ -169,9 +169,22 @@ pub async fn run(client: Client, metrics: Metrics, state: State) {
     let rce: Api<RestateCloudEnvironment> = Api::all(client.clone());
     let deployments: Api<Deployment> = Api::namespaced(client.clone(), &state.operator_namespace);
 
-    if let Err(e) = rce.list(&ListParams::default().limit(1)).await {
-        error!("RestateCloudEnvironment is not queryable; {e:?}. Is the CRD installed?");
-        std::process::exit(1);
+    match wait_for_crd::<RestateCloudEnvironment>(
+        ReadinessGate::RestateCloudEnvironment,
+        &client,
+        &metrics,
+        &state,
+    )
+    .await
+    {
+        Ok(CrdWait::Available) => {}
+        Ok(CrdWait::ShuttingDown) => return,
+        Err(e) => {
+            error!(
+                "Could not determine whether the RestateCloudEnvironment CRD is installed; {e:?}"
+            );
+            std::process::exit(1);
+        }
     }
 
     // all resources we create have this label

--- a/src/controllers/restatecluster/controller.rs
+++ b/src/controllers/restatecluster/controller.rs
@@ -20,7 +20,7 @@ use kube::runtime::reflector::{ObjectRef, Store};
 use kube::runtime::{Predicate, WatchStreamExt, metadata_watcher, reflector, watcher};
 use kube::{
     Resource,
-    api::{Api, ListParams, Patch, PatchParams, ResourceExt},
+    api::{Api, Patch, PatchParams, ResourceExt},
     client::Client,
     runtime::{
         controller::{Action, Controller},
@@ -34,7 +34,9 @@ use serde_json::json;
 use tokio::{sync::RwLock, time::Duration};
 use tracing::*;
 
-use crate::controllers::{Diagnostics, State};
+use crate::controllers::{
+    CrdWait, Diagnostics, ReadinessGate, State, wait_for_api_groups, wait_for_crd,
+};
 use crate::resources::iampolicymembers::IAMPolicyMember;
 use crate::resources::podidentityassociations::PodIdentityAssociation;
 use crate::resources::restateclusters::{
@@ -392,8 +394,9 @@ async fn apply_namespace(nss: &Api<Namespace>, ns: Namespace) -> std::result::Re
 
 // Initialize the controller and shared state (given the crd is installed)
 pub async fn run(client: Client, metrics: Metrics, state: State) {
-    let api_groups = match client.list_api_groups().await {
-        Ok(list) => list,
+    let api_groups = match wait_for_api_groups(&client).await {
+        Ok(Some(list)) => list,
+        Ok(None) => return,
         Err(e) => {
             error!("Could not list api groups: {e:?}");
             std::process::exit(1);
@@ -442,9 +445,15 @@ pub async fn run(client: Client, metrics: Metrics, state: State) {
         std::process::exit(1);
     }
 
-    if let Err(e) = rc_api.list(&ListParams::default().limit(1)).await {
-        error!("RestateCluster is not queryable; {e:?}. Is the CRD installed?");
-        std::process::exit(1);
+    match wait_for_crd::<RestateCluster>(ReadinessGate::RestateCluster, &client, &metrics, &state)
+        .await
+    {
+        Ok(CrdWait::Available) => {}
+        Ok(CrdWait::ShuttingDown) => return,
+        Err(e) => {
+            error!("Could not determine whether the RestateCluster CRD is installed; {e:?}");
+            std::process::exit(1);
+        }
     }
 
     // all resources we create have this label

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -10,9 +10,7 @@ use k8s_openapi::api::autoscaling::v2::HorizontalPodAutoscaler;
 use k8s_openapi::api::core::v1::{Secret, Service};
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
-use kube::api::{
-    Api, ListParams, ObjectMeta, PartialObjectMetaExt, Patch, PatchParams, ResourceExt,
-};
+use kube::api::{Api, ObjectMeta, PartialObjectMetaExt, Patch, PatchParams, ResourceExt};
 use kube::client::Client;
 use kube::core::Selector;
 use kube::core::subresource::Scale;
@@ -33,7 +31,9 @@ use tokio::sync::RwLock;
 use tracing::*;
 use url::Url;
 
-use crate::controllers::{Diagnostics, State, prewarmed_reflector};
+use crate::controllers::{
+    CrdWait, Diagnostics, ReadinessGate, State, prewarmed_reflector, wait_for_crd,
+};
 use crate::metrics::Metrics;
 use crate::resources::knative::{Configuration, Revision, Route};
 use crate::resources::restatecloudenvironments::{InProcessTunnelParams, RestateCloudEnvironment};
@@ -1255,9 +1255,20 @@ pub async fn run(client: Client, metrics: Metrics, state: State) {
     let services: Api<Service> = Api::all(client.clone());
     let hpas: Api<HorizontalPodAutoscaler> = Api::all(client.clone());
 
-    if let Err(e) = services.list(&ListParams::default().limit(1)).await {
-        error!("RestateDeployment is not queryable; {e:?}. Is the CRD installed?");
-        std::process::exit(1);
+    match wait_for_crd::<RestateDeployment>(
+        ReadinessGate::RestateDeployment,
+        &client,
+        &metrics,
+        &state,
+    )
+    .await
+    {
+        Ok(CrdWait::Available) => {}
+        Ok(CrdWait::ShuttingDown) => return,
+        Err(e) => {
+            error!("Could not determine whether the RestateDeployment CRD is installed; {e:?}");
+            std::process::exit(1);
+        }
     }
 
     // all resources we create have this label

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,24 @@ struct Arguments {
         default_value = "alpine:3.21"
     )]
     canary_image: String,
+
+    /// The name of the pod the operator is running in, used to attach operator-level events
+    /// to it. Unset when running outside a cluster, in which case no such events are emitted.
+    #[arg(
+        long = "operator-pod-name",
+        env = "OPERATOR_POD_NAME",
+        value_name = "POD_NAME"
+    )]
+    operator_pod_name: Option<String>,
+
+    /// The uid of the pod the operator is running in; without it, events attached to the pod
+    /// are still recorded but do not show up in `kubectl describe pod`.
+    #[arg(
+        long = "operator-pod-uid",
+        env = "OPERATOR_POD_UID",
+        value_name = "POD_UID"
+    )]
+    operator_pod_uid: Option<String>,
 }
 
 #[get("/metrics")]
@@ -80,9 +98,28 @@ async fn metrics(c: Data<State>, _req: HttpRequest) -> impl Responder {
     HttpResponse::Ok().body(buffer)
 }
 
+/// Liveness: the process is up and the web server is serving.
+///
+/// Deliberately says nothing about whether the controllers are reconciling — that is what
+/// `/ready` is for. Restarting the operator does not make a missing CRD appear, so a
+/// controller waiting for its CRD must not fail a liveness probe.
 #[get("/health")]
 async fn health(_: HttpRequest) -> impl Responder {
     HttpResponse::Ok().json("healthy")
+}
+
+/// Readiness: every controller has its CRD and has started reconciling.
+///
+/// Returns `503` with the list of controllers still waiting, so that an operator whose CRDs
+/// were never installed shows up as `NotReady` instead of sitting there looking healthy.
+#[get("/ready")]
+async fn ready(c: Data<State>, _req: HttpRequest) -> impl Responder {
+    let report = c.readiness.report().await;
+    if report.ready {
+        HttpResponse::Ok().json(report)
+    } else {
+        HttpResponse::ServiceUnavailable().json(report)
+    }
 }
 
 #[get("/")]
@@ -118,6 +155,8 @@ async fn main() -> anyhow::Result<()> {
         args.tunnel_client_default_image,
         args.cluster_dns,
         args.canary_image,
+        args.operator_pod_name,
+        args.operator_pod_uid,
     );
 
     let client = Client::try_default()
@@ -139,20 +178,33 @@ async fn main() -> anyhow::Result<()> {
         metric.clone(),
         state.clone(),
     );
-    let deployment_controller =
-        restate_operator::controllers::restatedeployment::run(client, metric, state.clone());
+    let deployment_controller = restate_operator::controllers::restatedeployment::run(
+        client.clone(),
+        metric,
+        state.clone(),
+    );
+    // The controllers wait for their CRDs independently; this reports all of them in one event
+    // rather than one per controller, and finishes once they are all reconciling.
+    let crd_wait_reporter =
+        restate_operator::controllers::report_pending_crds(client, state.clone());
 
     tokio::pin!(cluster_controller);
     tokio::pin!(cloud_environment_controller);
     tokio::pin!(deployment_controller);
+    tokio::pin!(crd_wait_reporter);
 
     // Start web server
     let server = HttpServer::new(move || {
         App::new()
             .app_data(Data::new(state.clone()))
-            .wrap(middleware::Logger::default().exclude("/health"))
+            .wrap(
+                middleware::Logger::default()
+                    .exclude("/health")
+                    .exclude("/ready"),
+            )
             .service(index)
             .service(health)
+            .service(ready)
             .service(metrics)
     })
     .bind("[::]:8080")?
@@ -162,12 +214,13 @@ async fn main() -> anyhow::Result<()> {
     tokio::pin!(server);
 
     // Both runtimes implements graceful shutdown, so poll until both are done
-    tokio::join!(
+    let (_, _, _, _, server_result) = tokio::join!(
         cluster_controller,
         cloud_environment_controller,
         deployment_controller,
+        crd_wait_reporter,
         server
-    )
-    .3?;
+    );
+    server_result?;
     Ok(())
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,8 @@
 use crate::Error;
 use kube::ResourceExt;
-use prometheus::{HistogramVec, IntCounter, IntCounterVec, Registry, histogram_opts, opts};
+use prometheus::{
+    HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, Registry, histogram_opts, opts,
+};
 use tokio::time::Instant;
 
 #[derive(Clone)]
@@ -8,6 +10,11 @@ pub struct Metrics {
     pub reconciliations: IntCounter,
     pub failures: IntCounterVec,
     pub reconcile_duration: HistogramVec,
+    /// 1 while a controller is waiting for its CRD to show up, 0 once it is available.
+    ///
+    /// A CRD that never arrives leaves the operator waiting forever, which is otherwise
+    /// only visible in the logs; this makes it alertable.
+    pub crd_missing: IntGaugeVec,
 }
 
 impl Default for Metrics {
@@ -31,10 +38,19 @@ impl Default for Metrics {
         .unwrap();
         let reconciliations =
             IntCounter::new("restate_operator_reconciliations_total", "reconciliations").unwrap();
+        let crd_missing = IntGaugeVec::new(
+            opts!(
+                "restate_operator_crd_missing",
+                "1 while the operator is waiting for a CRD to appear in the apiserver's discovery information, 0 once it is available",
+            ),
+            &["crd"],
+        )
+        .unwrap();
         Metrics {
             reconciliations,
             failures,
             reconcile_duration,
+            crd_missing,
         }
     }
 }
@@ -45,6 +61,7 @@ impl Metrics {
         registry.register(Box::new(self.reconcile_duration.clone()))?;
         registry.register(Box::new(self.failures.clone()))?;
         registry.register(Box::new(self.reconciliations.clone()))?;
+        registry.register(Box::new(self.crd_missing.clone()))?;
         Ok(self)
     }
 


### PR DESCRIPTION
Adjusted the controller startup logic to use a discovery client to wait for CRDs instead of just existing. The new behavior is more consistent with the other Kubernetes Operators.

Resolves #166