### PR TITLE
docs: clarify revisionHistoryLimit applies to Knative mode

### DIFF
--- a/crd/RestateDeployment.pkl
+++ b/crd/RestateDeployment.pkl
@@ -67,8 +67,16 @@ class Spec {
   /// Restate specific configuration
   restate: Restate
 
-  /// The number of old ReplicaSets to retain to allow rollback. Defaults to 10. Only used in ReplicaSet
-  /// mode.
+  /// The number of old, fully drained versions to keep for rollback before the operator deletes
+  /// them. Defaults to 10.
+  ///
+  /// Applies to both deployment modes: it bounds retained ReplicaSets in ReplicaSet mode and
+  /// retained Knative Configurations in Knative mode. Versions past the limit are deregistered
+  /// from Restate and removed once they have drained.
+  ///
+  /// In Knative mode a retained Configuration keeps running its `minScale` pods, because Knative
+  /// cannot rescale an existing Revision, so lower this for services with a high `minScale` to
+  /// avoid idle pods kept only for rollback.
   ///
   /// Default if undefined: `10`
   revisionHistoryLimit: Int(isPositive)?

--- a/crd/restatedeployments.yaml
+++ b/crd/restatedeployments.yaml
@@ -248,8 +248,16 @@ spec:
               revisionHistoryLimit:
                 default: 10
                 description: |-
-                  The number of old ReplicaSets to retain to allow rollback. Defaults to 10.
-                  Only used in ReplicaSet mode.
+                  The number of old, fully drained versions to keep for rollback before the operator
+                  deletes them. Defaults to 10.
+
+                  Applies to both deployment modes: it bounds retained ReplicaSets in ReplicaSet mode
+                  and retained Knative Configurations in Knative mode. Versions past the limit are
+                  deregistered from Restate and removed once they have drained.
+
+                  In Knative mode a retained Configuration keeps running its `minScale` pods, because
+                  Knative cannot rescale an existing Revision, so lower this for services with a high
+                  `minScale` to avoid idle pods kept only for rollback.
                 format: int32
                 minimum: 0.0
                 type: integer

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -134,8 +134,16 @@ pub struct RestateDeploymentSpec {
     #[schemars(default = "default_replicas", range(min = 0))]
     pub replicas: i32,
 
-    /// The number of old ReplicaSets to retain to allow rollback. Defaults to 10.
-    /// Only used in ReplicaSet mode.
+    /// The number of old, fully drained versions to keep for rollback before the operator
+    /// deletes them. Defaults to 10.
+    ///
+    /// Applies to both deployment modes: it bounds retained ReplicaSets in ReplicaSet mode
+    /// and retained Knative Configurations in Knative mode. Versions past the limit are
+    /// deregistered from Restate and removed once they have drained.
+    ///
+    /// In Knative mode a retained Configuration keeps running its `minScale` pods, because
+    /// Knative cannot rescale an existing Revision, so lower this for services with a high
+    /// `minScale` to avoid idle pods kept only for rollback.
     #[schemars(default = "default_revision_history_limit", range(min = 0))]
     pub revision_history_limit: i32,
 


### PR DESCRIPTION
## What

Corrects the `spec.revisionHistoryLimit` documentation, which still says *"Only used in ReplicaSet mode"* even though the Knative reconciler now honours it.

## Why

While chasing idle pods from accumulated Knative revisions I filed #182, believing there was no operator-side retention for Knative Configurations. Reading `main` more carefully, that turned out to be wrong: `cleanup_old_configurations` already bounds retained Configurations with `spec.revision_history_limit` (added recently in `0459f15`, "Cleanup: fix deletion hang"):

```rust
// src/controllers/restatedeployment/reconcilers/knative.rs
if retain_for_rollback(mode, historic_count, rsd.spec.revision_history_limit) {
    historic_count += 1;
    // ... keep within limit
}
// else: deregister from Restate + delete the Configuration
```

The field doc, however, still reads *"The number of old ReplicaSets to retain to allow rollback. Only used in ReplicaSet mode."* That description is what led me (and I suspect others) to believe the limit does nothing in Knative mode, so old drained Configurations look unbounded.

## Change

Documentation only. Rewords the field on the struct and mirrors it into the generated `crd/restatedeployments.yaml` and `crd/RestateDeployment.pkl` to say it applies to **both** modes, and adds the Knative-specific caveat: a retained Configuration keeps running its `minScale` pods (Knative cannot rescale an existing Revision), so services with a high `minScale` should lower this to avoid idle pods held only for rollback.

## Note on generated files

I don't have `cargo` / `pkl` available in my environment, so `crd/restatedeployments.yaml` and `crd/RestateDeployment.pkl` were updated by hand to match the struct doc comment. Please run `just generate` / `just generate-pkl` to confirm the exact formatting matches. No Rust logic changed, so `cargo clippy` / `cargo test` are unaffected.

## Possible follow-up (not in this PR)

The default of `10` is cheap for ReplicaSets (scaled to zero) but expensive in Knative, where each retained Configuration holds `minScale` pods. A lower Knative default, or scaling non-latest retained Configurations down, might be worth considering. Happy to follow up if that's of interest.

Refs #182.
