### PR TITLE
Clear the stale drain deadline on a re-adopted ReplicaSet

### DIFF
--- a/release-notes/unreleased/174-rollback-drain-deadline.md
+++ b/release-notes/unreleased/174-rollback-drain-deadline.md
@@ -1,0 +1,55 @@
+# Release Notes for Issue #174: Rolled-back versions keep their drain delay
+
+## Bug Fix
+
+### What Changed
+
+A version that is rolled back to — or reintroduced with an identical spec — no longer
+carries a stale removal deadline into its next rollout.
+
+When a version is superseded, the operator stamps `restate.dev/remove-version-at` on its
+ReplicaSet (Knative mode: its Configuration) to schedule teardown after
+`spec.restate.drainDelaySeconds`. Because ReplicaSets and Services are named by a content
+hash of the pod template, and Configurations by tag, rolling back re-adopts that exact
+object rather than creating a new one — and the stamp came with it. Nothing removed it:
+the annotation has its own field manager, so the operator's other applies own the fields
+they set and not that one, and the cleanup pass skips whichever version is currently
+latest.
+
+The next time that version was superseded, its deadline had already passed, so it was
+scaled to zero on the first reconcile instead of being given its drain window.
+
+The operator now clears the annotation when it re-adopts a version as the latest one, in
+both deployment modes.
+
+Clearing it also works now. In ReplicaSet mode the old clear left the annotation behind
+with an empty value instead of removing it, so a version that became active again while
+draining kept an empty deadline for good and was re-patched on every reconcile. Knative
+mode was unaffected by that part.
+
+### Why This Matters
+
+The drain delay exists so that invocations already pinned to a version can finish on it.
+A version that skipped the delay was scaled to zero while that work was still in flight,
+which surfaces as invocations retrying against a version with no pods behind it until they
+are re-pinned or time out.
+
+The window for this was narrow but not exotic: it needed a rollback (or a re-applied
+identical spec) followed by another rollout, which is the ordinary shape of "revert, fix
+forward".
+
+### Impact on Users
+
+- **Existing deployments:** no configuration change. A version currently holding a stale
+  or empty deadline has it cleared the next time it is reconciled as the latest version.
+- **New deployments:** no impact.
+- Rollback followed by a further rollout now takes `drainDelaySeconds` longer to tear the
+  intermediate version down — that delay is the fix, not a regression.
+
+### Migration Guidance
+
+None required.
+
+### Related Issues
+
+- Issue #174: Support rolling RestateDeployments back to a previously registered revision

--- a/src/controllers/restatedeployment/cleanup.rs
+++ b/src/controllers/restatedeployment/cleanup.rs
@@ -1,11 +1,19 @@
 //! Policy decisions shared by the ReplicaSet and Knative cleanup reconcilers: what
-//! Restate still needs a registered deployment for, how we ask it, and how long we keep a
-//! drained version around.
+//! Restate still needs a registered deployment for, how we ask it, how long we keep a
+//! drained version around, and the drain deadline that records it.
 
 use std::collections::HashMap;
+use std::fmt::Debug;
 use std::time::Duration;
 
+use kube::api::{Api, Patch, PatchParams};
+use kube::{Resource, ResourceExt};
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
+use serde_json::json;
+use tracing::{debug, info};
+
+use crate::Result;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CleanupMode {
@@ -213,9 +221,341 @@ pub(crate) fn retain_for_rollback(
     !mode.is_deleting() && historic_count < revision_history_limit
 }
 
+/// When a superseded version may be torn down.
+pub(crate) const RESTATE_REMOVE_VERSION_AT_ANNOTATION: &str = "restate.dev/remove-version-at";
+
+/// Every write to the deadline goes out under this one manager.
+const REMOVE_VERSION_AT_FIELD_MANAGER: &str = "restate-operator/remove-version-at";
+
+fn stamp_patch<K>(
+    remove_at: chrono::DateTime<chrono::Utc>,
+) -> (PatchParams, Patch<serde_json::Value>)
+where
+    K: Resource<DynamicType = ()>,
+{
+    let patch = json!({
+        "apiVersion": K::api_version(&()),
+        "kind": K::kind(&()),
+        "metadata": { "annotations": {
+            RESTATE_REMOVE_VERSION_AT_ANNOTATION: remove_at.to_rfc3339(),
+        } },
+    });
+
+    (
+        PatchParams::apply(REMOVE_VERSION_AT_FIELD_MANAGER).force(),
+        Patch::Apply(patch),
+    )
+}
+
+/// Giving up the claim is what removes the annotation; setting it to `null` leaves an
+/// empty string behind. Only a deadline this manager owns can go this way, so a hand-set
+/// one survives.
+fn clear_patch<K>() -> (PatchParams, Patch<serde_json::Value>)
+where
+    K: Resource<DynamicType = ()>,
+{
+    let patch = json!({
+        "apiVersion": K::api_version(&()),
+        "kind": K::kind(&()),
+        "metadata": { "annotations": {} },
+    });
+
+    (
+        PatchParams::apply(REMOVE_VERSION_AT_FIELD_MANAGER).force(),
+        Patch::Apply(patch),
+    )
+}
+
+pub(crate) async fn schedule_version_removal<K>(
+    api: &Api<K>,
+    namespace: &str,
+    name: &str,
+    drain_delay_seconds: i64,
+) -> Result<chrono::DateTime<chrono::Utc>>
+where
+    K: Resource<DynamicType = ()> + Clone + DeserializeOwned + Debug,
+{
+    let remove_at = chrono::Utc::now()
+        .checked_add_signed(chrono::TimeDelta::seconds(drain_delay_seconds))
+        .expect("remove_version_at in bounds");
+
+    info!(
+        kind = %K::kind(&()),
+        version = %name,
+        namespace = %namespace,
+        drain_delay_seconds,
+        remove_at = %remove_at.to_rfc3339(),
+        "Scheduling removal of old version (after drain delay)"
+    );
+
+    let (params, patch) = stamp_patch::<K>(remove_at);
+    api.patch_metadata(name, &params, &patch).await?;
+
+    Ok(remove_at)
+}
+
+/// For a version that is staying. A leftover deadline would tear it down with no drain
+/// delay the next time it is superseded. No API call if nothing is scheduled.
+pub(crate) async fn unschedule_version_removal<K>(api: &Api<K>, version: &K) -> Result<()>
+where
+    K: Resource<DynamicType = ()> + Clone + DeserializeOwned + Debug,
+{
+    if !version
+        .annotations()
+        .contains_key(RESTATE_REMOVE_VERSION_AT_ANNOTATION)
+    {
+        return Ok(());
+    }
+
+    let name = version.name_any();
+    debug!(
+        kind = %K::kind(&()),
+        version = %name,
+        namespace = %version.namespace().unwrap_or_default(),
+        "Unscheduling removal of version that is staying"
+    );
+
+    let (params, patch) = clear_patch::<K>();
+    api.patch_metadata(&name, &params, &patch).await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resources::knative::Configuration;
+    use k8s_openapi::api::apps::v1::ReplicaSet;
+
+    /// Both deployment modes write the same annotation under the same field manager.
+    #[test]
+    fn the_deadline_is_stamped_and_cleared_under_one_field_manager() {
+        let remove_at = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00+00:00")
+            .expect("test deadline parses")
+            .to_utc();
+
+        let (params, patch) = stamp_patch::<ReplicaSet>(remove_at);
+        assert_eq!(
+            params.field_manager.as_deref(),
+            Some("restate-operator/remove-version-at"),
+        );
+        assert_eq!(
+            patch,
+            Patch::Apply(json!({
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": { "annotations": {
+                    "restate.dev/remove-version-at": "2026-01-01T00:00:00+00:00",
+                } },
+            })),
+        );
+
+        assert_eq!(
+            stamp_patch::<Configuration>(remove_at).1,
+            Patch::Apply(json!({
+                "apiVersion": "serving.knative.dev/v1",
+                "kind": "Configuration",
+                "metadata": { "annotations": {
+                    "restate.dev/remove-version-at": "2026-01-01T00:00:00+00:00",
+                } },
+            })),
+        );
+
+        let (params, patch) = clear_patch::<ReplicaSet>();
+        assert_eq!(
+            params.field_manager.as_deref(),
+            Some("restate-operator/remove-version-at"),
+        );
+        assert_eq!(
+            patch,
+            Patch::Apply(json!({
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": { "annotations": {} },
+            })),
+        );
+
+        assert_eq!(
+            clear_patch::<Configuration>().1,
+            Patch::Apply(json!({
+                "apiVersion": "serving.knative.dev/v1",
+                "kind": "Configuration",
+                "metadata": { "annotations": {} },
+            })),
+        );
+    }
+
+    /// Stamp, clear, stamp again, as a rollback does it. Only a real apiserver can say
+    /// whether the clear removes the annotation and the next stamp lands.
+    ///
+    /// Creates and deletes the namespace `restate-operator-drain-deadline` in the current
+    /// kube context.
+    ///
+    ///     cargo test --lib -- --ignored the_cleared_deadline
+    mod live {
+        use super::*;
+        use k8s_openapi::api::apps::v1::ReplicaSet;
+        use k8s_openapi::api::core::v1::Namespace;
+        use kube::Client;
+        use kube::api::{DeleteParams, PostParams};
+
+        const NAMESPACE: &str = "restate-operator-drain-deadline";
+        const VERSION: &str = "greeter-abc123";
+
+        /// The deadline annotation, and every manager claiming it.
+        async fn deadline(rs_api: &Api<ReplicaSet>) -> (Option<String>, Vec<String>) {
+            let rs = rs_api
+                .get(VERSION)
+                .await
+                .expect("the ReplicaSet is readable");
+
+            let claimants = rs
+                .managed_fields()
+                .iter()
+                .filter(|entry| {
+                    let claimed = serde_json::to_string(&entry.fields_v1).unwrap_or_default();
+                    claimed.contains(RESTATE_REMOVE_VERSION_AT_ANNOTATION)
+                })
+                .map(|entry| entry.manager.clone().unwrap_or_default())
+                .collect();
+
+            (
+                rs.annotations()
+                    .get(RESTATE_REMOVE_VERSION_AT_ANNOTATION)
+                    .cloned(),
+                claimants,
+            )
+        }
+
+        #[tokio::test]
+        #[ignore = "needs a Kubernetes apiserver; run with --ignored"]
+        async fn the_cleared_deadline_can_be_stamped_again() {
+            let client = Client::try_default()
+                .await
+                .expect("a kube context to run against");
+
+            let ns_api: Api<Namespace> = Api::all(client.clone());
+            let _ = ns_api
+                .create(
+                    &PostParams::default(),
+                    &serde_json::from_value(json!({
+                        "apiVersion": "v1",
+                        "kind": "Namespace",
+                        "metadata": { "name": NAMESPACE },
+                    }))
+                    .expect("the scratch namespace deserializes"),
+                )
+                .await;
+
+            let rs_api: Api<ReplicaSet> = Api::namespaced(client, NAMESPACE);
+            let _ = rs_api.delete(VERSION, &DeleteParams::default()).await;
+
+            // as the operator creates it
+            rs_api
+                .create(
+                    &PostParams {
+                        dry_run: false,
+                        field_manager: Some("restate-operator".to_owned()),
+                    },
+                    &serde_json::from_value(json!({
+                        "apiVersion": "apps/v1",
+                        "kind": "ReplicaSet",
+                        "metadata": {
+                            "name": VERSION,
+                            "annotations": { "restate.dev/pod-template": "{}" },
+                        },
+                        "spec": {
+                            "replicas": 0,
+                            "selector": { "matchLabels": { "pod-template-hash": "abc123" } },
+                            "template": {
+                                "metadata": { "labels": { "pod-template-hash": "abc123" } },
+                                "spec": { "containers": [
+                                    { "name": "app", "image": "registry.k8s.io/pause:3.9" },
+                                ] },
+                            },
+                        },
+                    }))
+                    .expect("the test ReplicaSet deserializes"),
+                )
+                .await
+                .expect("the ReplicaSet is created");
+
+            let first = schedule_version_removal(&rs_api, NAMESPACE, VERSION, 300)
+                .await
+                .expect("the deadline is stamped");
+            assert_eq!(
+                deadline(&rs_api).await,
+                (
+                    Some(first.to_rfc3339()),
+                    vec![REMOVE_VERSION_AT_FIELD_MANAGER.to_owned()],
+                ),
+            );
+
+            let stamped = rs_api
+                .get(VERSION)
+                .await
+                .expect("the ReplicaSet is readable");
+            unschedule_version_removal(&rs_api, &stamped)
+                .await
+                .expect("the deadline is cleared");
+            assert_eq!(
+                deadline(&rs_api).await,
+                (None, vec![]),
+                "the annotation is gone, and nothing is left claiming it",
+            );
+
+            let second = schedule_version_removal(&rs_api, NAMESPACE, VERSION, 300)
+                .await
+                .expect("the cleared deadline is stamped again");
+            assert_ne!(second.to_rfc3339(), first.to_rfc3339());
+            assert_eq!(
+                deadline(&rs_api).await,
+                (
+                    Some(second.to_rfc3339()),
+                    vec![REMOVE_VERSION_AT_FIELD_MANAGER.to_owned()],
+                ),
+                "the re-stamped deadline landed, under the one manager",
+            );
+
+            let no_deadline = rs_api
+                .get(VERSION)
+                .await
+                .expect("the ReplicaSet is readable");
+            unschedule_version_removal(&rs_api, &no_deadline)
+                .await
+                .expect("clearing an unscheduled version is a no-op");
+
+            // a deadline this manager never owned survives the clear
+            rs_api
+                .patch_metadata(
+                    VERSION,
+                    &PatchParams::apply("someone-else").force(),
+                    &Patch::Apply(json!({
+                        "apiVersion": "apps/v1",
+                        "kind": "ReplicaSet",
+                        "metadata": { "annotations": {
+                            RESTATE_REMOVE_VERSION_AT_ANNOTATION: "2026-01-01T00:00:00+00:00",
+                        } },
+                    })),
+                )
+                .await
+                .expect("the foreign deadline is set");
+            let foreign = rs_api
+                .get(VERSION)
+                .await
+                .expect("the ReplicaSet is readable");
+            unschedule_version_removal(&rs_api, &foreign)
+                .await
+                .expect("the clear is applied");
+            assert_eq!(
+                deadline(&rs_api).await.0,
+                Some("2026-01-01T00:00:00+00:00".to_owned()),
+                "a deadline this manager never owned survives the clear",
+            );
+
+            let _ = ns_api.delete(NAMESPACE, &DeleteParams::default()).await;
+        }
+    }
 
     fn usage(latest: bool, pinned: u64, unpinned: u64) -> DeploymentUsage {
         DeploymentUsage {

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -48,7 +48,8 @@ use crate::{Error, Result};
 // Import our reconcilers
 use crate::controllers::restatedeployment::cleanup::{
     CleanupMode, DeploymentUsage, DeploymentUsageMap, DeploymentUsageRows,
-    blocked_deletion_requeue, deployment_usage_query, describe_blocking_versions,
+    RESTATE_REMOVE_VERSION_AT_ANNOTATION, blocked_deletion_requeue, deployment_usage_query,
+    describe_blocking_versions, unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::reconcilers;
 
@@ -314,6 +315,8 @@ impl RestateDeployment {
         // recorded by the operator on the ReplicaSet at creation (in-process tunnel
         // mode) and read back when building the registration URL
         annotations.remove(RESTATE_TUNNEL_NAME_ANNOTATION);
+        // the drain deadline; a copy would land under a manager the clear can't give up
+        annotations.remove(RESTATE_REMOVE_VERSION_AT_ANNOTATION);
 
         // Create/update the ReplicaSet for this version
         let reconcile_result = reconcilers::replicaset::reconcile_replicaset(
@@ -396,6 +399,11 @@ impl RestateDeployment {
                             ),
                         )
                         .await?;
+
+                    // This ReplicaSet was superseded before, so it can still carry the
+                    // deadline it drained under; nothing else removes it, and the next
+                    // rollout would tear it down early.
+                    unschedule_version_removal(&rs_api, &existing_replicaset).await?;
 
                     existing_replicaset
                 } else {

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -9,7 +9,8 @@ use tracing::*;
 use url::Url;
 
 use crate::controllers::restatedeployment::cleanup::{
-    BlockingVersion, CleanupMode, DeploymentUsageMap, retain_for_rollback,
+    BlockingVersion, CleanupMode, DeploymentUsageMap, RESTATE_REMOVE_VERSION_AT_ANNOTATION,
+    retain_for_rollback, schedule_version_removal, unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::controller::{
     Context, RESTATE_DEPLOYMENT_ID_ANNOTATION,
@@ -293,6 +294,10 @@ async fn reconcile_configuration(
         .patch(name, &params, &Patch::Apply(&config_spec))
         .await?;
 
+    // Rolling back to a tag re-adopts its Configuration, deadline included; the apply
+    // above cannot prune it and cleanup skips the active tag.
+    unschedule_version_removal(&config_api, &config).await?;
+
     Ok(config)
 }
 
@@ -333,6 +338,8 @@ fn build_configuration_spec(
     let mut config_annotations = rsd.annotations().clone();
     config_annotations.remove("kubectl.kubernetes.io/last-applied-configuration");
     config_annotations.remove("serving.knative.dev/rollout-duration"); // Route-only annotation
+    // the drain deadline; a copy would land under a manager the clear can't give up
+    config_annotations.remove(RESTATE_REMOVE_VERSION_AT_ANNOTATION);
     // Add operator-managed annotations
     config_annotations.insert(RESTATE_DEPLOYMENT_ANNOTATION.to_string(), rsd.name_any());
     config_annotations.insert(RESTATE_TAG_ANNOTATION.to_string(), tag.to_string());
@@ -737,8 +744,6 @@ async fn annotate_configuration(
     Ok(())
 }
 
-const RESTATE_REMOVE_VERSION_AT_ANNOTATION: &str = "restate.dev/remove-version-at";
-
 /// Delete Configurations that are no longer needed
 /// Mirrors the pattern from cleanup_old_replicasets() in replicaset.rs:156-399
 #[allow(clippy::too_many_arguments)]
@@ -835,43 +840,9 @@ pub async fn cleanup_old_configurations(
                 usage,
             });
 
-            if config
-                .metadata
-                .annotations
-                .as_ref()
-                .and_then(|a| a.get(RESTATE_REMOVE_VERSION_AT_ANNOTATION))
-                .is_none()
-            {
-                // not scheduled for removal; all good.
-                trace!(
-                    "Keeping active Configuration {} in namespace {namespace}",
-                    config_name,
-                );
-                continue;
-            }
-
-            debug!(
-                "Unscheduling removal of active Configuration {} in namespace {namespace}",
-                config_name,
-            );
-
-            // if we previously scheduled it for removal, but it now seems active, reset the timer by removing the annotation
+            // it was scheduled for removal but looks active again, so reset the timer
             let config_api: Api<Configuration> = Api::namespaced(ctx.client.clone(), namespace);
-            let params: PatchParams =
-                PatchParams::apply("restate-operator/remove-version-at").force();
-            config_api
-                .patch_metadata(
-                    &config_name,
-                    &params,
-                    &Patch::Apply(
-                        ObjectMeta {
-                            annotations: Some(Default::default()),
-                            ..Default::default()
-                        }
-                        .into_request_partial::<Configuration>(),
-                    ),
-                )
-                .await?;
+            unschedule_version_removal(&config_api, &config).await?;
 
             continue;
         }
@@ -947,40 +918,14 @@ pub async fn cleanup_old_configurations(
             }
             (None, _, true) => {
                 // endpoint exists and there's no valid remove_version_at annotation, create one
-                let drain_delay_seconds = rsd.spec.restate.drain_delay_seconds();
-                info!(
-                    configuration = %config_name,
-                    namespace = %namespace,
-                    drain_delay_seconds,
-                    "Scheduling removal of old Configuration (after drain delay)"
-                );
-
-                let remove_at = chrono::Utc::now()
-                    .checked_add_signed(chrono::TimeDelta::seconds(drain_delay_seconds))
-                    .expect("remove_version_at in bounds");
-
                 let config_api: Api<Configuration> = Api::namespaced(ctx.client.clone(), namespace);
-                let params = PatchParams::apply("restate-operator/remove-version-at").force();
-
-                config_api
-                    .patch_metadata(
-                        &config_name,
-                        &params,
-                        &Patch::Apply(
-                            ObjectMeta {
-                                annotations: Some(
-                                    [(
-                                        RESTATE_REMOVE_VERSION_AT_ANNOTATION.to_string(),
-                                        remove_at.to_rfc3339(),
-                                    )]
-                                    .into(),
-                                ),
-                                ..Default::default()
-                            }
-                            .into_request_partial::<Configuration>(),
-                        ),
-                    )
-                    .await?;
+                let remove_at = schedule_version_removal(
+                    &config_api,
+                    namespace,
+                    &config_name,
+                    rsd.spec.restate.drain_delay_seconds(),
+                )
+                .await?;
 
                 // ensure we keep track of the soonest remove_at
                 next_removal = match next_removal {

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -2,11 +2,9 @@ use std::collections::BTreeMap;
 
 use k8s_openapi::api::apps::v1::ReplicaSet;
 use k8s_openapi::api::autoscaling::v2::HorizontalPodAutoscaler;
-use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 
-use kube::api::{
-    Api, ApiResource, DynamicObject, PartialObjectMetaExt, Patch, PatchParams, PostParams,
-};
+use kube::api::{Api, ApiResource, DynamicObject, Patch, PatchParams, PostParams};
 use kube::core::subresource::Scale;
 use kube::runtime::events::{Event, EventType};
 use kube::runtime::reflector::ObjectRef;
@@ -16,7 +14,8 @@ use serde_json::json;
 use tracing::*;
 
 use crate::controllers::restatedeployment::cleanup::{
-    BlockingVersion, CleanupMode, DeploymentUsageMap, retain_for_rollback,
+    BlockingVersion, CleanupMode, DeploymentUsageMap, RESTATE_REMOVE_VERSION_AT_ANNOTATION,
+    retain_for_rollback, schedule_version_removal, unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::controller::{
     APP_MANAGED_BY_LABEL, Context, OWNED_BY_LABEL, RESTATE_DEPLOYMENT_ID_ANNOTATION,
@@ -29,7 +28,6 @@ use super::autoscaling::HpaPlan;
 
 pub const POD_TEMPLATE_HASH_LABEL: &str = "pod-template-hash";
 pub const RESTATE_POD_TEMPLATE_ANNOTATION: &str = "restate.dev/pod-template";
-pub const RESTATE_REMOVE_VERSION_AT_ANNOTATION: &str = "restate.dev/remove-version-at";
 /// Records the tunnel name a `tunnelMode: in-process` ReplicaSet was created with —
 /// the same value injected into its pods as RESTATE_INPROC_TUNNEL_NAME.
 pub const RESTATE_TUNNEL_NAME_ANNOTATION: &str = "restate.dev/tunnel-name";
@@ -427,38 +425,8 @@ pub async fn cleanup_old_replicasets(
                 HpaPlan::Skip => {}
             }
 
-            if rs
-                .annotations()
-                .get(RESTATE_REMOVE_VERSION_AT_ANNOTATION)
-                .is_none()
-            {
-                // not scheduled for removal; all good.
-                continue;
-            }
-
-            debug!(
-                "Unscheduling removal of active ReplicaSet {} in namespace {namespace}",
-                rs_name,
-            );
-
-            // if we previously scheduled it for removal, but it now seems active, reset the timer by removing the annotation
-            let params: PatchParams =
-                PatchParams::apply("restate-operator/remove-version-at").force();
-            rs_api
-                .patch_metadata(
-                    &rs_name,
-                    &params,
-                    &Patch::Apply(json!({
-                        "apiVersion": ReplicaSet::api_version(&()),
-                        "kind": ReplicaSet::kind(&()),
-                        "metadata": {
-                            "annotations": {
-                                RESTATE_REMOVE_VERSION_AT_ANNOTATION: null,
-                            }
-                        }
-                    })),
-                )
-                .await?;
+            // it was scheduled for removal but looks active again, so reset the timer
+            unschedule_version_removal(rs_api, &rs).await?;
 
             continue;
         }
@@ -568,33 +536,13 @@ pub async fn cleanup_old_replicasets(
             }
             (None, _, true) => {
                 // endpoint exists and there's no valid remove_version_at annotation, create one
-                let drain_delay_seconds = rsd.spec.restate.drain_delay_seconds();
-                info!(
-                    replicaset = %rs_name,
-                    namespace = %namespace,
-                    drain_delay_seconds,
-                    "Scheduling removal of old ReplicaSet (after drain delay)"
-                );
-                let remove_at = chrono::Utc::now()
-                    .checked_add_signed(chrono::TimeDelta::seconds(drain_delay_seconds))
-                    .expect("remove_version_at in bounds");
-
-                let params = PatchParams::apply("restate-operator/remove-version-at").force();
-                let patch = ObjectMeta {
-                    annotations: Some(
-                        [(
-                            RESTATE_REMOVE_VERSION_AT_ANNOTATION.to_string(),
-                            remove_at.to_rfc3339(),
-                        )]
-                        .into(),
-                    ),
-                    ..Default::default()
-                }
-                .into_request_partial::<ReplicaSet>();
-
-                rs_api
-                    .patch_metadata(&rs_name, &params, &Patch::Apply(patch))
-                    .await?;
+                let remove_at = schedule_version_removal(
+                    rs_api,
+                    namespace,
+                    &rs_name,
+                    rsd.spec.restate.drain_delay_seconds(),
+                )
+                .await?;
 
                 // ensure we keep track of the soonest remove_at
                 next_removal = match next_removal {
@@ -838,20 +786,62 @@ mod tests {
         const RSD_UID: &str = "uid-123";
         const VERSION: &str = "greeter-old";
 
-        /// Every request the reconciler made, in order, as "METHOD /path".
+        /// One request the reconciler made.
+        #[derive(Clone)]
+        struct Call {
+            method: String,
+            path: String,
+            field_manager: Option<String>,
+            /// Which kind of patch it was.
+            content_type: Option<String>,
+        }
+
+        /// Every request the reconciler made, in order.
         #[derive(Clone, Default)]
-        struct Calls(Arc<Mutex<Vec<String>>>);
+        struct Calls(Arc<Mutex<Vec<Call>>>);
 
         impl Calls {
+            /// Matching requests as "METHOD /path".
             fn matching(&self, needle: &str) -> Vec<String> {
+                self.to_path(needle)
+                    .into_iter()
+                    .map(|call| format!("{} {}", call.method, call.path))
+                    .collect()
+            }
+
+            /// The field managers of matching requests, in order.
+            fn field_managers(&self, needle: &str) -> Vec<String> {
+                self.to_path(needle)
+                    .into_iter()
+                    .filter_map(|call| call.field_manager)
+                    .collect()
+            }
+
+            /// The patch types of matching requests, in order.
+            fn patch_types(&self, needle: &str) -> Vec<String> {
+                self.to_path(needle)
+                    .into_iter()
+                    .filter_map(|call| call.content_type)
+                    .collect()
+            }
+
+            fn to_path(&self, needle: &str) -> Vec<Call> {
                 self.0
                     .lock()
                     .expect("calls are not poisoned")
                     .iter()
-                    .filter(|call| call.contains(needle))
+                    .filter(|call| call.path.contains(needle))
                     .cloned()
                     .collect()
             }
+        }
+
+        fn field_manager_of(query: Option<&str>) -> Option<String> {
+            query?
+                .split('&')
+                .find_map(|pair| pair.strip_prefix("fieldManager="))
+                // slashes in manager names are escaped on the wire
+                .map(|manager| manager.replace("%2F", "/"))
         }
 
         struct Harness {
@@ -884,11 +874,17 @@ mod tests {
                     let calls = calls.clone();
                     async move {
                         let path = req.uri().path().to_owned();
-                        calls
-                            .0
-                            .lock()
-                            .expect("calls are not poisoned")
-                            .push(format!("{} {path}", req.method()));
+                        let content_type = req
+                            .headers()
+                            .get(http::header::CONTENT_TYPE)
+                            .and_then(|value| value.to_str().ok())
+                            .map(str::to_owned);
+                        calls.0.lock().expect("calls are not poisoned").push(Call {
+                            method: req.method().to_string(),
+                            path: path.clone(),
+                            field_manager: field_manager_of(req.uri().query()),
+                            content_type,
+                        });
 
                         // enough of a body for kube to deserialise the return type of
                         // whichever call this was; none of it is asserted on
@@ -1162,6 +1158,71 @@ mod tests {
                 harness.calls.matching("horizontalpodautoscalers"),
                 Vec::<String>::new(),
                 "an owned HPA is garbage-collected with the RestateDeployment, not by us"
+            );
+        }
+
+        /// Stamp and clear both go out under one field manager. The controller's rollback
+        /// path clears through this same helper.
+        #[tokio::test]
+        async fn the_drain_deadline_is_stamped_and_cleared_by_one_field_manager() {
+            const MANAGER: &str = "restate-operator/remove-version-at";
+            let patch_of =
+                |name| format!("PATCH /apis/apps/v1/namespaces/{NAMESPACE}/replicasets/{name}");
+            let rsd = rsd(false, false);
+
+            // superseded with nothing in flight, so this pass stamps a deadline
+            let stamping = harness(vec![version("dp_super", None)], vec![]);
+            let (_, next_removal) = cleanup_old_replicasets(
+                NAMESPACE,
+                &stamping.ctx,
+                &stamping.rs_api,
+                RSD_UID,
+                &rsd,
+                &usage_of("dp_super", DeploymentUsage::default()),
+                None,
+            )
+            .await
+            .expect("cleanup succeeds");
+
+            assert!(next_removal.is_some(), "the version is left to drain");
+            assert_eq!(stamping.calls.matching(VERSION), vec![patch_of(VERSION)]);
+            assert_eq!(stamping.calls.field_managers(VERSION), vec![MANAGER]);
+            assert_eq!(
+                stamping.calls.patch_types(VERSION),
+                vec!["application/apply-patch+yaml"],
+            );
+
+            // a version still holding an invocation sheds its deadline, same manager
+            let clearing = harness(vec![version("dp_pinned", Some(chrono::Utc::now()))], vec![]);
+            let pinned = DeploymentUsage {
+                latest_for_service: false,
+                pinned_invocations: 1,
+                unpinned_invocations: 0,
+            };
+            let (blocking, _) = cleanup_old_replicasets(
+                NAMESPACE,
+                &clearing.ctx,
+                &clearing.rs_api,
+                RSD_UID,
+                &rsd,
+                &usage_of("dp_pinned", pinned),
+                None,
+            )
+            .await
+            .expect("cleanup succeeds");
+
+            assert_eq!(
+                blocking,
+                vec![BlockingVersion {
+                    name: VERSION.into(),
+                    usage: pinned,
+                }],
+            );
+            assert_eq!(clearing.calls.matching(VERSION), vec![patch_of(VERSION)]);
+            assert_eq!(clearing.calls.field_managers(VERSION), vec![MANAGER]);
+            assert_eq!(
+                clearing.calls.patch_types(VERSION),
+                vec!["application/apply-patch+yaml"],
             );
         }
     }


### PR DESCRIPTION
A ReplicaSet re-adopted as the current version was previously superseded, so it can still carry the removal deadline stamped on it while it drained. Nothing else clears it: the annotation patch on that path uses a different field manager, so server-side apply won't prune it, and cleanup_old_replicasets skips the current version via except_rs.

Left in place, an already-past deadline makes the next rollout tear this version down immediately instead of giving it drainDelaySeconds, stranding whatever is still pinned to it.

Refs #174