### PR TITLE
pin shared workflow to older version, pre-breakage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,5 +7,9 @@ on:
 jobs:
   build-docker-image:
     name: Build docker image
-    uses: restatedev/restate/.github/workflows/docker.yml@main
+    # Pinned to the commit before restatedev/restate f2605af9 (#5111), which added a
+    # `cargo metadata | jq 'select(.name == "restate-server")'` step. This repo's package
+    # is restate-operator, so that step exits non-zero here and fails the release build.
+    # Return to @main once the shared workflow takes the package name as an input.
+    uses: restatedev/restate/.github/workflows/docker.yml@e80dfe702f256abe9f53711910caf73fba05c2fb
     secrets: inherit


### PR DESCRIPTION
in restatedev/restate#5111 a change was introduced to a shared workflow that is also used by this repo, and it breaks the release process in a [surprising way](https://github.com/restatedev/restate-operator/actions/runs/31701854497/job/94452668752). the workflow uses the cargo app name, which is of course different between restate and restate-operator.

i'll fix it properly "upstream" but i don't want to wait on a PR approval process in the restate repo, so here i'm pinning it. hence the verbose and temporary comment.