### PR TITLE
Handle rollbacks correctly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,55 @@ jobs:
       # of only surfacing during the tagged release build.
       - name: Build the release image (build-only, no push)
         run: just docker
+      # Hand the built image to the e2e job rather than making it rebuild. The musl
+      # cross-compile is the slowest thing in CI; paying for it twice would roughly
+      # double PR wall-clock for no extra coverage.
+      - name: Export the image for the e2e job
+        run: docker save ghcr.io/restatedev/restate-operator:local -o /tmp/operator-image.tar
+      - uses: actions/upload-artifact@v4
+        with:
+          name: operator-image
+          path: /tmp/operator-image.tar
+          retention-days: 1
+
+  e2e-rollback:
+    name: E2E rollback
+    runs-on: ubuntu-latest
+    needs: build-image
+    # Three scenarios, each standing up a fresh RestateDeployment from scratch and
+    # waiting out real drain delays. A full run is well under 10 minutes; the
+    # margin is so a slow runner reports failures rather than a bare cancellation.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install just
+        uses: extractions/setup-just@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: operator-image
+          path: /tmp
+      - name: Load the operator image
+        run: docker load -i /tmp/operator-image.tar
+
+      - name: Build the greeter image
+        working-directory: examples/services/greeter
+        run: just docker
+
+      # Create the cluster here rather than letting the script do it, so both
+      # images can be loaded before the operator starts. The script reuses an
+      # existing healthy cluster of this name, so SKIP_BUILD=1 is all it needs.
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: restate-rollback-e2e
+
+      - name: Load images into kind
+        run: |
+          kind load docker-image ghcr.io/restatedev/restate-operator:local --name restate-rollback-e2e
+          kind load docker-image dev.local/restatedev/restate-operator/greeter:local --name restate-rollback-e2e
+
+      - name: Run the rollback e2e
+        env:
+          SKIP_BUILD: "1"
+        run: ./e2e/rollback.sh

--- a/e2e/rollback.sh
+++ b/e2e/rollback.sh
@@ -1,0 +1,533 @@
+#!/usr/bin/env bash
+#
+# e2e driver for rolling a RestateDeployment back to a previously registered
+# revision. See restatedev/restate-operator#174.
+#
+# The operator names ReplicaSets and Services by a content hash of the pod
+# template, so v1 -> v2 -> v1 re-adopts the original v1 ReplicaSet, Service URL
+# and Restate deployment id. Restoring the Kubernetes revision is therefore not
+# enough on its own: Restate must also be told that the restored deployment is
+# once again the one new invocations go to.
+#
+# Everything here asserts Restate's own view -- the service-to-deployment
+# mapping from GET /services/Greeter, and the version reported by an actual
+# invocation -- never the operator's status or the deployment id echoed back by
+# registration. Those are exactly the signals that look healthy while routing is
+# wrong, which is the bug.
+#
+# Restate version matters. The unversioned /deployments path resolves to
+# AdminApiVersion::Unknown, where `force` defaults to *false* (restatedev/restate
+# #3859, first released in v1.6.0). On such a server a re-registration of an
+# unchanged endpoint returns 200 "Unchanged" with the existing id and does not
+# make it latest. Pin at or above 1.6 or these scenarios cannot fail.
+#
+# Prerequisites on PATH: kind, kubectl, helm, docker, jq, just, curl.
+#
+# Usage:
+#   e2e/rollback.sh                     # full run, tears the cluster down at the end
+#   KEEP=1 e2e/rollback.sh              # keep the cluster for inspection
+#   SKIP_BUILD=1 e2e/rollback.sh        # reuse already-loaded images
+#   ONLY=clean|pinned-old|pinned-new e2e/rollback.sh
+#
+set -euo pipefail
+
+# ---- config ---------------------------------------------------------------
+CLUSTER_NAME="${CLUSTER_NAME:-restate-rollback-e2e}"
+OPERATOR_NS="${OPERATOR_NS:-restate-operator}"
+RESTATE_NS="${RESTATE_NS:-restate}"
+APP_NS="${APP_NS:-default}"
+RD_NAME="${RD_NAME:-greeter-rsd}"
+OPERATOR_IMAGE="ghcr.io/restatedev/restate-operator:local"
+GREETER_IMAGE="dev.local/restatedev/restate-operator/greeter:local"
+RESTATE_IMAGE="${RESTATE_IMAGE:-restatedev/restate:1.7}"
+# How long the invocation that pins a version stays in flight. Must outlast the
+# rollback plus a few reconciles, or the scenario stops testing what it says.
+PIN_SECONDS="${PIN_SECONDS:-120}"
+DRAIN_DELAY="${DRAIN_DELAY:-10}"
+CLUSTER_INGRESS_PORT=8080
+CLUSTER_ADMIN_PORT=9070
+# Deliberately uncommon local ports so we don't silently hit an unrelated
+# Restate port-forward (e.g. a Cloud control plane on 8080/9070).
+INGRESS_PORT="${INGRESS_PORT:-18081}"
+ADMIN_PORT="${ADMIN_PORT:-19071}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CTX="kind-${CLUSTER_NAME}"
+
+# ---- output helpers -------------------------------------------------------
+RED=$'\e[31m'; GREEN=$'\e[32m'; YELLOW=$'\e[33m'; BLUE=$'\e[34m'; BOLD=$'\e[1m'; RST=$'\e[0m'
+info()  { echo "${BLUE}==>${RST} $*"; }
+step()  { echo; echo "${BOLD}### $*${RST}"; }
+pass()  { echo "${GREEN}PASS${RST} $*"; PASSES=$((PASSES+1)); }
+fail()  { echo "${RED}FAIL${RST} $*"; FAILS=$((FAILS+1)); }
+warn()  { echo "${YELLOW}WARN${RST} $*"; }
+die()   { echo "${RED}fatal:${RST} $*" >&2; exit 1; }
+PASSES=0; FAILS=0; PF_PID=""
+
+kc() { kubectl --context "$CTX" "$@"; }
+
+wait_until() {
+  local desc="$1" timeout="$2"; shift 2
+  local deadline=$(( $(date +%s) + timeout ))
+  while true; do
+    if "$@" >/dev/null 2>&1; then return 0; fi
+    if (( $(date +%s) >= deadline )); then
+      warn "timed out after ${timeout}s waiting for: ${desc}"
+      return 1
+    fi
+    sleep 3
+  done
+}
+
+cleanup() {
+  [[ -n "$PF_PID" ]] && kill "$PF_PID" >/dev/null 2>&1 || true
+  if [[ "${KEEP:-0}" != "1" ]]; then
+    info "deleting kind cluster ${CLUSTER_NAME} (set KEEP=1 to keep it)"
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  else
+    info "KEEP=1 -- leaving cluster ${CLUSTER_NAME} up"
+  fi
+}
+trap cleanup EXIT
+
+# ---- Restate-side queries (the assertions that matter) --------------------
+# Every query below swallows its own failure and returns the empty string. They
+# run under `set -euo pipefail` inside command substitutions, so a transient
+# curl/kubectl blip would otherwise abort the entire run rather than failing a
+# single assertion -- and most of them are called from `wait_until`, where
+# "not yet" and "call failed" should behave identically.
+#
+# Which deployment does Restate send NEW invocations of Greeter to? This is the
+# `active_service_revisions` index -- the thing a rollback has to move, and the
+# thing a 200 "Unchanged" registration leaves untouched.
+latest_deployment_id() {
+  curl -sS "localhost:${ADMIN_PORT}/services/Greeter" 2>/dev/null \
+    | jq -r '.deployment_id // empty' 2>/dev/null || true
+}
+latest_is() { [[ "$(latest_deployment_id)" == "$1" ]]; }
+
+# Actually invoke, and report which version answered. Registration metadata can
+# agree while routing does not; this is the ground truth.
+greet_version() {
+  curl -sS "localhost:${INGRESS_PORT}/Greeter/greet" \
+    -H 'content-type: application/json' -d '"probe"' 2>/dev/null \
+    | jq -r '.version // empty' 2>/dev/null || true
+}
+greet_version_is() { [[ "$(greet_version)" == "$1" ]]; }
+
+admin_healthy() { curl -sf "localhost:${ADMIN_PORT}/health" >/dev/null 2>&1; }
+
+# ---- Kubernetes-side queries ----------------------------------------------
+# Find a version's ReplicaSet by the SERVICE_VERSION it was built with, rather
+# than by recomputing the operator's content hash -- the test should not have to
+# agree with the implementation on how names are derived.
+rs_for_version() {
+  kc -n "$APP_NS" get rs -l "restate.dev/owned-by=${RD_NAME}" -o json 2>/dev/null \
+    | jq -r --arg v "$1" '
+        .items[]
+        | select([.spec.template.spec.containers[].env[]?
+                  | select(.name == "SERVICE_VERSION") | .value] | index($v))
+        | .metadata.name' 2>/dev/null \
+    | head -n1 || true
+}
+rs_annotation() {
+  kc -n "$APP_NS" get rs "$1" -o jsonpath="{.metadata.annotations.restate\\.dev/$2}" 2>/dev/null || true
+}
+svc_annotation() {
+  kc -n "$APP_NS" get svc "$1" -o jsonpath="{.metadata.annotations.restate\\.dev/$2}" 2>/dev/null || true
+}
+rs_replicas()    { kc -n "$APP_NS" get rs "$1" -o jsonpath='{.spec.replicas}' 2>/dev/null || true; }
+rs_ready()       { kc -n "$APP_NS" get rs "$1" -o jsonpath='{.status.readyReplicas}' 2>/dev/null || true; }
+rs_replicas_is() { [[ "$(rs_replicas "$1")" == "$2" ]]; }
+rs_ready_is()    { [[ "$(rs_ready "$1")" == "$2" ]]; }
+rd_ready() {
+  kc -n "$APP_NS" get restatedeployment "$RD_NAME" \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null | grep -qx True
+}
+rd_status_field() {
+  kc -n "$APP_NS" get restatedeployment "$RD_NAME" -o jsonpath="{.status.$1}" 2>/dev/null || true
+}
+
+dump_diagnostics() {
+  echo "${YELLOW}--- diagnostics ---${RST}"
+  echo "  ### RestateDeployment / ReplicaSets / pods (${APP_NS})"
+  kc -n "$APP_NS" get restatedeployment,rs,pods -o wide 2>&1 | sed 's/^/  /' || true
+  echo "  ### RestateDeployment status"
+  kc -n "$APP_NS" get restatedeployment "$RD_NAME" -o jsonpath='{.status}' 2>&1 \
+    | jq . 2>/dev/null | sed 's/^/  /' || true
+  echo "  ### Restate services"
+  curl -sS "localhost:${ADMIN_PORT}/services" 2>&1 | jq . 2>/dev/null | sed 's/^/  /' || true
+  echo "  ### Restate deployments"
+  curl -sS "localhost:${ADMIN_PORT}/deployments" 2>&1 | jq . 2>/dev/null | sed 's/^/  /' || true
+  echo "  ### operator logs (tail 100)"
+  kc -n "$OPERATOR_NS" logs -l app=restate-operator --tail=100 2>&1 | sed 's/^/  /' || true
+}
+
+# ---- preflight ------------------------------------------------------------
+step "Preflight"
+for bin in kind kubectl helm docker jq just curl; do
+  command -v "$bin" >/dev/null 2>&1 || die "missing required tool: $bin"
+done
+info "all tools present"
+
+# ---- cluster --------------------------------------------------------------
+step "Create kind cluster"
+if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
+  kind export kubeconfig --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  if kc cluster-info >/dev/null 2>&1; then
+    info "cluster ${CLUSTER_NAME} healthy, reusing"
+  else
+    warn "cluster ${CLUSTER_NAME} is listed but unreachable; recreating"
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+    kind create cluster --name "$CLUSTER_NAME"
+  fi
+else
+  kind create cluster --name "$CLUSTER_NAME"
+fi
+
+step "Install CRDs"
+# All three, not just the two these scenarios use: the operator runs a controller
+# per CRD and each holds a readiness gate until its CRD is served, so omitting
+# restatecloudenvironments leaves the pod NotReady and `helm --wait` times out.
+kc apply --server-side -f "${REPO_ROOT}/crd/restateclusters.yaml"
+kc apply --server-side -f "${REPO_ROOT}/crd/restatedeployments.yaml"
+kc apply --server-side -f "${REPO_ROOT}/crd/restatecloudenvironments.yaml"
+
+# ---- images + operator ----------------------------------------------------
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+  step "Build + load operator image"
+  ( cd "$REPO_ROOT" && just docker )
+  kind load docker-image "$OPERATOR_IMAGE" --name "$CLUSTER_NAME"
+
+  step "Build + load greeter image"
+  ( cd "$REPO_ROOT/examples/services/greeter" && just docker )
+  kind load docker-image "$GREETER_IMAGE" --name "$CLUSTER_NAME"
+fi
+
+step "Deploy operator"
+# The chart depends on restate-operator-crds through a local file:// path, and
+# both the vendored copy under charts/restate-operator-helm/charts/ and Chart.lock
+# are gitignored. A machine that has built the chart before has them and a fresh
+# checkout does not, which is why this only ever failed in CI. `update` rather
+# than `build` because `build` reads the lock that isn't there; the dependency is
+# a sibling directory at this same commit, so resolving it is a local copy.
+helm dependency update "${REPO_ROOT}/charts/restate-operator-helm" >/dev/null \
+  || die "could not resolve the operator chart's dependencies"
+
+# installCrds=false: the CRDs were applied above straight from crd/, which is the
+# copy under test. Letting the subchart install them too would have Helm try to
+# adopt objects created by kubectl, which it refuses for want of its own
+# ownership labels.
+helm --kube-context "$CTX" upgrade --install restate-operator \
+  "${REPO_ROOT}/charts/restate-operator-helm" \
+  --namespace "$OPERATOR_NS" --create-namespace \
+  --set installCrds=false \
+  --set version=local --wait --timeout 180s
+kc -n "$OPERATOR_NS" rollout restart deployment -l app=restate-operator >/dev/null 2>&1 || true
+kc -n "$OPERATOR_NS" rollout status deployment -l app=restate-operator --timeout=120s
+
+# ---- restate cluster ------------------------------------------------------
+step "Deploy + provision RestateCluster (${RESTATE_IMAGE})"
+# Pinned here rather than reusing examples/cluster/cluster.yaml: these scenarios
+# depend on the admin API's `force` default, which changed in v1.6.0.
+kc apply --server-side -f - <<YAML
+apiVersion: restate.dev/v1
+kind: RestateCluster
+metadata:
+  name: restate
+spec:
+  compute:
+    image: ${RESTATE_IMAGE}
+  storage:
+    storageRequestBytes: 2147483648
+YAML
+wait_until "restate-0 pod to exist" 180 kc -n "$RESTATE_NS" get pod restate-0
+kc -n "$RESTATE_NS" wait --for=condition=Ready pod/restate-0 --timeout=240s \
+  || die "restate-0 did not become ready"
+kc -n "$RESTATE_NS" exec restate-0 -- restatectl provision --yes >/dev/null 2>&1 \
+  || kc -n "$RESTATE_NS" exec restate-0 -- restatectl provision >/dev/null 2>&1 \
+  || warn "provision returned non-zero (may already be provisioned)"
+
+step "Port-forward Restate ingress + admin"
+kc -n "$RESTATE_NS" port-forward svc/restate \
+  "${INGRESS_PORT}:${CLUSTER_INGRESS_PORT}" "${ADMIN_PORT}:${CLUSTER_ADMIN_PORT}" \
+  >/tmp/restate-rollback-pf.log 2>&1 &
+PF_PID=$!
+sleep 2
+if ! kill -0 "$PF_PID" 2>/dev/null || grep -q "address already in use" /tmp/restate-rollback-pf.log; then
+  cat /tmp/restate-rollback-pf.log >&2
+  die "port-forward failed (ports ${INGRESS_PORT}/${ADMIN_PORT} in use?). Set INGRESS_PORT/ADMIN_PORT."
+fi
+wait_until "admin API reachable" 60 admin_healthy || die "admin API never came up"
+
+step "Check the Restate version actually exercises the bug"
+SERVER_VERSION="$(curl -sS "localhost:${ADMIN_PORT}/version" 2>/dev/null | jq -r '.version // "unknown"' 2>/dev/null || echo unknown)"
+info "Restate server version: ${SERVER_VERSION}"
+case "$SERVER_VERSION" in
+  1.0.*|1.1.*|1.2.*|1.3.*|1.4.*|1.5.*)
+    warn "Restate ${SERVER_VERSION} predates the force-default change (v1.6.0);"
+    warn "registration still force-overwrites, so these scenarios cannot fail."
+    ;;
+esac
+
+# ---- manifest + fixtures --------------------------------------------------
+# revisionHistoryLimit is deliberately generous: the rollback under test only
+# exists if the superseded ReplicaSet is *retained* after draining. A limit of 0
+# would delete it (and deregister its deployment), turning every rollback into a
+# plain first-time registration and testing nothing.
+rd_manifest() {
+  local version="$1"
+  cat <<YAML
+apiVersion: restate.dev/v1beta1
+kind: RestateDeployment
+metadata:
+  name: ${RD_NAME}
+  namespace: ${APP_NS}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: ${RD_NAME}
+  restate:
+    register:
+      cluster: restate
+    drainDelaySeconds: ${DRAIN_DELAY}
+  template:
+    metadata:
+      labels:
+        app: ${RD_NAME}
+    spec:
+      containers:
+        - name: service
+          image: ${GREETER_IMAGE}
+          imagePullPolicy: Never
+          ports:
+            - name: h2c
+              containerPort: 9080
+          env:
+            - name: SERVICE_VERSION
+              value: "${version}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+YAML
+}
+deploy_version() { rd_manifest "$1" | kc apply -f - >/dev/null; }
+
+# Start a long slowGreet synchronously in the background, capturing the response
+# body. Reading `.version` from it afterwards proves which version actually ran
+# the invocation -- not merely which one it was routed to at submission time.
+PIN_FILE=""
+start_pinned_invocation() {
+  PIN_FILE="$(mktemp)"
+  curl -sS --max-time $((PIN_SECONDS + 120)) \
+    "localhost:${INGRESS_PORT}/Greeter/slowGreet" \
+    -H 'content-type: application/json' \
+    -d "{\"name\":\"pin\",\"delaySeconds\":${PIN_SECONDS}}" >"$PIN_FILE" 2>/dev/null &
+  PIN_PID=$!
+  sleep 5   # let it reach the server and pin
+  info "pinned invocation started (in flight for ~${PIN_SECONDS}s)"
+}
+# Sets PIN_VERSION rather than printing it. The wait has to happen in the shell
+# that started the curl: called as "$(await_pinned_invocation)" the function runs
+# in a command-substitution subshell, which is not the background job's parent, so
+# `wait` returns instantly ("not a child of this shell") and jq reads a response
+# file nothing has written yet -- every pinned assertion then sees '<no result>'.
+PIN_VERSION=""
+await_pinned_invocation() {
+  wait "$PIN_PID" 2>/dev/null || true
+  PIN_VERSION="$(jq -r '.version // empty' <"$PIN_FILE" 2>/dev/null || true)"
+}
+
+reset_fixture() {
+  kc -n "$APP_NS" delete restatedeployment "$RD_NAME" --ignore-not-found --wait=true --timeout=180s >/dev/null 2>&1 || true
+  wait_until "old ReplicaSets to be cleared" 120 bash -c \
+    "[[ -z \"\$(kubectl --context ${CTX} -n ${APP_NS} get rs -l restate.dev/owned-by=${RD_NAME} -o name 2>/dev/null)\" ]]" || true
+}
+
+# ===========================================================================
+# Scenario: clean rollback -- v1 drained and retained, then restored.
+#
+# Reproduces the "registered but not latest" case: v1's deployment is still
+# registered, so registration is attempted but the server answers 200
+# "Unchanged" with v1's existing id and leaves v2 latest.
+# ===========================================================================
+scenario_clean() {
+  step "Scenario: clean rollback (no pinned invocations)"
+  deploy_version v1
+  wait_until "v1 Ready" 240 rd_ready || { fail "v1 never became Ready"; return; }
+  local rs_v1 dp_v1; rs_v1="$(rs_for_version v1)"; dp_v1="$(rs_annotation "$rs_v1" deployment-id)"
+  [[ -n "$dp_v1" ]] || { fail "v1 ReplicaSet has no deployment-id annotation"; return; }
+  info "v1: rs=${rs_v1} deployment=${dp_v1}"
+
+  wait_until "Restate to route to v1" 60 latest_is "$dp_v1" \
+    && pass "v1 is latest after first registration" \
+    || fail "v1 is not latest after first registration (latest=$(latest_deployment_id))"
+
+  deploy_version v2
+  wait_until "v2 Ready" 240 rd_ready || warn "v2 not Ready; continuing"
+  local rs_v2 dp_v2; rs_v2="$(rs_for_version v2)"; dp_v2="$(rs_annotation "$rs_v2" deployment-id)"
+  info "v2: rs=${rs_v2} deployment=${dp_v2}"
+  wait_until "Restate to route to v2" 90 latest_is "$dp_v2" \
+    && pass "v2 is latest after the forward roll" \
+    || fail "v2 is not latest after the forward roll (latest=$(latest_deployment_id))"
+
+  # The rollback only tests the retained-endpoint path once v1 has actually
+  # drained to zero but is still registered.
+  wait_until "v1 to drain to 0 replicas (still retained)" 180 rs_replicas_is "$rs_v1" 0 \
+    || warn "v1 did not scale to 0; the rollback may exercise a different path"
+  kc -n "$APP_NS" get rs "$rs_v1" >/dev/null 2>&1 \
+    || { fail "v1 ReplicaSet was deleted, not retained -- revisionHistoryLimit too low?"; return; }
+
+  info "rolling back to v1 (identical spec -> re-adopts ${rs_v1})…"
+  deploy_version v1
+
+  wait_until "v1 ReplicaSet to be ready again" 240 rs_ready_is "$rs_v1" 1 \
+    && pass "retained v1 ReplicaSet scaled back up and became ready" \
+    || fail "v1 ReplicaSet did not become ready again"
+
+  if wait_until "Restate to route back to v1" 180 latest_is "$dp_v1"; then
+    pass "Restate promoted v1 back to latest"
+  else
+    fail "v1 was restored in Kubernetes but Restate still routes to $(latest_deployment_id) (expected ${dp_v1})"
+  fi
+
+  if wait_until "invocations to land on v1" 90 greet_version_is v1; then
+    pass "new invocations execute on v1"
+  else
+    fail "new invocations still execute on '$(greet_version)' (expected v1)"
+  fi
+
+  # Ready must mean "Restate routes here", not merely "the pods are up".
+  if rd_ready && ! latest_is "$dp_v1"; then
+    fail "Ready=True while ${dp_v1} is not latest -- Ready does not imply promotion"
+  else
+    pass "Ready=True agrees with Restate's routing"
+  fi
+}
+
+# ===========================================================================
+# Scenario: rollback while an invocation is pinned to the OLD version.
+#
+# Reproduces the "retained by pinned invocations" case: v1 reads as active, so
+# registration is skipped entirely and v2 silently stays latest.
+# ===========================================================================
+scenario_pinned_old() {
+  step "Scenario: rollback with an invocation pinned to v1"
+  deploy_version v1
+  wait_until "v1 Ready" 240 rd_ready || { fail "v1 never became Ready"; return; }
+  local rs_v1 dp_v1; rs_v1="$(rs_for_version v1)"; dp_v1="$(rs_annotation "$rs_v1" deployment-id)"
+  info "v1: rs=${rs_v1} deployment=${dp_v1}"
+
+  start_pinned_invocation   # pins to v1, which is latest right now
+
+  deploy_version v2
+  wait_until "v2 Ready" 240 rd_ready || warn "v2 not Ready; continuing"
+  local rs_v2 dp_v2; rs_v2="$(rs_for_version v2)"; dp_v2="$(rs_annotation "$rs_v2" deployment-id)"
+  wait_until "Restate to route to v2" 90 latest_is "$dp_v2" \
+    || warn "v2 never became latest; the rollback assertion below is weaker"
+
+  # v1 must still be held by the in-flight invocation -- that is the precondition
+  # this scenario exists to cover.
+  if rs_replicas_is "$rs_v1" 0; then
+    warn "v1 already scaled to 0; the pinned invocation did not hold it (PIN_SECONDS too short?)"
+  else
+    info "v1 still held by its in-flight invocation, as intended"
+  fi
+
+  info "rolling back to v1 while it still has a pinned invocation…"
+  deploy_version v1
+
+  if wait_until "Restate to route back to v1" 180 latest_is "$dp_v1"; then
+    pass "Restate promoted v1 back to latest despite the pinned invocation"
+  else
+    fail "v1 held a pinned invocation, so registration was skipped and Restate still routes to $(latest_deployment_id)"
+  fi
+
+  if wait_until "invocations to land on v1" 90 greet_version_is v1; then
+    pass "new invocations execute on v1"
+  else
+    fail "new invocations still execute on '$(greet_version)' (expected v1)"
+  fi
+
+  await_pinned_invocation
+  if [[ "$PIN_VERSION" == "v1" ]]; then
+    pass "the invocation pinned to v1 completed on v1"
+  else
+    fail "the pinned invocation completed on '${PIN_VERSION:-<no result>}' (expected v1)"
+  fi
+}
+
+# ===========================================================================
+# Scenario: rollback while an invocation is pinned to the NEW version.
+#
+# Not in the issue's list, but it is the half that proves the superseded
+# revision is still drained properly rather than merely abandoned: v2 must keep
+# its own in-flight work, take no new work, and only then scale away.
+# ===========================================================================
+scenario_pinned_new() {
+  step "Scenario: rollback with an invocation pinned to v2"
+  deploy_version v1
+  wait_until "v1 Ready" 240 rd_ready || { fail "v1 never became Ready"; return; }
+  local rs_v1 dp_v1; rs_v1="$(rs_for_version v1)"; dp_v1="$(rs_annotation "$rs_v1" deployment-id)"
+
+  deploy_version v2
+  wait_until "v2 Ready" 240 rd_ready || warn "v2 not Ready; continuing"
+  local rs_v2 dp_v2; rs_v2="$(rs_for_version v2)"; dp_v2="$(rs_annotation "$rs_v2" deployment-id)"
+  wait_until "Restate to route to v2" 90 latest_is "$dp_v2" \
+    || { fail "v2 never became latest; cannot pin to it"; return; }
+
+  start_pinned_invocation   # pins to v2, which is latest right now
+
+  info "rolling back to v1 while v2 holds a pinned invocation…"
+  deploy_version v1
+
+  if wait_until "Restate to route back to v1" 180 latest_is "$dp_v1"; then
+    pass "Restate promoted v1 back to latest while v2 was still draining"
+  else
+    fail "Restate still routes to $(latest_deployment_id) (expected ${dp_v1})"
+  fi
+
+  if wait_until "invocations to land on v1" 90 greet_version_is v1; then
+    pass "new invocations execute on v1, not the draining v2"
+  else
+    fail "new invocations execute on '$(greet_version)' (expected v1)"
+  fi
+
+  await_pinned_invocation
+  if [[ "$PIN_VERSION" == "v2" ]]; then
+    pass "the invocation pinned to v2 completed on v2 after the rollback"
+  else
+    fail "the pinned invocation completed on '${PIN_VERSION:-<no result>}' (expected v2)"
+  fi
+
+  if wait_until "v2 to drain to 0 replicas" 180 rs_replicas_is "$rs_v2" 0; then
+    pass "v2 drained and scaled down once its invocation finished"
+  else
+    fail "v2 did not scale down after draining (replicas=$(rs_replicas "$rs_v2"))"
+  fi
+}
+
+# ===========================================================================
+for s in ${ONLY:-clean pinned-old pinned-new}; do
+  reset_fixture
+  case "$s" in
+    clean)      scenario_clean ;;
+    pinned-old) scenario_pinned_old ;;
+    pinned-new) scenario_pinned_new ;;
+    *)          die "unknown scenario: $s" ;;
+  esac
+done
+
+step "Results"
+echo "  ${GREEN}${PASSES} passed${RST}, ${RED}${FAILS} failed${RST}"
+(( FAILS == 0 )) || { dump_diagnostics; die "e2e had failures"; }
+info "all assertions passed"

--- a/release-notes/unreleased/174-rollback-promotion.md
+++ b/release-notes/unreleased/174-rollback-promotion.md
@@ -1,0 +1,127 @@
+# Release Notes for Issue #174: Rolling back now moves Restate's routing
+
+## Bug Fix
+
+### What Changed
+
+Rolling a `RestateDeployment` back to a previously registered revision now makes that
+revision the one Restate sends new invocations to, and `Ready=True` no longer claims
+otherwise.
+
+Because ReplicaSets and Services are named by a content hash of the pod template,
+`v1 -> v2 -> v1` re-adopts the original ReplicaSet, Service URL and Restate deployment id
+rather than creating new ones. Restoring the Kubernetes revision was therefore never enough
+on its own — Restate also has to be told that the restored deployment is latest again — and
+two separate faults stopped that from happening:
+
+- **The decision asked the wrong question.** The operator skipped registration whenever the
+  recorded deployment was "active", where active meant *either* that a service pointed at it
+  *or* that it had unfinished invocations. A rolled-back version holding a single pinned
+  invocation satisfied the second half, so the operator did nothing at all and the newer
+  version kept serving.
+- **When it did register, it could not promote.** Registration is a `POST /deployments`
+  against the unversioned admin path, which resolves to `AdminApiVersion::Unknown`, where
+  `force` defaults to *false* (changed in Restate v1.6.0). Re-registering an unchanged
+  endpoint on such a server returns `200` with the existing deployment id and changes
+  nothing. The operator read that as success.
+
+The operator now decides purely on whether Restate routes new invocations to the recorded
+deployment, and re-registers with overwrite when it does not — which bumps that deployment's
+service revisions past the current latest while keeping its deployment id, so invocations
+already pinned to it are undisturbed. It then asks Restate what it actually routes before
+reporting `Ready`.
+
+Alongside that:
+
+- **`force` is now always sent explicitly.** Its default depends on the admin API version a
+  request resolves to, and that default has already changed once underneath the operator.
+- **Registration is verified, not assumed.** After registering, the operator checks
+  `GET /services` and confirms every service discovered at the endpoint resolves to this
+  deployment. A registration that made no routing change is no longer treated as a success.
+- **The deployment id is recorded before the routing is confirmed.** The id is true either
+  way — it is what Restate holds for that endpoint — and recording it is what lets the next
+  reconcile plan a promotion. Confirming first would strand a registration that landed on an
+  endpoint Restate already knew but was not routing to, with nothing written down and every
+  subsequent reconcile planning the same plain registration again.
+- **A promotion emits a `Promoted` event.** Overwriting is how Restate is asked to move
+  routing, and it also permits breaking schema changes and resets the deployment's
+  registration timestamp, so it leaves an audit trail rather than only a log line.
+- **A foreign owner is reported, not fought.** If the desired deployment is superseded and
+  no version of this `RestateDeployment` holds the service either, something outside it has
+  registered those services. The operator refuses to force in that case and reports
+  `Ready=False` with reason `ForeignDeployment`. Forcing would start a promotion war, with
+  two controllers bumping revisions to take the service back indefinitely.
+- **The ReplicaSet cache is prewarmed at startup.** That cache is how a rollback is told
+  apart from a foreign owner, and an unsynced one would answer "nothing of ours is latest",
+  which would park a healthy rollback at `Ready=False` until the cache filled.
+- **Knative mode promotes too.** It used to return on the recorded deployment id alone, so
+  it could never promote on a rollback; it now plans against Restate's routing exactly as
+  ReplicaSet mode does, using its Configurations as the owned-version evidence.
+
+### Known limitation
+
+`latest_for_service`, the flag this decides on, is true when a deployment is latest for *any*
+of its services. A deployment that is latest for some and superseded for others therefore
+reads as current, and a rollback onto it does nothing. Reaching that state needs one version
+to expose a strict subset of another's services. Resolving routing per service needs admin
+reads this change deliberately does not add; it is tracked separately.
+
+### Why This Matters
+
+A rollback that restored the pods but not the routing looked entirely healthy: the
+ReplicaSet scaled back up, `Ready` went `True`, and the deployment id in status was the
+expected one. Only the traffic was still going to the version being rolled back *from* —
+which, during an incident, is the version being rolled back away from.
+
+### Impact on Users
+
+- **`Ready=True` is stricter.** It now means Restate routes new invocations to the desired
+  revision, not merely that the pods are up. Deployments sitting in an inconsistent state —
+  including ones that have been inconsistent for a while — will report `Ready=False` with a
+  reason until it resolves.
+- **On upgrade, inconsistent deployments are promoted on the next reconcile.** If a
+  `RestateDeployment`'s desired revision is not currently latest in Restate, the operator
+  will move routing to it. This is the fix working, but it is a routing change that happens
+  without being asked for, so upgrade at a time when that is acceptable.
+- **An endpoint registered outside its `RestateDeployment` now stalls rather than being
+  silently tolerated.** Services that were pointed at a manually registered deployment, or at
+  one left behind by a decommissioned controller, report `Ready=False` with reason
+  `ForeignDeployment` on the first reconcile after the upgrade — the operator declines to
+  take them by force. Nothing is written and no routing changes; resolve it by removing the
+  other registrant so the `RestateDeployment`'s own endpoint becomes latest again.
+- **Rollback requires the restored version's pods to serve discovery.** Overwriting
+  re-runs discovery against the endpoint, so a rollback to a revision whose image can no
+  longer be pulled now blocks at `Ready=False` instead of silently half-completing.
+- **A promoted deployment's registration time is reset in Restate.** Overwriting replaces
+  `sys_deployment.created_at`, so a rolled-back deployment appears freshly registered in the
+  UI and in `sys_deployment`. The operator keeps no separate record of the original time.
+- **`force: false` is now sent explicitly where the field was previously omitted.** No
+  behaviour change. Restate defaults the omitted flag by admin API version — *true* on `/v1`
+  and `/v2`, *false* on the unversioned router and `/v3` — but the operator only ever reaches
+  the unversioned router, where the default was already false: it builds each request as
+  `admin_url.join("/deployments")`, and a leading-slash path replaces the base path outright,
+  so a version prefix on `restate.register` could not survive into the request even if one
+  were configured. Sending the flag makes the operator's intent independent of that default
+  rather than changing what any current deployment does.
+- **New deployments:** no impact beyond the above.
+
+### Migration Guidance
+
+None required. No CRD change, and no new annotation or status field.
+
+To check whether a deployment is in the inconsistent state this fixes, compare the id the
+operator recorded against the one Restate routes to:
+
+```bash
+kubectl get restatedeployment <name> -n <namespace> -o jsonpath='{.status.deploymentId}'
+curl -s "$RESTATE_ADMIN/services/<ServiceName>" | jq -r .deployment_id
+```
+
+If they differ, upgrading the operator resolves it on the next reconcile.
+
+### Related Issues
+
+- Issue #174: Support rolling RestateDeployments back to a previously registered revision
+- Issue #146: content-hash RS naming doesn't handle niche rollback edge case
+- restatedev/restate#5157: decouple deployment registration from selecting the latest
+  revision — the intended replacement for forced re-registration

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -271,7 +271,12 @@ pub fn service_url(
 /// 2. Polls the reflector until the store is ready (pre-warming)
 /// 3. Returns the reflector stream ready to be passed to owns_stream() or watches_stream()
 ///
-/// The store must be created with `store_shared()` for this pattern to work correctly.
+/// `store` may come from either `store()` or `store_shared()`; readiness is signalled by the
+/// writer, which both share. Use `store_shared()` only if something else needs to subscribe.
+///
+/// Events consumed while pre-warming are not delivered to the controller. That is fine for
+/// the streams used here: the RestateDeployment reflector driving the controller emits every
+/// object on its initial list, so each one is reconciled once at startup regardless.
 pub async fn prewarmed_reflector<K>(
     store: reflector::Store<K>,
     writer: reflector::store::Writer<K>,

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -25,11 +25,9 @@ use kube::runtime::{
 
 use kube::Resource;
 use reqwest::Method;
-use serde::Deserialize;
 use serde_json::json;
 use tokio::sync::RwLock;
 use tracing::*;
-use url::Url;
 
 use crate::controllers::{
     CrdWait, Diagnostics, ReadinessGate, State, prewarmed_reflector, wait_for_crd,
@@ -51,6 +49,7 @@ use crate::controllers::restatedeployment::cleanup::{
     blocked_deletion_requeue, deployment_usage_query, describe_blocking_versions,
 };
 use crate::controllers::restatedeployment::reconcilers;
+use crate::controllers::restatedeployment::registration::{self, RegistrationAction};
 
 use super::reconcilers::replicaset::{
     POD_TEMPLATE_HASH_LABEL, RESTATE_POD_TEMPLATE_ANNOTATION, RESTATE_TUNNEL_NAME_ANNOTATION,
@@ -470,14 +469,34 @@ impl RestateDeployment {
 
         let existing_deployment_id = replicaset
             .annotations()
-            .get(RESTATE_DEPLOYMENT_ID_ANNOTATION);
+            .get(RESTATE_DEPLOYMENT_ID_ANNOTATION)
+            .cloned();
 
-        // if the repliceset doesn't have a deployment id, or its deployment id is not active, register it
-        if existing_deployment_id.is_none_or(|existing_deployment_id| {
-            !deployments
-                .get(existing_deployment_id)
-                .is_some_and(|usage| usage.is_active(CleanupMode::Rollout))
-        }) {
+        let action = registration::plan_registration(
+            existing_deployment_id.as_deref(),
+            &deployments,
+            || registration::owned_deployment_ids(&ctx.replicasets_store, namespace, &my_uid),
+        );
+
+        // This branch leaves the old ReplicaSets alone: the reconcile returns before
+        // `cleanup_old_replicasets`. That is deliberate — draining a version while we cannot
+        // tell who is serving its services risks removing the endpoint still taking traffic.
+        if action == RegistrationAction::Conflict {
+            // Deliberately no admin write. See `RegistrationAction::Conflict`.
+            return Err(Error::DeploymentNotLatest {
+                message: format!(
+                    "Deployment {} is registered but superseded, and no version of this \
+                     RestateDeployment is serving its services. Something outside this \
+                     RestateDeployment has registered them; check `GET /services` against the \
+                     Restate admin API. The operator will not force a promotion here.",
+                    existing_deployment_id.as_deref().unwrap_or("<unknown>"),
+                ),
+                reason: "ForeignDeployment".into(),
+                requeue_after: None,
+            });
+        }
+
+        if action != RegistrationAction::AlreadyLatest {
             let valid = async {
                 if let Some(cluster_name) = &self.spec.restate.register.cluster {
                     // wait for the cluster to be ready before registering to it
@@ -519,50 +538,102 @@ impl RestateDeployment {
                 Err(err) => return Err(err),
             }
 
-            // Register the latest version with Restate cluster using the service URL
-            let deployment_id = self
-                .register_service_with_restate(
-                    &ctx,
-                    &service_endpoint,
-                    self.spec.restate.use_http11.as_ref().cloned(),
-                )
-                .await?;
-            // if registration succeeded, treat this as an active endpoint
-            // if we fail after this point we will re-register and should get the same deployment id
+            // Register the latest version with Restate cluster using the service URL.
+            // A promotion re-registers the same endpoint with overwrite, so Restate bumps
+            // its service revisions past the current latest without minting a new
+            // deployment id — leaving invocations already pinned to it undisturbed.
+            let registered = registration::register_deployment(
+                &ctx,
+                self,
+                &service_endpoint,
+                self.spec.restate.use_http11.as_ref().cloned(),
+                action.overwrite(),
+            )
+            .await?;
+
+            // Recorded before the routing is confirmed, because the id is true either way:
+            // it is what Restate holds for this endpoint. Deferring the annotation until
+            // after confirmation would strand a version whose registration landed on an
+            // endpoint Restate already knew but was not routing to — with nothing recorded,
+            // the next reconcile plans a plain `Register` again rather than a promotion, and
+            // repeats that forever.
+            if existing_deployment_id.as_deref() != Some(registered.id.as_str()) {
+                debug!(
+                    "Updating deployment-id annotation of ReplicaSet/Service {versioned_name} in namespace {namespace}"
+                );
+
+                // store the id against the versioned objects
+                let params = PatchParams::apply("restate-operator/deployment-id").force();
+                let patch = ObjectMeta {
+                    annotations: Some(
+                        [(
+                            RESTATE_DEPLOYMENT_ID_ANNOTATION.to_string(),
+                            registered.id.clone(),
+                        )]
+                        .into(),
+                    ),
+                    ..Default::default()
+                };
+                rs_api
+                    .patch_metadata(
+                        &versioned_name,
+                        &params,
+                        &Patch::Apply(patch.clone().into_request_partial::<ReplicaSet>()),
+                    )
+                    .await?;
+                svc_api
+                    .patch_metadata(
+                        &versioned_name,
+                        &params,
+                        &Patch::Apply(patch.into_request_partial::<Service>()),
+                    )
+                    .await?;
+            }
+
+            // Registration's own response cannot distinguish "promoted" from "already
+            // existed, nothing changed" — both are a 200 carrying this deployment id. Ask
+            // Restate what it actually routes before treating this as done, or `Ready=True`
+            // would go on meaning "the pods are up" rather than "new work lands here".
+            registration::confirm_latest(&ctx, &self.spec.restate.register, &registered).await?;
+
+            if let RegistrationAction::Promote { superseded_by } = &action {
+                ctx.recorder
+                    .publish(
+                        &Event {
+                            type_: EventType::Normal,
+                            reason: "Promoted".into(),
+                            // Worth an event rather than only a log line: a promotion is a
+                            // forced re-registration, which Restate treats as permitting
+                            // breaking schema changes, and it resets the deployment's
+                            // registration time in Restate. Both deserve an audit trail.
+                            note: Some(format!(
+                                "Promoted deployment {} back to latest for {}, superseding {superseded_by}",
+                                registered.id,
+                                versioned_name.as_str(),
+                            )),
+                            action: "Reconcile".into(),
+                            secondary: None,
+                        },
+                        &self.object_ref(&()),
+                    )
+                    .await?;
+            }
+
+            // Confirmed above, so this is Restate's answer rather than an assumption.
+            //
+            // The deployment this one superseded keeps its stale `latest_for_service` until
+            // the next reconcile re-runs the query, so cleanup reads it as active and defers
+            // its drain by one pass. A promotion names it, but not whether it lost latest for
+            // *every* service it serves — it may still be the endpoint for one this version
+            // never discovered — so clearing the flag here could drain a version still taking
+            // traffic. One extra pass is the cheaper mistake.
             deployments.insert(
-                deployment_id.clone(),
+                registered.id.clone(),
                 DeploymentUsage {
                     latest_for_service: true,
                     ..Default::default()
                 },
             );
-
-            debug!(
-                "Updating deployment-id annotation of ReplicaSet/Service {versioned_name} in namespace {namespace}"
-            );
-
-            // store the id against the versioned objects
-            let params = PatchParams::apply("restate-operator/deployment-id").force();
-            let patch = ObjectMeta {
-                annotations: Some(
-                    [(RESTATE_DEPLOYMENT_ID_ANNOTATION.to_string(), deployment_id)].into(),
-                ),
-                ..Default::default()
-            };
-            rs_api
-                .patch_metadata(
-                    &versioned_name,
-                    &params,
-                    &Patch::Apply(patch.clone().into_request_partial::<ReplicaSet>()),
-                )
-                .await?;
-            svc_api
-                .patch_metadata(
-                    &versioned_name,
-                    &params,
-                    &Patch::Apply(patch.into_request_partial::<Service>()),
-                )
-                .await?;
         }
 
         // Clean up old ReplicaSets that are no longer needed
@@ -734,6 +805,26 @@ impl RestateDeployment {
                         "False".into(),
                     )
                 }
+                // See the ReplicaSet-mode arm below: healthy pods, stale routing.
+                Err(Error::DeploymentNotLatest {
+                    ref message,
+                    ref reason,
+                    requeue_after,
+                }) => {
+                    let requeue_after = requeue_after.unwrap_or(Duration::from_secs(30));
+                    warn!(
+                        name = %self.metadata.name.as_deref().unwrap_or("unknown"),
+                        namespace = %namespace,
+                        reason = %reason,
+                        "{message}"
+                    );
+                    (
+                        Ok(Action::requeue(requeue_after)),
+                        message.clone(),
+                        reason.clone(),
+                        "False".into(),
+                    )
+                }
                 Err(err) => {
                     let message = err.to_string();
                     (
@@ -810,6 +901,29 @@ impl RestateDeployment {
                         Ok(Action::requeue(Duration::ZERO)),
                         "Encountered a hash collision, will retry with a new template hash".into(),
                         "HashCollision".into(),
+                        "False".into(),
+                    )
+                }
+                // The desired version exists in Restate but is not what new invocations go
+                // to. Reported as not-Ready rather than as a reconcile failure: the pods are
+                // healthy, and a `Ready=True` here would be the exact false assurance that
+                // let a silent rollback failure pass for a successful one.
+                Err(Error::DeploymentNotLatest {
+                    ref message,
+                    ref reason,
+                    requeue_after,
+                }) => {
+                    let requeue_after = requeue_after.unwrap_or(Duration::from_secs(30));
+                    warn!(
+                        name = %self.metadata.name.as_deref().unwrap_or("unknown"),
+                        namespace = %namespace,
+                        reason = %reason,
+                        "{message}"
+                    );
+                    (
+                        Ok(Action::requeue(requeue_after)),
+                        message.clone(),
+                        reason.clone(),
                         "False".into(),
                     )
                 }
@@ -930,53 +1044,6 @@ impl RestateDeployment {
             .await?;
 
         result
-    }
-
-    /// Register a service version with the Restate cluster
-    pub(super) async fn register_service_with_restate(
-        &self,
-        ctx: &Context,
-        service_endpoint: &Url,
-        use_http11: Option<bool>,
-    ) -> Result<String> {
-        debug!(
-            "Registering endpoint '{service_endpoint}' to Restate at '{}'",
-            &self.spec.restate.register
-        );
-
-        #[derive(Deserialize)]
-        struct DeploymentResponse {
-            id: String,
-        }
-
-        let mut payload = serde_json::json!({
-            "uri": service_endpoint,
-        });
-
-        if let Some(use_http11) = use_http11 {
-            payload["use_http_11"] = serde_json::Value::Bool(use_http11);
-        }
-
-        let resp = ctx
-            .request(Method::POST, &self.spec.restate.register, "/deployments")?
-            .json(&payload)
-            .send()
-            .await
-            .map_err(Error::AdminCallFailed)?;
-        let resp: DeploymentResponse = check_admin_response(resp)
-            .await?
-            .json()
-            .await
-            .map_err(Error::AdminCallFailed)?;
-
-        let deployment_id = &resp.id;
-        info!(
-            deployment_id = %deployment_id,
-            url = %service_endpoint,
-            "Successfully registered Restate deployment"
-        );
-
-        Ok(resp.id)
     }
 
     pub(super) async fn list_deployments(
@@ -1301,12 +1368,16 @@ pub async fn run(client: Client, metrics: Metrics, state: State) {
     let not_created_cfg = Config::default();
 
     let (replicasets_store, replicasets_writer) = kube::runtime::reflector::store();
-    let replicaset_reflector = kube::runtime::reflector(
+    // Prewarmed, because the registration planner tells a rollback apart from a foreign
+    // controller by asking this store which other versions of a RestateDeployment hold
+    // Restate's latest revision. An unsynced store answers "none of ours", which reads as a
+    // conflict and would park an otherwise healthy rollback at Ready=False until it filled.
+    let replicaset_reflector = prewarmed_reflector(
+        replicasets_store.clone(),
         replicasets_writer,
         kube::runtime::watcher(replicasets, cfg.clone()),
     )
-    .touched_objects()
-    .default_backoff();
+    .await;
 
     // A reflector (rather than `.owns(...)`) also gives a queryable cache, so we can
     // check whether a draining version still has an HPA before issuing a delete —

--- a/src/controllers/restatedeployment/mod.rs
+++ b/src/controllers/restatedeployment/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod cleanup;
 pub mod controller;
+pub(crate) mod registration;
 
 mod reconcilers;
 

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::{Api, DeleteParams, PartialObjectMetaExt, Patch, PatchParams, PropagationPolicy};
+use kube::runtime::events::{Event, EventType};
 use kube::runtime::reflector::ObjectRef;
 use kube::{Resource, ResourceExt};
 use serde_json::json;
@@ -15,6 +16,7 @@ use crate::controllers::restatedeployment::controller::{
     Context, RESTATE_DEPLOYMENT_ID_ANNOTATION,
 };
 use crate::controllers::restatedeployment::reconcilers::replicaset::generate_pod_template_hash;
+use crate::controllers::restatedeployment::registration;
 use crate::resources::knative::{
     Configuration, ConfigurationTemplateMetadata, ConfigurationTemplateSpec,
     ConfigurationTemplateSpecContainers, Revision, Route, RouteSpec, RouteTraffic,
@@ -212,23 +214,31 @@ pub async fn reconcile_knative(
         knative_status.url = route.status.as_ref().and_then(|s| s.url.clone());
     }
 
-    // Register or lookup deployment
-    let deployment_id = register_or_lookup_deployment(ctx, rsd, namespace, &config, &route).await?;
-    trace!(deployment_id = %deployment_id, "Deployment registered/looked up");
-
-    // Update status with deployment ID
-    status.deployment_id = Some(deployment_id.clone());
-
-    // Annotate Configuration with deployment metadata
-    annotate_configuration(ctx, namespace, &config, &deployment_id).await?;
-
-    // Cleanup old Configurations (mirrors ReplicaSet cleanup pattern)
     // this path only runs for a live RestateDeployment; deletion goes to `cleanup`.
+    // Read before registering, because what Restate currently routes to is what decides
+    // whether this version needs registering, promoting, or leaving alone.
     let deployments = rsd.list_deployments(ctx, CleanupMode::Rollout).await?;
     let rsd_uid = rsd
         .uid()
         .ok_or_else(|| Error::InvalidRestateConfig("RestateDeployment must have UID".into()))?;
 
+    // Registers, promotes, or leaves alone as Restate's routing requires, annotating the
+    // Configuration with the resulting deployment id.
+    let deployment_id = register_or_promote_deployment(
+        ctx,
+        rsd,
+        namespace,
+        &rsd_uid,
+        &config,
+        &route,
+        &deployments,
+    )
+    .await?;
+    trace!(deployment_id = %deployment_id, "Deployment registered/looked up");
+
+    status.deployment_id = Some(deployment_id);
+
+    // Cleanup old Configurations (mirrors ReplicaSet cleanup pattern)
     let (_, next_removal) =
         cleanup_old_configurations(namespace, ctx, &rsd_uid, rsd, &deployments, Some(&tag)).await?;
 
@@ -636,23 +646,54 @@ fn check_revision_ready(revision: &Revision) -> Result<()> {
     })
 }
 
-/// Register deployment with Restate or lookup existing deployment ID
-async fn register_or_lookup_deployment(
+/// Register this version's endpoint with Restate, promoting it if a rollback needs it.
+///
+/// Knative names its Configuration and Route after the same content hash the ReplicaSet path
+/// uses, so `v1 -> v2 -> v1` re-adopts v1's Configuration, its Route URL and its deployment
+/// id here too — and the same rollback has to move Restate's routing. This used to return on
+/// the recorded annotation alone, which meant it could never promote.
+#[allow(clippy::too_many_arguments)]
+async fn register_or_promote_deployment(
     ctx: &Context,
     rsd: &RestateDeployment,
-    _namespace: &str,
+    namespace: &str,
+    rsd_uid: &str,
     config: &Configuration,
     route: &Route,
+    deployments: &DeploymentUsageMap,
 ) -> Result<String> {
-    // Check if Configuration already has deployment-id annotation
-    if let Some(annotations) = &config.metadata.annotations
-        && let Some(deployment_id) = annotations.get(RESTATE_DEPLOYMENT_ID_ANNOTATION)
-    {
-        trace!(
-            deployment_id = %deployment_id,
-            "Found existing deployment ID in Configuration annotation"
-        );
-        return Ok(deployment_id.clone());
+    let recorded_id = config.annotations().get(RESTATE_DEPLOYMENT_ID_ANNOTATION);
+
+    let action =
+        registration::plan_registration(recorded_id.map(String::as_str), deployments, || {
+            registration::owned_deployment_ids(&ctx.configuration_store, namespace, rsd_uid)
+        });
+
+    match &action {
+        // Restate already sends new invocations here; nothing to say to it.
+        registration::RegistrationAction::AlreadyLatest => {
+            let recorded_id = recorded_id.cloned().expect("AlreadyLatest implies an id");
+            trace!(
+                deployment_id = %recorded_id,
+                "Configuration's deployment is already latest"
+            );
+            annotate_configuration(ctx, namespace, config, &recorded_id).await?;
+            return Ok(recorded_id);
+        }
+        registration::RegistrationAction::Conflict => {
+            return Err(Error::DeploymentNotLatest {
+                message: format!(
+                    "Deployment {} is registered but superseded, and no Configuration of this \
+                     RestateDeployment is serving its services. Something outside this \
+                     RestateDeployment has registered them; check `GET /services` against the \
+                     Restate admin API. The operator will not force a promotion here.",
+                    recorded_id.map(String::as_str).unwrap_or("<unknown>"),
+                ),
+                reason: "ForeignDeployment".into(),
+                requeue_after: None,
+            });
+        }
+        _ => {}
     }
 
     // Build endpoint URL from Route default URL
@@ -673,11 +714,42 @@ async fn register_or_lookup_deployment(
         .register
         .maybe_tunnel_url(&ctx.rce_store, url)?;
 
-    let deployment_id = rsd
-        .register_service_with_restate(ctx, &url, rsd.spec.restate.use_http11.as_ref().cloned())
-        .await?;
+    let registered = registration::register_deployment(
+        ctx,
+        rsd,
+        &url,
+        rsd.spec.restate.use_http11.as_ref().cloned(),
+        action.overwrite(),
+    )
+    .await?;
 
-    Ok(deployment_id)
+    // Recorded before the routing is confirmed, for the reason given in the ReplicaSet path:
+    // the id is what Restate holds for this endpoint either way, and it is what lets the next
+    // reconcile plan a promotion rather than repeating this same plain registration.
+    annotate_configuration(ctx, namespace, config, &registered.id).await?;
+
+    registration::confirm_latest(ctx, &rsd.spec.restate.register, &registered).await?;
+
+    if let registration::RegistrationAction::Promote { superseded_by } = &action {
+        ctx.recorder
+            .publish(
+                &Event {
+                    type_: EventType::Normal,
+                    reason: "Promoted".into(),
+                    note: Some(format!(
+                        "Promoted deployment {} back to latest for Configuration {}, superseding {superseded_by}",
+                        registered.id,
+                        config.name_any(),
+                    )),
+                    action: "Reconcile".into(),
+                    secondary: None,
+                },
+                &rsd.object_ref(&()),
+            )
+            .await?;
+    }
+
+    Ok(registered.id)
 }
 
 /// Annotate Configuration with deployment metadata

--- a/src/controllers/restatedeployment/registration.rs
+++ b/src/controllers/restatedeployment/registration.rs
@@ -1,0 +1,481 @@
+//! Deciding what to tell Restate about the current version's endpoint, and confirming it
+//! was heard.
+//!
+//! Registration and cleanup ask different questions of the same data. Cleanup asks "may I
+//! remove this deployment?", for which in-flight invocations matter as much as being a
+//! service's endpoint — that is [`DeploymentUsage::is_active`]. Registration asks "does new
+//! work go here?", for which only the endpoint matters. Conflating the two is what let a
+//! rollback onto a version that still held a pinned invocation read as "already handled"
+//! and leave the newer version serving traffic.
+
+use std::collections::{BTreeSet, HashMap};
+
+use kube::runtime::reflector::Store;
+use kube::{Resource, ResourceExt};
+use reqwest::Method;
+use serde::Deserialize;
+
+use crate::controllers::restatedeployment::cleanup::DeploymentUsageMap;
+use crate::controllers::restatedeployment::controller::{
+    Context, RESTATE_DEPLOYMENT_ID_ANNOTATION, check_admin_response,
+};
+use crate::resources::restatedeployments::{RestateAdminEndpoint, RestateDeployment};
+use crate::{Error, Result};
+
+/// Whether a registration may replace an existing deployment at the same address.
+///
+/// Restate maps this onto its `force` flag, which is the only mechanism currently able to
+/// move a service's latest revision onto an already-registered deployment without minting
+/// a new deployment id. `PUT /deployments/{id}` deliberately preserves the revision number
+/// and so cannot promote. See restatedev/restate#5157 for the intended replacement, which
+/// would let `Yes` become an explicit "select this deployment" call instead.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Overwrite {
+    No,
+    Yes,
+}
+
+impl Overwrite {
+    /// Restate's `force` also implies `breaking`: there is no overwrite-without-breaking
+    /// flag. That is tolerable for a rollback — reversing a breaking change is what the
+    /// user asked for — but it is why this is never sent on a first registration.
+    fn force(self) -> bool {
+        self == Self::Yes
+    }
+}
+
+/// What the operator must do to make this version the one Restate routes new invocations to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum RegistrationAction {
+    /// Nothing recorded, or Restate has never heard of the recorded id.
+    Register,
+    /// Restate knows this id but another of *our own* versions is serving new invocations —
+    /// a rollback. Re-register the same endpoint with overwrite so its service revisions are
+    /// bumped past the current latest, keeping the deployment id, and everything pinned to
+    /// it, intact. Carries the id that currently holds latest, for the event the operator
+    /// emits afterwards.
+    Promote { superseded_by: String },
+    /// Already serving new invocations. Leave it alone.
+    AlreadyLatest,
+    /// Our deployment is registered but superseded, and no version of this RestateDeployment
+    /// is serving these services either — so something outside it is. Forcing here would
+    /// start a promotion war between two controllers, each bumping revisions to take the
+    /// service back, so refuse to write anything and report instead.
+    Conflict,
+}
+
+impl RegistrationAction {
+    pub(super) fn overwrite(&self) -> Overwrite {
+        match self {
+            Self::Promote { .. } => Overwrite::Yes,
+            _ => Overwrite::No,
+        }
+    }
+}
+
+/// Decide from what Restate already told us, without any further admin calls.
+///
+/// `owned_ids` yields the deployment ids recorded on the versioned objects belonging to this
+/// RestateDeployment — the evidence that distinguishes a rollback (one of ours holds latest)
+/// from a foreign controller having taken the service over. It is a closure because
+/// collecting it means walking a cluster-wide reflector cache, and the steady state
+/// (`AlreadyLatest`) never needs the answer.
+///
+/// Known limitation: `latest_for_service` is true when a deployment is latest for *any* of
+/// its services, so a deployment that is latest for some and superseded for others reads as
+/// `AlreadyLatest` here. That state needs a version exposing a strict subset of another's
+/// services to arise. [`confirm_latest`] catches it after a write; catching it on the
+/// untouched path needs per-service data the usage query does not carry, and is deliberately
+/// left out of this change.
+pub(super) fn plan_registration(
+    recorded_id: Option<&str>,
+    deployments: &DeploymentUsageMap,
+    owned_ids: impl FnOnce() -> BTreeSet<String>,
+) -> RegistrationAction {
+    let Some(recorded_id) = recorded_id else {
+        return RegistrationAction::Register;
+    };
+
+    let Some(usage) = deployments.get(recorded_id) else {
+        // Registered under an id Restate no longer has — deregistered out of band, or a
+        // brand new endpoint. Either way a plain registration is what's wanted.
+        return RegistrationAction::Register;
+    };
+
+    if usage.latest_for_service {
+        return RegistrationAction::AlreadyLatest;
+    }
+
+    // Our deployment exists but is superseded. It can only have been superseded by whoever
+    // registered these services next; if that is one of our own versions this is a rollback.
+    // Ordered, so a (pathological) tie between two of our versions still names the same one
+    // every reconcile rather than flapping in what the operator reports.
+    let superseded_by = owned_ids()
+        .into_iter()
+        .filter(|id| id != recorded_id)
+        .find(|id| {
+            deployments
+                .get(id)
+                .is_some_and(|usage| usage.latest_for_service)
+        });
+
+    match superseded_by {
+        Some(superseded_by) => RegistrationAction::Promote { superseded_by },
+        None => RegistrationAction::Conflict,
+    }
+}
+
+/// The deployment ids recorded on the versioned objects owned by this RestateDeployment
+/// (ReplicaSets in ReplicaSet mode, Configurations in Knative mode).
+pub(super) fn owned_deployment_ids<K>(
+    store: &Store<K>,
+    namespace: &str,
+    rsd_uid: &str,
+) -> BTreeSet<String>
+where
+    K: Resource + Clone + 'static,
+    K::DynamicType: std::hash::Hash + Eq + Clone + Default,
+{
+    store
+        .state()
+        .into_iter()
+        .filter(|obj| {
+            let obj_namespace = match obj.meta().namespace.as_deref() {
+                Some("") | None => "default",
+                Some(ns) => ns,
+            };
+            obj_namespace == namespace
+                && obj.owner_references().iter().any(|reference| {
+                    reference.uid == rsd_uid
+                        && reference.kind == <RestateDeployment as Resource>::kind(&())
+                })
+        })
+        .filter_map(|obj| {
+            obj.annotations()
+                .get(RESTATE_DEPLOYMENT_ID_ANNOTATION)
+                .cloned()
+        })
+        .collect()
+}
+
+/// A deployment as Restate returned it from registration.
+#[derive(Debug, Clone)]
+pub(super) struct RegisteredDeployment {
+    pub id: String,
+    /// The services Restate discovered at this endpoint — what [`confirm_latest`] checks.
+    pub services: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct RegisterDeploymentResponse {
+    id: String,
+    #[serde(default)]
+    services: Vec<ServiceRef>,
+}
+
+#[derive(Deserialize)]
+struct ServiceRef {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct ListServicesResponse {
+    #[serde(default)]
+    services: Vec<ServiceLatest>,
+}
+
+#[derive(Deserialize)]
+struct ServiceLatest {
+    name: String,
+    deployment_id: String,
+}
+
+/// Register (or re-register) an endpoint.
+pub(super) async fn register_deployment(
+    ctx: &Context,
+    rsd: &RestateDeployment,
+    service_endpoint: &url::Url,
+    use_http11: Option<bool>,
+    overwrite: Overwrite,
+) -> Result<RegisteredDeployment> {
+    let endpoint = &rsd.spec.restate.register;
+
+    tracing::debug!(
+        force = overwrite.force(),
+        "Registering endpoint '{service_endpoint}' to Restate at '{endpoint}'",
+    );
+
+    let mut payload = serde_json::json!({
+        "uri": service_endpoint,
+        // Always explicit. This flag's default depends on the admin API version the request
+        // resolves to, and it has already changed once (restatedev/restate#3859) — silently
+        // turning every re-registration into a no-op, which is the bug this path exists to
+        // fix. Stating it keeps the operator's intent independent of that default.
+        "force": overwrite.force(),
+    });
+
+    if let Some(use_http11) = use_http11 {
+        payload["use_http_11"] = serde_json::Value::Bool(use_http11);
+    }
+
+    let resp = ctx
+        .request(Method::POST, endpoint, "/deployments")?
+        .json(&payload)
+        .send()
+        .await
+        .map_err(Error::AdminCallFailed)?;
+    let resp: RegisterDeploymentResponse = check_admin_response(resp)
+        .await?
+        .json()
+        .await
+        .map_err(Error::AdminCallFailed)?;
+
+    tracing::info!(
+        deployment_id = %resp.id,
+        url = %service_endpoint,
+        force = overwrite.force(),
+        "Successfully registered Restate deployment"
+    );
+
+    Ok(RegisteredDeployment {
+        id: resp.id,
+        services: resp.services.into_iter().map(|svc| svc.name).collect(),
+    })
+}
+
+/// Assert that Restate now routes every one of this deployment's services to it.
+///
+/// Registration's own response cannot answer this. A non-overwriting registration of an
+/// endpoint Restate already knows returns 200 with the existing deployment id and its own
+/// services attached, which is indistinguishable from success by inspection — the operator
+/// used to take exactly that as proof and report `Ready=True` while the previous version
+/// kept serving. `GET /services` is the authoritative view and is a metadata read, so it
+/// costs nothing like the usage query.
+pub(super) async fn confirm_latest(
+    ctx: &Context,
+    endpoint: &RestateAdminEndpoint,
+    registered: &RegisteredDeployment,
+) -> Result<()> {
+    if registered.services.is_empty() {
+        // Nothing discovered at the endpoint. Not something this function can adjudicate;
+        // the deployment is registered but serves nothing, which cleanup will handle.
+        return Ok(());
+    }
+
+    let latest = latest_deployment_by_service(ctx, endpoint).await?;
+
+    let superseded: Vec<&str> = registered
+        .services
+        .iter()
+        .filter(|service| latest.get(*service).map(String::as_str) != Some(registered.id.as_str()))
+        .map(String::as_str)
+        .collect();
+
+    if superseded.is_empty() {
+        return Ok(());
+    }
+
+    let detail = superseded
+        .iter()
+        .map(|service| match latest.get(*service) {
+            Some(other) => format!("{service} -> {other}"),
+            None => format!("{service} -> (unregistered)"),
+        })
+        .collect::<Vec<_>>()
+        .join(", ");
+
+    Err(Error::DeploymentNotLatest {
+        message: format!(
+            "Restate registered deployment {} but still routes new invocations elsewhere: {detail}",
+            registered.id
+        ),
+        reason: "NotLatest".into(),
+        requeue_after: None,
+    })
+}
+
+async fn latest_deployment_by_service(
+    ctx: &Context,
+    endpoint: &RestateAdminEndpoint,
+) -> Result<HashMap<String, String>> {
+    let resp = ctx
+        .request(Method::GET, endpoint, "/services")?
+        .header(reqwest::header::ACCEPT, "application/json")
+        .send()
+        .await
+        .map_err(Error::AdminCallFailed)?;
+
+    let resp: ListServicesResponse = check_admin_response(resp)
+        .await?
+        .json()
+        .await
+        .map_err(Error::AdminCallFailed)?;
+
+    Ok(resp
+        .services
+        .into_iter()
+        .map(|svc| (svc.name, svc.deployment_id))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::controllers::restatedeployment::cleanup::DeploymentUsage;
+
+    fn usage(latest: bool, pinned: u64) -> DeploymentUsage {
+        DeploymentUsage {
+            latest_for_service: latest,
+            pinned_invocations: pinned,
+            unpinned_invocations: 0,
+        }
+    }
+
+    fn owned(ids: &[&str]) -> BTreeSet<String> {
+        ids.iter().map(|id| id.to_string()).collect()
+    }
+
+    fn promote(superseded_by: &str) -> RegistrationAction {
+        RegistrationAction::Promote {
+            superseded_by: superseded_by.into(),
+        }
+    }
+
+    #[test]
+    fn nothing_recorded_registers() {
+        assert_eq!(
+            plan_registration(None, &DeploymentUsageMap::new(), || owned(&[])),
+            RegistrationAction::Register
+        );
+    }
+
+    #[test]
+    fn recorded_but_unknown_to_restate_registers() {
+        // deregistered out of band; a plain registration re-creates it
+        let deployments = DeploymentUsageMap::from([("dp_other".into(), usage(true, 0))]);
+        assert_eq!(
+            plan_registration(Some("dp_gone"), &deployments, || owned(&["dp_gone"])),
+            RegistrationAction::Register
+        );
+    }
+
+    #[test]
+    fn latest_deployment_is_left_alone() {
+        let deployments = DeploymentUsageMap::from([("dp_v1".into(), usage(true, 0))]);
+        assert_eq!(
+            plan_registration(Some("dp_v1"), &deployments, || owned(&["dp_v1"])),
+            RegistrationAction::AlreadyLatest
+        );
+    }
+
+    /// The steady state must not pay for the cluster-wide reflector walk that only a
+    /// rollback needs.
+    #[test]
+    fn the_untouched_path_never_collects_the_owned_ids() {
+        let deployments = DeploymentUsageMap::from([("dp_v1".into(), usage(true, 0))]);
+        plan_registration(Some("dp_v1"), &deployments, || {
+            panic!("owned ids collected on the AlreadyLatest path")
+        });
+        plan_registration(None, &deployments, || {
+            panic!("owned ids collected on the Register path")
+        });
+    }
+
+    #[test]
+    fn rollback_onto_a_drained_version_promotes() {
+        let deployments = DeploymentUsageMap::from([
+            ("dp_v1".into(), usage(false, 0)),
+            ("dp_v2".into(), usage(true, 0)),
+        ]);
+        assert_eq!(
+            plan_registration(Some("dp_v1"), &deployments, || owned(&["dp_v1", "dp_v2"])),
+            promote("dp_v2")
+        );
+    }
+
+    /// The #174 regression: a rolled-back version still holding a pinned invocation used to
+    /// read as "active" and skip registration entirely, leaving the newer version latest.
+    /// In-flight work must have no bearing on the decision.
+    #[test]
+    fn rollback_promotes_even_while_pinned_invocations_remain() {
+        let deployments = DeploymentUsageMap::from([
+            ("dp_v1".into(), usage(false, 7)),
+            ("dp_v2".into(), usage(true, 0)),
+        ]);
+        assert_eq!(
+            plan_registration(Some("dp_v1"), &deployments, || owned(&["dp_v1", "dp_v2"])),
+            promote("dp_v2")
+        );
+    }
+
+    /// ...and the same holds when the version that superseded it is itself draining work.
+    #[test]
+    fn promotion_is_unaffected_by_the_superseding_versions_workload() {
+        let deployments = DeploymentUsageMap::from([
+            ("dp_v1".into(), usage(false, 0)),
+            ("dp_v2".into(), usage(true, 12)),
+        ]);
+        assert_eq!(
+            plan_registration(Some("dp_v1"), &deployments, || owned(&["dp_v1", "dp_v2"])),
+            promote("dp_v2")
+        );
+    }
+
+    /// Forcing here would fight whatever else is registering the service: each controller
+    /// would bump revisions to take it back, forever, rediscovering both endpoints each time.
+    #[test]
+    fn a_foreign_owner_is_a_conflict_not_a_promotion() {
+        let deployments = DeploymentUsageMap::from([
+            ("dp_mine".into(), usage(false, 0)),
+            ("dp_theirs".into(), usage(true, 0)),
+        ]);
+        assert_eq!(
+            plan_registration(Some("dp_mine"), &deployments, || owned(&["dp_mine"])),
+            RegistrationAction::Conflict
+        );
+    }
+
+    /// A superseded deployment whose successor is also superseded (two rollbacks deep) is
+    /// still ours to promote, as long as some version of ours holds latest — and the version
+    /// named as having superseded it is the one actually serving, not the one in between.
+    #[test]
+    fn promotion_looks_past_intermediate_superseded_versions() {
+        let deployments = DeploymentUsageMap::from([
+            ("dp_v1".into(), usage(false, 0)),
+            ("dp_v2".into(), usage(false, 0)),
+            ("dp_v3".into(), usage(true, 0)),
+        ]);
+        assert_eq!(
+            plan_registration(Some("dp_v1"), &deployments, || owned(&[
+                "dp_v1", "dp_v2", "dp_v3"
+            ])),
+            promote("dp_v3")
+        );
+    }
+
+    /// No version of ours holds latest and the map names nobody who does. Registration
+    /// creates service revisions, so something must be holding them; not being able to see
+    /// what — a stale cache, a deployment removed from under us — is exactly when forcing is
+    /// least safe. The guard stays shut and reports rather than guessing.
+    #[test]
+    fn all_of_our_versions_superseded_by_nobody_is_a_conflict() {
+        let deployments = DeploymentUsageMap::from([
+            ("dp_v1".into(), usage(false, 0)),
+            ("dp_v2".into(), usage(false, 0)),
+        ]);
+        assert_eq!(
+            plan_registration(Some("dp_v1"), &deployments, || owned(&["dp_v1", "dp_v2"])),
+            RegistrationAction::Conflict
+        );
+    }
+
+    #[test]
+    fn only_promotion_overwrites() {
+        assert_eq!(RegistrationAction::Register.overwrite(), Overwrite::No);
+        assert_eq!(promote("dp_v2").overwrite(), Overwrite::Yes);
+        assert_eq!(RegistrationAction::AlreadyLatest.overwrite(), Overwrite::No);
+        assert_eq!(RegistrationAction::Conflict.overwrite(), Overwrite::No);
+        assert!(!Overwrite::No.force());
+        assert!(Overwrite::Yes.force());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,16 @@ pub enum Error {
     #[error("Encountered a hash collision, will retry with a new template hash")]
     HashCollision,
 
+    /// The desired version is registered but Restate still routes new invocations somewhere
+    /// else. Kept distinct from `DeploymentNotReady`: the pods are fine, it is the routing
+    /// that has not caught up, and `Ready=True` must not be reported until it has.
+    #[error("RestateDeployment version is not latest in Restate: {message}")]
+    DeploymentNotLatest {
+        message: String,
+        reason: String,
+        requeue_after: Option<Duration>,
+    },
+
     #[error(
         "This RestateDeployment is backing active versions in Restate: {blocked_by}. If you want to delete the RestateDeployment, either register new endpoints for the relevant services or cancel/complete the outstanding invocations."
     )]
@@ -117,6 +127,7 @@ impl Error {
             Error::AdminCallFailed(_) => "AdminCallFailed",
             Error::AdminCallRejected { .. } => "AdminCallRejected",
             Error::HashCollision => "HashCollision",
+            Error::DeploymentNotLatest { .. } => "DeploymentNotLatest",
             Error::DeploymentInUse { .. } => "DeploymentInUse",
             Error::DeploymentDraining { .. } => "DeploymentDraining",
             Error::ConfigurationNotReady { .. } => "ConfigurationNotReady",


### PR DESCRIPTION
    Promote the desired revision on rollback
    
    Rolling back to a previously registered revision restored the pods but
    not Restate's routing. There were two causes:
    1. The decision to register skipped any deployment that was "active", which
       included one merely holding a pinned invocation
    2. The registration never asked for an overwrite, so Restate answered
       "unchanged" and the newer version kept serving.
    
    Now, when a rollback happens, the operators decides on where to route
    new invocations. When the revision isn't the latest, it force registers
    the rollback. Additionally, "Ready" is gated on GET to `/services`.
    
    This is the core fix for #174