### PR TITLE
[WIP][1000% vibed] Add RestateKafkaIntegration CRD (restate.dev/v1alpha1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,12 +136,29 @@ RestateDeployment supports two modes (see `src/resources/restatedeployments.rs:2
 (`spec.restate.ingress`, the same `cluster`/`cloud`/`service`/`url` union as
 `RestateDeployment` but resolved to the *ingress* port 8080) and its credentials
 (`spec.restate.authToken`) are typed CRD fields. Everything Kafka-side is the container's own
-`.properties` surface, passed through inline (`spec.config`) or from a Secret/ConfigMap
-(`spec.configFrom`) -- so upstream config options need no CRD change. Do not add typed fields
-mirroring `CONFIGURATION.md` upstream; that was a deliberate design decision.
+`.properties` surface: `spec.config` (an inline block) plus `spec.configRefs` (a list of
+`secretRef` / `configMapRef` sources), which may be set together -- so upstream config options
+need no CRD change. Do not add typed fields mirroring `CONFIGURATION.md` upstream; that was a
+deliberate design decision.
 
-- The operator supplies `RESTATE_INGRESS_URL`, `RESTATE_AUTH_TOKEN` and `CONFIG_FILE` as env
-  vars, which the container prefers over the properties file.
+- **Config is a merged file list, not env vars.** The container's `CONFIG_FILE` is a
+  comma-separated list of `.properties` files merged left to right (later wins), and the
+  environment still wins over all files. The operator mounts each source as its own read-only
+  file under `/etc/restate-kafka/` and lists them in `CONFIG_FILE` in this order: its own
+  `restate.properties` (the resolved `restate.ingress.url`) *first* and lowest-precedence, then
+  `spec.config` as `config.properties`, then each `spec.configRefs` entry as
+  `config-<i>.properties` (`<i>` = list position). So `spec.config` can override the ingress
+  URL and a ref can override `spec.config`. There is no `RESTATE_INGRESS_URL` env var any more.
+- **The auth token stays in a Secret.** `spec.restate.authToken` is still injected as the
+  `RESTATE_AUTH_TOKEN` env var via a `secretKeyRef` (the operator never reads the Secret); it
+  must never be written into the plain-text ConfigMap / `.properties` files. There is no
+  file-based token property upstream, and env wins over files, so this is both necessary and
+  safe.
+- **The owned ConfigMap always exists** (it carries at least the ingress URL) and also holds
+  the inline `spec.config` under `config.properties`. Its digest is on the pod template, so
+  editing the ingress URL or `spec.config` rolls the pods; `spec.configRefs` are not read, so
+  they are not hashed (manual `kubectl rollout restart`). GC via owner reference tears the
+  ConfigMap down -- the operator never deletes it, so no `configmaps` `delete` RBAC.
 - `spec.template` is a *partial* pod template strategic-merged over the generated one
   (`src/controllers/restatekafkaintegration/merge.rs`). Absent overlay fields must stay absent:
   a `null` in the overlay deletes a key, so never serialize `None` into the overlay.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Kubernetes operator for [Restate](https://restate.dev/), written in Rust. The operator manages three main Custom Resource Definitions (CRDs):
+This is a Kubernetes operator for [Restate](https://restate.dev/), written in Rust. The operator manages four main Custom Resource Definitions (CRDs):
 - `RestateCluster` - Manages Restate server clusters with StatefulSets
 - `RestateDeployment` - Manages Restate SDK service deployments (similar to Kubernetes Deployments but with Restate-specific versioning)
 - `RestateCloudEnvironment` - Integrates with Restate Cloud environments
+- `RestateKafkaIntegration` - Runs the Kafka ingress integration container, consuming Kafka topics into Restate invocations (`restate.dev/v1alpha1`)
 
 The operator enforces network isolation by default, handles service versioning/draining, and supports both ReplicaSet and Knative Serving deployment modes.
 
@@ -88,10 +89,17 @@ just check
 
 ### Controller Structure
 
-The operator runs three concurrent controllers (see `src/main.rs:94-105`):
+The operator runs four concurrent controllers (see `src/main.rs`):
 1. **RestateCluster Controller** (`src/controllers/restatecluster/`) - Manages StatefulSets, Services, NetworkPolicies for Restate server clusters
 2. **RestateCloudEnvironment Controller** (`src/controllers/restatecloudenvironment/`) - Manages tunnel deployments for Restate Cloud integration
 3. **RestateDeployment Controller** (`src/controllers/restatedeployment/`) - Manages service deployments with versioning and draining
+4. **RestateKafkaIntegration Controller** (`src/controllers/restatekafkaintegration/`) - Manages the Kafka ingress integration Deployment (and its ConfigMap)
+
+Adding a controller means adding a `ReadinessGate` variant in `src/controllers/mod.rs` (the
+`ALL` array is fixed-size and indexed by discriminant, with a test enforcing the ordering), a
+`tokio::pin!` and a slot in the `tokio::join!` in `src/main.rs`, a `<name>_crdgen` /
+`<name>_schemagen` bin pair, a `justfile` generate line, a symlink under
+`charts/restate-operator-crds/crd-manifests/`, and RBAC.
 
 Each controller implements a reconciliation loop using the Kube-rs runtime.
 
@@ -101,6 +109,7 @@ CRD structs are defined in `src/resources/`:
 - `restateclusters.rs` - RestateCluster CRD
 - `restatedeployments.rs` - RestateDeployment CRD
 - `restatecloudenvironments.rs` - RestateCloudEnvironment CRD
+- `restatekafkaintegrations.rs` - RestateKafkaIntegration CRD
 - `knative.rs` - Knative Serving resource definitions
 
 Additional AWS-specific resources:
@@ -120,6 +129,26 @@ RestateDeployment supports two modes (see `src/resources/restatedeployments.rs:2
 - Same tag = in-place update (new Knative Revision within same Restate deployment)
 - Changed tag = versioned update (new Restate deployment ID)
 - No tag = template hash as tag (every template change creates new deployment)
+
+### RestateKafkaIntegration
+
+**Key Concept - pass-through configuration**: only the Restate destination
+(`spec.restate.ingress`, the same `cluster`/`cloud`/`service`/`url` union as
+`RestateDeployment` but resolved to the *ingress* port 8080) and its credentials
+(`spec.restate.authToken`) are typed CRD fields. Everything Kafka-side is the container's own
+`.properties` surface, passed through inline (`spec.config`) or from a Secret/ConfigMap
+(`spec.configFrom`) -- so upstream config options need no CRD change. Do not add typed fields
+mirroring `CONFIGURATION.md` upstream; that was a deliberate design decision.
+
+- The operator supplies `RESTATE_INGRESS_URL`, `RESTATE_AUTH_TOKEN` and `CONFIG_FILE` as env
+  vars, which the container prefers over the properties file.
+- `spec.template` is a *partial* pod template strategic-merged over the generated one
+  (`src/controllers/restatekafkaintegration/merge.rs`). Absent overlay fields must stay absent:
+  a `null` in the overlay deletes a key, so never serialize `None` into the overlay.
+- No finalizer: there is nothing to deregister, so owner references and GC are enough.
+- **NetworkPolicy gotcha**: reaching a `RestateCluster`'s ingress requires
+  `spec.security.networkPeers.ingress` on the cluster. The `allow.restate.dev/<cluster>` pod
+  label only governs the cluster's *egress*.
 
 ### Network Isolation
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,16 @@ doc = false
 name = "cloud_schemagen"
 path = "src/bin/cloud_schemagen.rs"
 
+[[bin]]
+doc = false
+name = "kafka_crdgen"
+path = "src/bin/kafka_crdgen.rs"
+
+[[bin]]
+doc = false
+name = "kafka_schemagen"
+path = "src/bin/kafka_schemagen.rs"
+
 [lib]
 name = "restate_operator"
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A Kubernetes operator that creates [Restate](https://restate.dev/) clusters. Sup
 - Sign requests using private keys from Secrets or CSI Secret Store
 - Deploy Restate SDK services using the `RestateDeployment` crd, the operator will manage their versions automatically, draining
   old versions when there are no longer invocations running against them.
+- Consume Kafka topics into Restate invocations using the `RestateKafkaIntegration` crd.
 
 ## Installation
 
@@ -64,7 +65,7 @@ so they and their custom resources are retained on `helm uninstall`.
 
 ## Custom Resource Definitions
 
-The operator introduces three Custom Resource Definitions (CRDs): `RestateCluster`, `RestateDeployment`, and `RestateCloudEnvironment`.
+The operator introduces four Custom Resource Definitions (CRDs): `RestateCluster`, `RestateDeployment`, `RestateCloudEnvironment`, and `RestateKafkaIntegration`.
 
 ### `RestateCluster`
 
@@ -814,6 +815,174 @@ A few things to be aware of:
   Consider a readiness probe that reflects tunnel establishment if you need tighter rollouts.
 - `tunnelMode: in-process` is not supported in Knative mode: the Knative autoscaler sees no
   inbound traffic for tunnel invocations, so scale-to-zero would never scale back up.
+
+### `RestateKafkaIntegration`
+
+The `RestateKafkaIntegration` CRD runs the
+[Restate Kafka ingress integration](https://github.com/restatedev/ingress-integration-kafka) --
+a standalone container that consumes Kafka topics and turns each record into a Restate
+invocation. The operator manages a `Deployment` of it in the custom resource's own namespace,
+resolves the Restate ingress URL from the reference you give it, and (for inline configuration)
+a `ConfigMap` to hold it.
+
+The CRD is `restate.dev/v1alpha1`; its shape may still change.
+
+Only the Restate destination and its credentials are modelled as fields. Everything else --
+the Kafka connection, consumer settings, the record mapper, metrics, retry policy -- is the
+container's own configuration surface, documented in
+[CONFIGURATION.md](https://github.com/restatedev/ingress-integration-kafka/blob/main/CONFIGURATION.md),
+and is passed straight through as a Java `.properties` file. That way a new option upstream is
+usable immediately, without waiting for a CRD change.
+
+#### Minimal Example
+
+```yaml
+apiVersion: restate.dev/v1alpha1
+kind: RestateKafkaIntegration
+metadata:
+  name: orders-to-restate
+spec:
+  replicas: 2
+  restate:
+    ingress:
+      cluster: restate
+  config: |
+    bootstrap.servers=kafka.kafka.svc.cluster.local:9092
+    group.id=orders-to-restate
+    topics=orders
+    restate.record.mapper.service=OrderService
+    restate.record.mapper.handler=onKafkaEvent
+```
+
+See [`examples/kafka`](./examples/kafka) for a runnable version, including a throwaway Kafka.
+
+#### Spec Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `restate` | `object` | **Required**. Where to send invocations, and how to authenticate. See details below. |
+| `replicas` | `integer` | Number of desired pods. Defaults to `1`. |
+| `image` | `string` | Container image. Defaults to the operator's built-in default (override cluster-wide with the `kafkaIntegrationImage` Helm value). |
+| `imagePullPolicy` | `string` | One of `Always`, `Never`, `IfNotPresent`. |
+| `config` | `string` | Inline `.properties` configuration. Mutually exclusive with `configFrom`. |
+| `configFrom` | `object` | Read the `.properties` configuration from a Secret or ConfigMap. Mutually exclusive with `config`. |
+| `template` | `object` | Overrides merged over the pod template the operator generates. See details below. |
+
+Throughput scales with replicas up to your topics' partition count -- Kafka distributes
+partitions across the whole consumer group, so replicas beyond that sit idle. Note each pod
+also runs `restate.kafka.consumer.instances` consumers of its own (default: twice its CPU
+count). `kubectl scale rki/<name> --replicas=N` works, as does pointing a
+`HorizontalPodAutoscaler` at the resource.
+
+#### `spec.restate`
+
+| Field | Type | Description |
+|---|---|---|
+| `ingress` | `object` | **Required**. Exactly one of `cluster`, `cloud`, `service` or `url`. |
+| `authToken` | `object` | A `{name, key}` reference to a Secret **in this namespace** holding a bearer token, passed to the container as `RESTATE_AUTH_TOKEN`. |
+
+**`ingress` Fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `cluster` | `string` | The name of a `RestateCluster`; resolves to `http://restate.<cluster>.svc.<clusterDns>:8080`. |
+| `cloud` | `string` | The name of a `RestateCloudEnvironment`; resolves to its public ingress. Requires `authToken`. |
+| `service` | `object` | A `{name, namespace, port, path}` reference to a Service. `port` defaults to `8080`. |
+| `url` | `string` | A Restate ingress URL. |
+
+The operator never reads the `authToken` Secret: it is referenced from the pod spec, so the
+kubelet resolves it. This is also why `cloud` needs one rather than reusing the
+`RestateCloudEnvironment`'s own credentials, which live in a Secret in the *operator's*
+namespace -- copying it into your namespace would mean granting the operator cluster-wide read
+access to Secrets.
+
+#### Configuration
+
+The container reads a `.properties` file and lets environment variables override it. The
+operator uses both layers:
+
+| Layer | Set by | Contents |
+|---|---|---|
+| `.properties` file at `/etc/restate-kafka/config.properties` | you | everything: `bootstrap.servers`, `group.id`, `topics`, `sasl.*`, `restate.record.mapper.*`, ... |
+| environment variables | the operator | `RESTATE_INGRESS_URL`, `RESTATE_AUTH_TOKEN`, `CONFIG_FILE` |
+| `spec.template` | you | anything else, applied last |
+
+Because environment variables win, `restate.ingress.url` and `restate.auth.token` in the
+properties file have no effect -- the operator owns the destination.
+
+**`spec.config`** is stored in a `ConfigMap` the operator owns, named after the custom
+resource. The pod template carries a digest of it, so editing `spec.config` rolls the pods.
+
+**`spec.configFrom`** takes exactly one of:
+
+| Field | Type | Description |
+|---|---|---|
+| `secretRef` | `object` | `{name, key}`; `key` defaults to `config.properties`. |
+| `configMapRef` | `object` | `{name, key}`; `key` defaults to `config.properties`. |
+
+Use `configFrom` with a Secret as soon as the configuration contains credentials:
+`spec.config` is part of the custom resource, so it is stored and displayed in plain text. The
+operator does not read the referenced object, so changing its contents does **not** restart the
+pods -- run `kubectl rollout restart deployment/<name>`.
+
+#### `spec.template`
+
+A partial pod template, strategic-merged over the one the operator generates. Objects merge
+key by key; lists whose Kubernetes merge key the operator knows (`containers`,
+`initContainers`, `volumes`, `env`, `volumeMounts`, `ports`, `imagePullSecrets`, `hostAliases`)
+merge entry by entry, so you can override one field without restating the rest. Any other list
+replaces the generated one, and an explicit `null` removes a generated field.
+
+The operator's container is named `kafka-integration`. Target it by name to set resources,
+probes, extra environment variables or volume mounts:
+
+```yaml
+  template:
+    spec:
+      containers:
+        - name: kafka-integration
+          resources:
+            requests: {cpu: 500m, memory: 512Mi}
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: -XX:MaxRAMPercentage=75
+```
+
+The pod labels the operator manages (`app.kubernetes.io/name`, `app.kubernetes.io/instance`)
+are re-applied after the merge, because a template whose labels no longer match the
+Deployment's immutable selector is rejected outright by the apiserver.
+
+The generated pod deliberately has **no readiness or liveness probe**: the image exposes no
+health endpoint, and it exits non-zero on unrecoverable errors (bad configuration, exhausted
+reconnect retries), so the restart policy is the real liveness mechanism. Add one via
+`spec.template` if you want one.
+
+Rollouts use `maxSurge: 0, maxUnavailable: 1`, since surging would add consumers to the group
+before the old ones leave and cost an extra Kafka rebalance.
+
+#### NetworkPolicy
+
+A `RestateCluster` denies **all** inbound traffic to its ingress port unless
+`spec.security.networkPeers.ingress` names a peer. The integration dials in to that port, so
+without a peer it will never connect -- and the failure looks like a hang, not a rejection.
+
+Add a peer selecting the integration's pods:
+
+```yaml
+kind: RestateCluster
+spec:
+  security:
+    networkPeers:
+      ingress:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: restate-kafka-integration
+```
+
+The operator also labels the pods `allow.restate.dev/<cluster-name>: "true"`, which is what
+the cluster's *egress* policy matches on; that label alone does not open ingress.
+
 
 ### EKS Pod Identity
 

--- a/README.md
+++ b/README.md
@@ -822,8 +822,8 @@ The `RestateKafkaIntegration` CRD runs the
 [Restate Kafka ingress integration](https://github.com/restatedev/ingress-integration-kafka) --
 a standalone container that consumes Kafka topics and turns each record into a Restate
 invocation. The operator manages a `Deployment` of it in the custom resource's own namespace,
-resolves the Restate ingress URL from the reference you give it, and (for inline configuration)
-a `ConfigMap` to hold it.
+resolves the Restate ingress URL from the reference you give it, and owns a `ConfigMap` holding
+that URL plus any inline configuration.
 
 The CRD is `restate.dev/v1alpha1`; its shape may still change.
 
@@ -864,8 +864,8 @@ See [`examples/kafka`](./examples/kafka) for a runnable version, including a thr
 | `replicas` | `integer` | Number of desired pods. Defaults to `1`. |
 | `image` | `string` | Container image. Defaults to the operator's built-in default (override cluster-wide with the `kafkaIntegrationImage` Helm value). |
 | `imagePullPolicy` | `string` | One of `Always`, `Never`, `IfNotPresent`. |
-| `config` | `string` | Inline `.properties` configuration. Mutually exclusive with `configFrom`. |
-| `configFrom` | `object` | Read the `.properties` configuration from a Secret or ConfigMap. Mutually exclusive with `config`. |
+| `config` | `string` | Inline `.properties` configuration. See details below. |
+| `configRefs` | `array` | Additional `.properties` sources (Secrets/ConfigMaps) merged on top of `config`, in order. See details below. |
 | `template` | `object` | Overrides merged over the pod template the operator generates. See details below. |
 
 Throughput scales with replicas up to your topics' partition count -- Kafka distributes
@@ -879,7 +879,7 @@ count). `kubectl scale rki/<name> --replicas=N` works, as does pointing a
 | Field | Type | Description |
 |---|---|---|
 | `ingress` | `object` | **Required**. Exactly one of `cluster`, `cloud`, `service` or `url`. |
-| `authToken` | `object` | A `{name, key}` reference to a Secret **in this namespace** holding a bearer token, passed to the container as `RESTATE_AUTH_TOKEN`. |
+| `authToken` | `object` | A `{name, key}` reference to a Secret **in this namespace** holding a bearer token, passed to the container as `RESTATE_AUTH_TOKEN`. The token stays in the Secret and never lands in a config file. |
 
 **`ingress` Fields**
 
@@ -898,32 +898,37 @@ access to Secrets.
 
 #### Configuration
 
-The container reads a `.properties` file and lets environment variables override it. The
-operator uses both layers:
+Everything Kafka-side -- `bootstrap.servers`, `group.id`, `topics`, `sasl.*`,
+`restate.record.mapper.*`, ... -- is the container's own `.properties` surface, given as two
+fields that layer:
 
-| Layer | Set by | Contents |
-|---|---|---|
-| `.properties` file at `/etc/restate-kafka/config.properties` | you | everything: `bootstrap.servers`, `group.id`, `topics`, `sasl.*`, `restate.record.mapper.*`, ... |
-| environment variables | the operator | `RESTATE_INGRESS_URL`, `RESTATE_AUTH_TOKEN`, `CONFIG_FILE` |
-| `spec.template` | you | anything else, applied last |
+- **`spec.config`** is an inline `.properties` block, stored in the custom resource.
+- **`spec.configRefs`** is a list of Secret/ConfigMap references, each setting exactly one of:
 
-Because environment variables win, `restate.ingress.url` and `restate.auth.token` in the
-properties file have no effect -- the operator owns the destination.
+  | Field | Type | Description |
+  |---|---|---|
+  | `secretRef` | `object` | `{name, key}` pointing at a Secret; `key` defaults to `config.properties`. |
+  | `configMapRef` | `object` | `{name, key}` pointing at a ConfigMap; `key` defaults to `config.properties`. |
 
-**`spec.config`** is stored in a `ConfigMap` the operator owns, named after the custom
-resource. The pod template carries a digest of it, so editing `spec.config` rolls the pods.
+Each source is mounted as its own read-only file under `/etc/restate-kafka/`, and the
+container's `CONFIG_FILE` lists them in merge order (later wins): the operator's own resolved
+`restate.ingress.url` first, then `spec.config`, then each `spec.configRefs` entry in order. So
+`spec.config` can override the ingress URL, and a ref can override `spec.config` -- e.g. a
+plain-text inline base with a `secretRef` overlay for credentials.
 
-**`spec.configFrom`** takes exactly one of:
+The Restate ingress **bearer token** is the exception: it goes in `spec.restate.authToken`,
+never in a config file, and reaches the container as the `RESTATE_AUTH_TOKEN` environment
+variable -- which the container prefers over any `restate.auth.token` in a file -- so it stays a
+Secret reference and never lands in plain text.
 
-| Field | Type | Description |
-|---|---|---|
-| `secretRef` | `object` | `{name, key}`; `key` defaults to `config.properties`. |
-| `configMapRef` | `object` | `{name, key}`; `key` defaults to `config.properties`. |
+`spec.config` lives in a `ConfigMap` the operator owns, named after the custom resource; the pod
+template carries a digest of that ConfigMap, so editing `spec.config` -- or a change to the
+resolved ingress URL -- rolls the pods. The operator does **not** read `spec.configRefs`
+objects, so changing their contents does not restart the pods -- run `kubectl rollout restart
+deployment/<name>`.
 
-Use `configFrom` with a Secret as soon as the configuration contains credentials:
-`spec.config` is part of the custom resource, so it is stored and displayed in plain text. The
-operator does not read the referenced object, so changing its contents does **not** restart the
-pods -- run `kubectl rollout restart deployment/<name>`.
+Keep credentials (`sasl.jaas.config`, `sasl.password`, ...) in a `spec.configRefs` Secret:
+`spec.config` is part of the custom resource, so it is stored and displayed in plain text.
 
 #### `spec.template`
 

--- a/charts/restate-operator-crds/crd-manifests/restatekafkaintegrations.yaml
+++ b/charts/restate-operator-crds/crd-manifests/restatekafkaintegrations.yaml
@@ -1,0 +1,1 @@
+../../../crd/restatekafkaintegrations.yaml

--- a/charts/restate-operator-helm/templates/deployment.yaml
+++ b/charts/restate-operator-helm/templates/deployment.yaml
@@ -86,6 +86,10 @@ spec:
             - name: CLUSTER_DNS
               value: {{ .Values.clusterDns }}
           {{- end }}
+          {{- if .Values.kafkaIntegrationImage }}
+            - name: OPERATOR_KAFKA_INTEGRATION_DEFAULT_IMAGE
+              value: {{ .Values.kafkaIntegrationImage }}
+          {{- end }}
           {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/charts/restate-operator-helm/templates/rbac.yaml
+++ b/charts/restate-operator-helm/templates/rbac.yaml
@@ -32,6 +32,9 @@ rules:
       - restatecloudenvironments
       - restatecloudenvironments/status
       - restatecloudenvironments/finalizers
+      - restatekafkaintegrations
+      - restatekafkaintegrations/status
+      - restatekafkaintegrations/finalizers
     verbs:
       - get
       - list
@@ -90,6 +93,29 @@ rules:
       - networking.k8s.io
       - vpcresources.k8s.aws
       - secrets-store.csi.x-k8s.io
+  # RestateKafkaIntegration owns a Deployment, and a ConfigMap when spec.config is used
+  # inline, in the RestateKafkaIntegration's own namespace. Unlike the RestateCloudEnvironment
+  # tunnel Deployment -- which always lands in the operator's namespace, and so is covered by
+  # the namespaced Role below -- those can be anywhere, hence a cluster-wide grant.
+  # ConfigMaps already have get/list/watch/create/patch above; only delete is missing, needed
+  # when a user switches from spec.config to spec.configFrom.
+  - resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - patch
+      - delete
+    apiGroups:
+      - apps
+  - resources:
+      - configmaps
+    verbs:
+      - delete
+    apiGroups:
+      - ''
   # Per-version autoscaling: the operator manages one HorizontalPodAutoscaler per
   # draining (non-latest) RestateDeployment version, and watches them (owns).
   - resources:

--- a/charts/restate-operator-helm/templates/rbac.yaml
+++ b/charts/restate-operator-helm/templates/rbac.yaml
@@ -93,12 +93,13 @@ rules:
       - networking.k8s.io
       - vpcresources.k8s.aws
       - secrets-store.csi.x-k8s.io
-  # RestateKafkaIntegration owns a Deployment, and a ConfigMap when spec.config is used
-  # inline, in the RestateKafkaIntegration's own namespace. Unlike the RestateCloudEnvironment
-  # tunnel Deployment -- which always lands in the operator's namespace, and so is covered by
-  # the namespaced Role below -- those can be anywhere, hence a cluster-wide grant.
-  # ConfigMaps already have get/list/watch/create/patch above; only delete is missing, needed
-  # when a user switches from spec.config to spec.configFrom.
+  # RestateKafkaIntegration owns a Deployment, and a ConfigMap (holding the resolved ingress
+  # location plus any inline spec.config entries), in the RestateKafkaIntegration's own
+  # namespace. Unlike the RestateCloudEnvironment tunnel Deployment -- which always lands in the
+  # operator's namespace, and so is covered by the namespaced Role below -- those can be
+  # anywhere, hence a cluster-wide grant. The ConfigMap always exists and is torn down by
+  # garbage collection through its owner reference, so the get/list/watch/create/patch grant
+  # above is enough -- the operator never deletes it itself.
   - resources:
       - deployments
     verbs:
@@ -110,12 +111,6 @@ rules:
       - delete
     apiGroups:
       - apps
-  - resources:
-      - configmaps
-    verbs:
-      - delete
-    apiGroups:
-      - ''
   # Per-version autoscaling: the operator manages one HorizontalPodAutoscaler per
   # draining (non-latest) RestateDeployment version, and watches them (owns).
   - resources:

--- a/charts/restate-operator-helm/values.yaml
+++ b/charts/restate-operator-helm/values.yaml
@@ -20,6 +20,7 @@ awsPodIdentityAssociationCluster: null
 gcpWorkloadIdentity: null
 clusterDns: null # defaults to "cluster.local" in the operator binary
 canaryImage: null # defaults to "alpine:3.21"; image must provide cat, grep, wget and a CA bundle at /etc/ssl/certs/ca-certificates.crt
+kafkaIntegrationImage: null # default image for RestateKafkaIntegration pods; defaults to "ghcr.io/restatedev/ingress-integration-kafka:latest" in the operator binary
 
 podSecurityContext:
   fsGroup: 2000

--- a/crd/pklgen/generate-kafka.pkl
+++ b/crd/pklgen/generate-kafka.pkl
@@ -1,0 +1,6 @@
+amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.crd@2.0.2::sha256:8e07ae25589d38613ce466d2af1cec7609721c34c7e7e5fe301e9efd4de2d462#/generate.pkl"
+
+source = "./crd/restatekafkaintegrations.yaml"
+
+// No converters: `spec.template` is a *partial* pod template merged over the one the operator
+// generates, so mapping it onto k8s' PodTemplateSpec would wrongly demand `containers`.

--- a/crd/restatekafkaintegrations.yaml
+++ b/crd/restatekafkaintegrations.yaml
@@ -46,74 +46,72 @@ spec:
 
               The operator only models where Restate is and how to authenticate to it; everything else
               (Kafka connection, consumer settings, record mapper, metrics, retry policy) is the
-              container's own configuration surface and is passed through verbatim as a `.properties`
-              file via `spec.config` or `spec.configFrom`.
+              container's own configuration surface and is passed through verbatim as one or more
+              `.properties` files via `spec.config`.
             properties:
               config:
                 description: |-
-                  Inline configuration for the integration, in Java `.properties` format. The operator
-                  stores this in a ConfigMap it owns, mounts it, and points the container's
-                  `CONFIG_FILE` at it. Editing it rolls the pods.
+                  Inline configuration for the integration, in Java `.properties` format.
 
                   Every option documented at
                   https://github.com/restatedev/ingress-integration-kafka/blob/main/CONFIGURATION.md
                   is accepted, using the property-key spelling (not the environment-variable one).
                   At a minimum the integration needs `bootstrap.servers`, `group.id` and `topics`.
 
-                  `restate.ingress.url` and `restate.auth.token` set here have no effect: the operator
-                  supplies both as environment variables, which the container prefers over the file.
+                  The operator stores this in a ConfigMap it owns and mounts it as a config file, merged
+                  after its own resolved `restate.ingress.url` (so this can override the ingress URL) and
+                  before `spec.configRefs` (so a ref can override this). Editing it rolls the pods.
 
-                  This is the CR's own body, so it is stored and displayed in plain text - keep
-                  credentials (`sasl.jaas.config`, `sasl.password`, ...) in `spec.configFrom` with a
-                  Secret instead.
-
-                  Mutually exclusive with `configFrom`.
+                  This is part of the custom resource, so it is stored and displayed in plain text - keep
+                  credentials (`sasl.jaas.config`, `sasl.password`, ...) in a `spec.configRefs` Secret,
+                  and the Restate ingress bearer token in `spec.restate.authToken`, never here.
                 nullable: true
                 type: string
-              configFrom:
+              configRefs:
                 description: |-
-                  Configuration for the integration, read from a Secret or ConfigMap in this namespace
-                  and mounted as the container's `CONFIG_FILE`. Use this rather than `config` when the
-                  configuration contains credentials.
+                  Additional configuration sources, read from Secrets or ConfigMaps in this namespace and
+                  merged on top of `spec.config` in order - a later ref overrides an earlier one, and any
+                  ref overrides `spec.config`.
 
-                  The operator does not read the referenced object, so changing its contents does not
-                  restart the pods; run `kubectl rollout restart deployment/<name>` to pick a change up.
-
-                  Mutually exclusive with `config`.
-                nullable: true
-                oneOf:
-                - required:
-                  - secretRef
-                - required:
-                  - configMapRef
-                properties:
-                  configMapRef:
-                    description: A ConfigMap in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified
-                    properties:
-                      key:
-                        description: The key to read the `.properties` configuration from. Defaults to `config.properties`.
-                        nullable: true
-                        type: string
-                      name:
-                        description: The name of the referenced object. It must be in the same namespace as this resource.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  secretRef:
-                    description: A Secret in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified
-                    properties:
-                      key:
-                        description: The key to read the `.properties` configuration from. Defaults to `config.properties`.
-                        nullable: true
-                        type: string
-                      name:
-                        description: The name of the referenced object. It must be in the same namespace as this resource.
-                        type: string
-                    required:
-                    - name
-                    type: object
-                type: object
+                  Each entry is a `secretRef` or a `configMapRef`; use a `secretRef` for anything
+                  sensitive. The operator does not read these objects, so changing their contents does not
+                  restart the pods; run `kubectl rollout restart deployment/<name>` afterwards.
+                items:
+                  description: 'One additional source of `.properties` configuration: a Secret key or a ConfigMap key'
+                  oneOf:
+                  - required:
+                    - secretRef
+                  - required:
+                    - configMapRef
+                  properties:
+                    configMapRef:
+                      description: A ConfigMap in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified
+                      properties:
+                        key:
+                          description: The key to read the `.properties` configuration from. Defaults to `config.properties`.
+                          nullable: true
+                          type: string
+                        name:
+                          description: The name of the referenced object. It must be in the same namespace as this resource.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    secretRef:
+                      description: A Secret in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified
+                      properties:
+                        key:
+                          description: The key to read the `.properties` configuration from. Defaults to `config.properties`.
+                          nullable: true
+                          type: string
+                        name:
+                          description: The name of the referenced object. It must be in the same namespace as this resource.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                  type: object
+                type: array
               image:
                 description: |-
                   Container image name. Defaults to a suggested version of
@@ -145,7 +143,11 @@ spec:
                   authToken:
                     description: |-
                       A Secret key in this namespace holding a bearer token for the Restate ingress,
-                      supplied to the container as `RESTATE_AUTH_TOKEN`.
+                      supplied to the container as the `RESTATE_AUTH_TOKEN` environment variable.
+
+                      This is where the token belongs: it stays in a Secret and is never written into the
+                      plain-text `.properties` files. The container prefers the environment variable over any
+                      `restate.auth.token` in a config file, so nothing in `spec.config` can shadow it.
 
                       Required when `ingress.cloud` is set; optional (and usually unnecessary) otherwise.
                       The operator never reads this Secret - it is referenced from the pod spec, so the
@@ -257,9 +259,6 @@ spec:
             required:
             - restate
             type: object
-            x-kubernetes-validations:
-            - message: only one of spec.config and spec.configFrom may be set
-              rule: '!(has(self.config) && has(self.configFrom))'
           status:
             description: |-
               Status of the RestateKafkaIntegration

--- a/crd/restatekafkaintegrations.yaml
+++ b/crd/restatekafkaintegrations.yaml
@@ -1,0 +1,345 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: restatekafkaintegrations.restate.dev
+spec:
+  group: restate.dev
+  names:
+    kind: RestateKafkaIntegration
+    plural: restatekafkaintegrations
+    shortNames:
+    - rki
+    singular: restatekafkaintegration
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.replicas
+      name: Desired
+      type: integer
+    - jsonPath: .status.readyReplicas
+      name: Ready
+      type: integer
+    - jsonPath: .status.availableReplicas
+      name: Available
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.ingressUrl
+      name: Ingress
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for RestateKafkaIntegrationSpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              RestateKafkaIntegration runs the Restate Kafka ingress integration
+              (`ghcr.io/restatedev/ingress-integration-kafka`), which consumes Kafka topics and turns
+              each record into a Restate invocation.
+
+              The operator only models where Restate is and how to authenticate to it; everything else
+              (Kafka connection, consumer settings, record mapper, metrics, retry policy) is the
+              container's own configuration surface and is passed through verbatim as a `.properties`
+              file via `spec.config` or `spec.configFrom`.
+            properties:
+              config:
+                description: |-
+                  Inline configuration for the integration, in Java `.properties` format. The operator
+                  stores this in a ConfigMap it owns, mounts it, and points the container's
+                  `CONFIG_FILE` at it. Editing it rolls the pods.
+
+                  Every option documented at
+                  https://github.com/restatedev/ingress-integration-kafka/blob/main/CONFIGURATION.md
+                  is accepted, using the property-key spelling (not the environment-variable one).
+                  At a minimum the integration needs `bootstrap.servers`, `group.id` and `topics`.
+
+                  `restate.ingress.url` and `restate.auth.token` set here have no effect: the operator
+                  supplies both as environment variables, which the container prefers over the file.
+
+                  This is the CR's own body, so it is stored and displayed in plain text - keep
+                  credentials (`sasl.jaas.config`, `sasl.password`, ...) in `spec.configFrom` with a
+                  Secret instead.
+
+                  Mutually exclusive with `configFrom`.
+                nullable: true
+                type: string
+              configFrom:
+                description: |-
+                  Configuration for the integration, read from a Secret or ConfigMap in this namespace
+                  and mounted as the container's `CONFIG_FILE`. Use this rather than `config` when the
+                  configuration contains credentials.
+
+                  The operator does not read the referenced object, so changing its contents does not
+                  restart the pods; run `kubectl rollout restart deployment/<name>` to pick a change up.
+
+                  Mutually exclusive with `config`.
+                nullable: true
+                oneOf:
+                - required:
+                  - secretRef
+                - required:
+                  - configMapRef
+                properties:
+                  configMapRef:
+                    description: A ConfigMap in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified
+                    properties:
+                      key:
+                        description: The key to read the `.properties` configuration from. Defaults to `config.properties`.
+                        nullable: true
+                        type: string
+                      name:
+                        description: The name of the referenced object. It must be in the same namespace as this resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  secretRef:
+                    description: A Secret in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified
+                    properties:
+                      key:
+                        description: The key to read the `.properties` configuration from. Defaults to `config.properties`.
+                        nullable: true
+                        type: string
+                      name:
+                        description: The name of the referenced object. It must be in the same namespace as this resource.
+                        type: string
+                    required:
+                    - name
+                    type: object
+                type: object
+              image:
+                description: |-
+                  Container image name. Defaults to a suggested version of
+                  ghcr.io/restatedev/ingress-integration-kafka.
+                nullable: true
+                type: string
+              imagePullPolicy:
+                description: |-
+                  Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest
+                  tag is specified, or IfNotPresent otherwise.
+                  More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                nullable: true
+                type: string
+              replicas:
+                default: 1
+                description: |-
+                  Number of desired pods. Defaults to 1.
+
+                  Kafka distributes the subscribed partitions across the whole consumer group, so
+                  throughput scales with replicas up to the partition count; replicas beyond that sit
+                  idle. Note that each pod itself runs `restate.kafka.consumer.instances` consumers
+                  (defaulting to twice the container's CPU count).
+                format: int32
+                minimum: 0.0
+                type: integer
+              restate:
+                description: Where to send the invocations produced from Kafka records, and how to authenticate.
+                properties:
+                  authToken:
+                    description: |-
+                      A Secret key in this namespace holding a bearer token for the Restate ingress,
+                      supplied to the container as `RESTATE_AUTH_TOKEN`.
+
+                      Required when `ingress.cloud` is set; optional (and usually unnecessary) otherwise.
+                      The operator never reads this Secret - it is referenced from the pod spec, so the
+                      kubelet resolves it.
+                    nullable: true
+                    properties:
+                      key:
+                        description: The key to read from the referenced Secret
+                        type: string
+                      name:
+                        description: The name of the referenced Secret. It must be in the same namespace as this resource.
+                        type: string
+                    required:
+                    - key
+                    - name
+                    type: object
+                  ingress:
+                    description: The location of the Restate ingress to send invocations to.
+                    oneOf:
+                    - required:
+                      - cluster
+                    - required:
+                      - cloud
+                    - required:
+                      - service
+                    - required:
+                      - url
+                    properties:
+                      cloud:
+                        description: The name of a RestateCloudEnvironment whose ingress to send invocations to. Requires `spec.restate.authToken`. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+                        type: string
+                      cluster:
+                        description: The name of a RestateCluster whose ingress to send invocations to. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+                        type: string
+                      service:
+                        description: A reference to a Service hosting the Restate ingress. If `port` is unset it defaults to 8080. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+                        properties:
+                          name:
+                            description: '`name` is the name of the service. Required'
+                            type: string
+                          namespace:
+                            description: '`namespace` is the namespace of the service. Required'
+                            type: string
+                          path:
+                            description: '`path` is an optional URL path which will be prepended before admin api paths. Should not end in a /.'
+                            nullable: true
+                            type: string
+                          port:
+                            description: If specified, the port on the service that hosts the admin api. Defaults to 9070. `port` should be a valid port number (1-65535, inclusive).
+                            format: int32
+                            maximum: 65535.0
+                            minimum: 1.0
+                            nullable: true
+                            type: integer
+                        required:
+                        - name
+                        - namespace
+                        type: object
+                      url:
+                        description: A url of the Restate ingress to send invocations to. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+                        type: string
+                    type: object
+                required:
+                - ingress
+                type: object
+              template:
+                description: |-
+                  Overrides applied on top of the pod template the operator generates.
+
+                  This is a partial pod template, strategic-merged over the generated one: objects are
+                  merged key by key, and lists whose Kubernetes merge key the operator knows
+                  (`containers`, `initContainers`, `volumes`, `env`, `volumeMounts`, `ports`,
+                  `imagePullSecrets`, `hostAliases`) are merged entry by entry, so you can override a
+                  single field without restating the rest. Any other list replaces the generated one,
+                  and an explicit `null` removes a generated field.
+
+                  The operator's own container is named `kafka-integration`; target it by name to set
+                  resources, probes, extra environment variables or volume mounts. The generated pod
+                  deliberately has no readiness or liveness probe (the image exposes no health endpoint
+                  and exits non-zero on unrecoverable errors), so add one here if you want one.
+                nullable: true
+                properties:
+                  metadata:
+                    description: Labels and annotations to merge into the generated pod template's metadata.
+                    nullable: true
+                    properties:
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations'
+                        nullable: true
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels'
+                        nullable: true
+                        type: object
+                    type: object
+                  spec:
+                    description: |-
+                      Pod spec fields to merge over the generated pod spec.
+
+                      Passed through verbatim, so it accepts any field the target Kubernetes version
+                      understands.
+                    nullable: true
+                    x-kubernetes-preserve-unknown-fields: true
+                type: object
+            required:
+            - restate
+            type: object
+            x-kubernetes-validations:
+            - message: only one of spec.config and spec.configFrom may be set
+              rule: '!(has(self.config) && has(self.configFrom))'
+          status:
+            description: |-
+              Status of the RestateKafkaIntegration
+              This is set and managed automatically by the controller
+            nullable: true
+            properties:
+              availableReplicas:
+                description: Total number of available pods (ready for at least minReadySeconds)
+                format: int32
+                nullable: true
+                type: integer
+              conditions:
+                description: Represents the latest available observations of current state
+                items:
+                  description: A condition of a RestateKafkaIntegration
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about last transition.
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition, known values are (`Ready`).
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              ingressUrl:
+                description: The resolved Restate ingress URL the integration was configured with
+                nullable: true
+                type: string
+              labelSelector:
+                description: The label selector of this RestateKafkaIntegration as a string, for the scale subresource
+                nullable: true
+                type: string
+              observedGeneration:
+                description: The generation observed by the controller
+                format: int64
+                nullable: true
+                type: integer
+              readyReplicas:
+                description: Total number of ready pods
+                format: int32
+                nullable: true
+                type: integer
+              replicas:
+                description: Total number of non-terminated pods targeted by this RestateKafkaIntegration
+                format: int32
+                type: integer
+              unavailableReplicas:
+                description: Total number of unavailable pods
+                format: int32
+                nullable: true
+                type: integer
+            required:
+            - replicas
+            type: object
+        required:
+        - spec
+        title: RestateKafkaIntegration
+        type: object
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.labelSelector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}

--- a/examples/kafka/README.md
+++ b/examples/kafka/README.md
@@ -1,0 +1,30 @@
+# Kafka ingress integration example
+
+Runs [`ingress-integration-kafka`](https://github.com/restatedev/ingress-integration-kafka)
+against a `RestateCluster` with a `RestateKafkaIntegration`, so records on a Kafka topic
+become Restate invocations.
+
+`kafka.yaml` is a throwaway single-broker KRaft Kafka for trying this out -- it is not a
+production Kafka deployment.
+
+```bash
+kubectl apply --server-side -f kafka.yaml
+kubectl apply --server-side -f cluster.yaml
+kubectl apply --server-side -f integration.yaml
+
+kubectl get rki -o wide
+kubectl logs -l app.kubernetes.io/name=restate-kafka-integration
+```
+
+## The NetworkPolicy bit
+
+A `RestateCluster` denies all inbound traffic to its ingress port (8080) unless
+`spec.security.networkPeers.ingress` names a peer. The integration dials *in* to that port,
+so without a peer it will simply never connect.
+
+`cluster.yaml` shows the peer to add: it selects pods labelled
+`app.kubernetes.io/name: restate-kafka-integration` in any namespace. The operator puts that
+label on the pods it creates, along with `allow.restate.dev/<cluster-name>` (which is what
+lets the cluster's *egress* policy reach back out).
+
+If your cluster sets `spec.security.disableNetworkPolicies: true`, none of this applies.

--- a/examples/kafka/cluster.yaml
+++ b/examples/kafka/cluster.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: restate.dev/v1
+kind: RestateCluster
+metadata:
+  name: restate
+spec:
+  compute:
+    image: restatedev/restate:1.7
+
+  storage:
+    # 2 GiB storage (sufficient for testing)
+    storageRequestBytes: 2147483648
+
+  security:
+    networkPeers:
+      # The Kafka integration connects in to the cluster's ingress port (8080). Without a
+      # peer here the operator's default deny-all NetworkPolicy drops those connections.
+      ingress:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: restate-kafka-integration

--- a/examples/kafka/integration.yaml
+++ b/examples/kafka/integration.yaml
@@ -1,0 +1,84 @@
+---
+# Minimal: everything Kafka-side lives in the inline .properties config.
+apiVersion: restate.dev/v1alpha1
+kind: RestateKafkaIntegration
+metadata:
+  name: orders-to-restate
+spec:
+  replicas: 2
+
+  restate:
+    ingress:
+      # A RestateCluster named `restate` serves its ingress at
+      # http://restate.restate.svc.cluster.local:8080
+      cluster: restate
+
+  config: |
+    bootstrap.servers=kafka.kafka.svc.cluster.local:9092
+    group.id=orders-to-restate
+    topics=orders
+
+    # Start from the beginning of the topic on a fresh consumer group, so records produced
+    # before this existed are not skipped.
+    auto.offset.reset=earliest
+
+    # Every record goes to Counter/add; the Kafka key becomes the virtual object key and the
+    # record value becomes the payload.
+    restate.record.mapper.service=Counter
+    restate.record.mapper.handler=add
+
+---
+# The same thing with the configuration in a Secret instead, which is what you want as soon
+# as it contains credentials (`sasl.jaas.config`, `sasl.password`, ...). `spec.config` is
+# part of the custom resource, so it is stored and displayed in plain text.
+#
+# Note the operator does not read this Secret, so editing it does not restart the pods --
+# run `kubectl rollout restart deployment/orders-to-restate-sasl` after a change.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kafka-config
+stringData:
+  config.properties: |
+    bootstrap.servers=broker.example:9093
+    group.id=orders-to-restate
+    topics=orders
+    security.protocol=SASL_SSL
+    sasl.mechanism=PLAIN
+    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="user" password="not-a-real-password";
+    restate.record.mapper.service=Counter
+    restate.record.mapper.handler=add
+
+---
+apiVersion: restate.dev/v1alpha1
+kind: RestateKafkaIntegration
+metadata:
+  name: orders-to-restate-sasl
+spec:
+  restate:
+    ingress:
+      cluster: restate
+
+  configFrom:
+    secretRef:
+      name: kafka-config
+      # `key` defaults to config.properties
+      key: config.properties
+
+  # Overrides merged over the pod template the operator generates. The operator's container
+  # is named `kafka-integration`; anything not mentioned here keeps the generated value.
+  template:
+    spec:
+      containers:
+        - name: kafka-integration
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              memory: 1Gi
+          env:
+            - name: JDK_JAVA_OPTIONS
+              value: -XX:MaxRAMPercentage=75
+      nodeSelector:
+        kubernetes.io/arch: arm64

--- a/examples/kafka/integration.yaml
+++ b/examples/kafka/integration.yaml
@@ -10,7 +10,8 @@ spec:
   restate:
     ingress:
       # A RestateCluster named `restate` serves its ingress at
-      # http://restate.restate.svc.cluster.local:8080
+      # http://restate.restate.svc.cluster.local:8080. The operator writes that URL into the
+      # first config file it mounts, so you never set restate.ingress.url yourself.
       cluster: restate
 
   config: |
@@ -28,26 +29,25 @@ spec:
     restate.record.mapper.handler=add
 
 ---
-# The same thing with the configuration in a Secret instead, which is what you want as soon
-# as it contains credentials (`sasl.jaas.config`, `sasl.password`, ...). `spec.config` is
-# part of the custom resource, so it is stored and displayed in plain text.
+# Mixing sources: an inline plain-text base, with credentials kept in a Secret referenced from
+# spec.configRefs. Anything sensitive (`sasl.jaas.config`, `sasl.password`, ...) belongs in a
+# ref, because spec.config is part of the custom resource and is stored and displayed in plain
+# text. configRefs are merged on top of config, in order, so the Secret wins on shared keys.
 #
-# Note the operator does not read this Secret, so editing it does not restart the pods --
+# The Restate ingress bearer token is different again: it goes in spec.restate.authToken, never
+# in a config file, so it stays a Secret reference and never touches the .properties surface.
+#
+# The operator does not read configRefs objects, so editing them does not restart the pods --
 # run `kubectl rollout restart deployment/orders-to-restate-sasl` after a change.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: kafka-config
+  name: kafka-credentials
 stringData:
   config.properties: |
-    bootstrap.servers=broker.example:9093
-    group.id=orders-to-restate
-    topics=orders
     security.protocol=SASL_SSL
     sasl.mechanism=PLAIN
     sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="user" password="not-a-real-password";
-    restate.record.mapper.service=Counter
-    restate.record.mapper.handler=add
 
 ---
 apiVersion: restate.dev/v1alpha1
@@ -59,11 +59,18 @@ spec:
     ingress:
       cluster: restate
 
-  configFrom:
-    secretRef:
-      name: kafka-config
-      # `key` defaults to config.properties
-      key: config.properties
+  config: |
+    bootstrap.servers=broker.example:9093
+    group.id=orders-to-restate
+    topics=orders
+    restate.record.mapper.service=Counter
+    restate.record.mapper.handler=add
+
+  configRefs:
+    - secretRef:
+        name: kafka-credentials
+        # `key` defaults to config.properties
+        key: config.properties
 
   # Overrides merged over the pod template the operator generates. The operator's container
   # is named `kafka-integration`; anything not mentioned here keeps the generated value.

--- a/examples/kafka/kafka.yaml
+++ b/examples/kafka/kafka.yaml
@@ -1,0 +1,80 @@
+---
+# A single-broker KRaft Kafka for trying the integration out. Ephemeral storage, no auth,
+# no replication -- do not use this for anything you care about.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kafka
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  clusterIP: None
+  selector:
+    app: kafka
+  ports:
+    - name: kafka
+      port: 9092
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  serviceName: kafka
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.5.0
+          ports:
+            - name: kafka
+              containerPort: 9092
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: broker,controller
+            - name: CLUSTER_ID
+              value: MkU3OEVBNTcwNTJENDM2Qk
+            - name: KAFKA_LISTENERS
+              value: PLAINTEXT://:9092,CONTROLLER://:9093
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: PLAINTEXT://kafka-0.kafka.kafka.svc.cluster.local:9092
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: PLAINTEXT
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: CONTROLLER
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: 1@kafka-0.kafka.kafka.svc.cluster.local:9093
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS
+              value: "0"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "true"
+            - name: KAFKA_LOG_DIRS
+              value: /var/lib/kafka/data
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/kafka
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/justfile
+++ b/justfile
@@ -67,6 +67,7 @@ generate:
   cargo run --bin cluster_crdgen | grep -vF 'categories: []' > crd/restateclusters.yaml
   cargo run --bin deployment_crdgen | grep -vF 'categories: []' > crd/restatedeployments.yaml
   cargo run --bin cloud_crdgen | grep -vF 'categories: []' > crd/restatecloudenvironments.yaml
+  cargo run --bin kafka_crdgen | grep -vF 'categories: []' > crd/restatekafkaintegrations.yaml
 
 # Regenerate the Pkl bindings (a convenience for Pkl users) from the CRD YAML. Requires `pkl`;
 # run `just generate` first so the YAML is current. The generator package is pinned by version and
@@ -75,9 +76,10 @@ generate-pkl: _check-pkl
   pkl eval crd/pklgen/generate-cluster.pkl -m crd
   pkl eval crd/pklgen/generate-deployment.pkl -m crd
   pkl eval crd/pklgen/generate-cloud.pkl -m crd
+  pkl eval crd/pklgen/generate-kafka.pkl -m crd
   # pkl resolves the relative `source` to an absolute file:// URI in the generated header comment;
   # rewrite it back to the repo-relative form so the committed files stay portable.
-  sed -i.bak -E 's#<file://[^ ]*/\./crd/#<file:./crd/#' crd/RestateCluster.pkl crd/RestateDeployment.pkl crd/RestateCloudEnvironment.pkl
+  sed -i.bak -E 's#<file://[^ ]*/\./crd/#<file:./crd/#' crd/RestateCluster.pkl crd/RestateDeployment.pkl crd/RestateCloudEnvironment.pkl crd/RestateKafkaIntegration.pkl
   rm -f crd/*.pkl.bak
 
 generate-examples: _check-pkl
@@ -87,6 +89,8 @@ generate-examples: _check-pkl
 install-crds: generate
   kubectl create -f crd/restateclusters.yaml
   kubectl create -f crd/restatedeployments.yaml
+  kubectl create -f crd/restatecloudenvironments.yaml
+  kubectl create -f crd/restatekafkaintegrations.yaml
 
 # Extract dependencies
 chef-prepare:

--- a/release-notes/unreleased/restate-kafka-integration.md
+++ b/release-notes/unreleased/restate-kafka-integration.md
@@ -8,7 +8,7 @@ A fourth CRD, `RestateKafkaIntegration` (`restate.dev/v1alpha1`, short name `rki
 [Restate Kafka ingress integration](https://github.com/restatedev/ingress-integration-kafka) --
 a container that consumes Kafka topics and turns each record into a Restate invocation. The
 operator manages an `apps/v1` `Deployment` of it in the custom resource's own namespace, and a
-`ConfigMap` when the configuration is given inline.
+`ConfigMap` holding the resolved ingress URL plus any inline configuration.
 
 ```yaml
 apiVersion: restate.dev/v1alpha1
@@ -35,13 +35,18 @@ Only the Restate destination is modelled as fields:
   than the admin port. A `RestateCluster` named `X` resolves to
   `http://restate.X.svc.<clusterDns>:8080`.
 - `spec.restate.authToken` is a `{name, key}` reference to a Secret **in the custom resource's
-  own namespace**, passed to the container as `RESTATE_AUTH_TOKEN`. It is required with
-  `ingress.cloud`, and optional otherwise.
+  own namespace**, passed to the container as the `RESTATE_AUTH_TOKEN` environment variable. It
+  is required with `ingress.cloud`, and optional otherwise. The token stays in the Secret and is
+  never written into a `.properties` file.
 
-Everything Kafka-side is the container's own configuration surface and is passed through
-verbatim as a Java `.properties` file, either inline (`spec.config`) or from a Secret or
-ConfigMap (`spec.configFrom`). `spec.template` is a partial pod template strategic-merged over
-the generated one, for resources, probes, sidecars, node placement and the like.
+Everything Kafka-side is the container's own configuration surface, given as `spec.config` (an
+inline `.properties` block) plus `spec.configRefs` (a list of `secretRef` / `configMapRef`
+sources). The container merges them -- the operator's own resolved `restate.ingress.url` first,
+then `spec.config`, then each `spec.configRefs` entry in order -- with a later source winning on
+shared keys. So you can mix a plain-text inline base with a `secretRef` overlay for credentials,
+and override the ingress URL if you must. `spec.template` is a partial pod template
+strategic-merged over the generated one, for resources, probes, sidecars, node placement and the
+like.
 
 ### Why This Matters
 
@@ -63,9 +68,11 @@ upstream option is usable the day it ships, instead of waiting for an operator r
   `RestateKafkaIntegration` as pending until the CRD is installed. Users who manage CRDs
   out-of-band must apply the new one, or the operator will stay `NotReady`.
 - **RBAC**: the operator now needs cluster-wide access to `apps/deployments`
-  (get/list/watch/create/patch/delete) and `delete` on `configmaps`, because these children
-  land in the user's namespace rather than the operator's. `helm upgrade` applies this; a
-  hand-managed ClusterRole needs updating.
+  (get/list/watch/create/patch/delete), because these children land in the user's namespace
+  rather than the operator's. The owned `ConfigMap` is covered by the existing cluster-wide
+  `configmaps` get/list/watch/create/patch grant (it is torn down by garbage collection, never
+  deleted by the operator). `helm upgrade` applies this; a hand-managed ClusterRole needs
+  updating.
 
 ### Migration Guidance
 

--- a/release-notes/unreleased/restate-kafka-integration.md
+++ b/release-notes/unreleased/restate-kafka-integration.md
@@ -1,0 +1,87 @@
+# Release Notes: `RestateKafkaIntegration` CRD
+
+## New Feature
+
+### What Changed
+
+A fourth CRD, `RestateKafkaIntegration` (`restate.dev/v1alpha1`, short name `rki`), runs the
+[Restate Kafka ingress integration](https://github.com/restatedev/ingress-integration-kafka) --
+a container that consumes Kafka topics and turns each record into a Restate invocation. The
+operator manages an `apps/v1` `Deployment` of it in the custom resource's own namespace, and a
+`ConfigMap` when the configuration is given inline.
+
+```yaml
+apiVersion: restate.dev/v1alpha1
+kind: RestateKafkaIntegration
+metadata:
+  name: orders-to-restate
+spec:
+  replicas: 2
+  restate:
+    ingress:
+      cluster: restate
+  config: |
+    bootstrap.servers=kafka.kafka.svc.cluster.local:9092
+    group.id=orders-to-restate
+    topics=orders
+    restate.record.mapper.service=OrderService
+    restate.record.mapper.handler=onKafkaEvent
+```
+
+Only the Restate destination is modelled as fields:
+
+- `spec.restate.ingress` is the same `cluster` / `cloud` / `service` / `url` union as
+  `RestateDeployment`'s `spec.restate.register`, resolved to the **ingress** port (8080) rather
+  than the admin port. A `RestateCluster` named `X` resolves to
+  `http://restate.X.svc.<clusterDns>:8080`.
+- `spec.restate.authToken` is a `{name, key}` reference to a Secret **in the custom resource's
+  own namespace**, passed to the container as `RESTATE_AUTH_TOKEN`. It is required with
+  `ingress.cloud`, and optional otherwise.
+
+Everything Kafka-side is the container's own configuration surface and is passed through
+verbatim as a Java `.properties` file, either inline (`spec.config`) or from a Secret or
+ConfigMap (`spec.configFrom`). `spec.template` is a partial pod template strategic-merged over
+the generated one, for resources, probes, sidecars, node placement and the like.
+
+### Why This Matters
+
+Running the integration by hand meant writing a `Deployment`, knowing the cluster's in-cluster
+ingress URL, and keeping the image tag in sync. This makes it a declarative resource that
+tracks the cluster it points at.
+
+Deliberately *not* mirroring the container's configuration options as CRD fields means a new
+upstream option is usable the day it ships, instead of waiting for an operator release.
+`spec.config` accepting property-key spelling (`auto.offset.reset`, not
+`KAFKA_AUTO_OFFSET_RESET`) also means the upstream documentation applies unchanged.
+
+### Impact on Users
+
+- **Existing deployments**: no change. Nothing reconciles differently, and the new controller
+  simply has nothing to do until a `RestateKafkaIntegration` exists.
+- **New deployments**: the CRD ships in the `restate-operator-crds` chart alongside the other
+  three, and the operator's readiness now also waits for it -- so `/ready` reports
+  `RestateKafkaIntegration` as pending until the CRD is installed. Users who manage CRDs
+  out-of-band must apply the new one, or the operator will stay `NotReady`.
+- **RBAC**: the operator now needs cluster-wide access to `apps/deployments`
+  (get/list/watch/create/patch/delete) and `delete` on `configmaps`, because these children
+  land in the user's namespace rather than the operator's. `helm upgrade` applies this; a
+  hand-managed ClusterRole needs updating.
+
+### Migration Guidance
+
+- Reinstall or upgrade the CRDs (`helm upgrade` with `installCrds: true`, or apply
+  `crd/restatekafkaintegrations.yaml` / the `restate-operator-crds` chart).
+- `helm upgrade` the operator chart to pick up the ClusterRole change.
+- Optionally set the `kafkaIntegrationImage` Helm value to pin the default image
+  (`OPERATOR_KAFKA_INTEGRATION_DEFAULT_IMAGE` / `--kafka-integration-default-image`); it
+  currently defaults to `ghcr.io/restatedev/ingress-integration-kafka:latest`, since upstream
+  has published no version tags yet.
+
+### Known Gotcha
+
+A `RestateCluster` denies all inbound traffic to its ingress port unless
+`spec.security.networkPeers.ingress` names a peer, and the integration dials *in* to that
+port. Without a peer it will never connect, and the failure presents as a hang. The operator
+labels the integration's pods `app.kubernetes.io/name: restate-kafka-integration` and
+`allow.restate.dev/<cluster-name>: "true"`; the former is what an ingress peer should select
+(the latter governs the cluster's egress). See `examples/kafka` and the README section.

--- a/src/bin/kafka_crdgen.rs
+++ b/src/bin/kafka_crdgen.rs
@@ -1,0 +1,11 @@
+use kube::CustomResourceExt;
+
+fn main() {
+    print!(
+        "{}",
+        serde_yaml::to_string(
+            &restate_operator::resources::restatekafkaintegrations::RestateKafkaIntegration::crd()
+        )
+        .unwrap()
+    )
+}

--- a/src/bin/kafka_schemagen.rs
+++ b/src/bin/kafka_schemagen.rs
@@ -1,0 +1,19 @@
+use schemars::JsonSchema;
+fn main() {
+    let mut generator = schemars::generate::SchemaSettings::openapi3()
+        .with(|s| {
+            s.inline_subschemas = true;
+            s.meta_schema = None;
+        })
+        .with_transform(kube::core::schema::StructuralSchemaRewriter)
+        .into_generator();
+    print!(
+        "{}",
+        serde_json::to_string_pretty(
+            &restate_operator::resources::restatekafkaintegrations::RestateKafkaIntegration::json_schema(
+                &mut generator
+            )
+        )
+        .unwrap()
+    )
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -20,6 +20,7 @@ use crate::Metrics;
 pub mod restatecloudenvironment;
 pub mod restatecluster;
 pub mod restatedeployment;
+pub mod restatekafkaintegration;
 
 /// How often each controller re-checks for its missing CRD, and how often the aggregate
 /// `WaitingForCRD` event is re-published while any are missing.
@@ -49,15 +50,17 @@ pub enum ReadinessGate {
     RestateCluster,
     RestateCloudEnvironment,
     RestateDeployment,
+    RestateKafkaIntegration,
 }
 
 impl ReadinessGate {
     /// Every gate. The order is the order flags are stored in [`Readiness`], so a gate's
     /// position here must match its discriminant; there is a test for that.
-    pub const ALL: [Self; 3] = [
+    pub const ALL: [Self; 4] = [
         Self::RestateCluster,
         Self::RestateCloudEnvironment,
         Self::RestateDeployment,
+        Self::RestateKafkaIntegration,
     ];
 
     fn name(self) -> &'static str {
@@ -65,6 +68,7 @@ impl ReadinessGate {
             Self::RestateCluster => "RestateCluster",
             Self::RestateCloudEnvironment => "RestateCloudEnvironment",
             Self::RestateDeployment => "RestateDeployment",
+            Self::RestateKafkaIntegration => "RestateKafkaIntegration",
         }
     }
 }
@@ -183,6 +187,9 @@ pub struct State {
     /// The default image to use for tunnel client pods
     tunnel_client_default_image: String,
 
+    /// The default image to use for Kafka integration pods
+    kafka_integration_default_image: String,
+
     /// The cluster DNS suffix (e.g. "cluster.local")
     pub cluster_dns: String,
 
@@ -205,6 +212,7 @@ impl State {
         operator_label_name: Option<String>,
         operator_label_value: Option<String>,
         tunnel_client_default_image: String,
+        kafka_integration_default_image: String,
         cluster_dns: String,
         canary_image: String,
         operator_pod_name: Option<String>,
@@ -229,6 +237,7 @@ impl State {
             operator_label_name,
             operator_label_value,
             tunnel_client_default_image,
+            kafka_integration_default_image,
             cluster_dns,
             canary_image,
             operator_object_ref,
@@ -657,7 +666,8 @@ mod tests {
             vec![
                 "RestateCluster",
                 "RestateCloudEnvironment",
-                "RestateDeployment"
+                "RestateDeployment",
+                "RestateKafkaIntegration"
             ]
         );
 
@@ -665,6 +675,9 @@ mod tests {
         // marking twice must not affect the other gates
         readiness.mark_ready(ReadinessGate::RestateCluster).await;
         readiness.mark_ready(ReadinessGate::RestateDeployment).await;
+        readiness
+            .mark_ready(ReadinessGate::RestateKafkaIntegration)
+            .await;
 
         let report = readiness.report().await;
         assert!(!report.ready);

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -945,6 +945,7 @@ mod tests {
                     None,
                     None,
                     "tunnel:latest".into(),
+                    "kafka-integration:latest".into(),
                     "cluster.local".into(),
                     "alpine:3.21".into(),
                     None,

--- a/src/controllers/restatekafkaintegration/controller.rs
+++ b/src/controllers/restatekafkaintegration/controller.rs
@@ -1,0 +1,507 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::Utc;
+use futures::StreamExt;
+use k8s_openapi::api::apps::v1::{Deployment, DeploymentStatus};
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+use kube::api::{Api, ObjectMeta, Patch, PatchParams};
+use kube::client::Client;
+use kube::runtime::WatchStreamExt;
+use kube::runtime::controller::{self, Action};
+use kube::runtime::events::{Event, EventType, Recorder};
+use kube::runtime::reflector::Store;
+use kube::runtime::watcher::Config;
+use kube::{Resource, ResourceExt};
+use serde_json::json;
+use tokio::sync::RwLock;
+use tracing::*;
+
+use crate::controllers::restatekafkaintegration::reconcilers;
+use crate::controllers::{CrdWait, Diagnostics, ReadinessGate, State, wait_for_crd};
+use crate::metrics::Metrics;
+use crate::resources::restatecloudenvironments::RestateCloudEnvironment;
+use crate::resources::restatekafkaintegrations::{
+    RestateKafkaIntegration, RestateKafkaIntegrationCondition, RestateKafkaIntegrationSpec,
+};
+use crate::telemetry;
+use crate::{Error, Result};
+
+/// How often a healthy RestateKafkaIntegration is re-reconciled, as a backstop for anything
+/// the watches miss.
+const REQUEUE_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// How long to wait before looking again at a Deployment that is not yet available.
+const NOT_READY_REQUEUE_INTERVAL: Duration = Duration::from_secs(10);
+
+pub(super) struct Context {
+    /// Kubernetes client
+    pub client: Client,
+    /// Kubernetes event recorder
+    pub recorder: Recorder,
+    /// Cache of RestateCloudEnvironments, for `spec.restate.ingress.cloud`
+    pub rce_store: Store<RestateCloudEnvironment>,
+    /// The cluster DNS suffix (e.g. "cluster.local")
+    pub cluster_dns: String,
+    /// The default image to use for Kafka integration pods
+    pub kafka_integration_default_image: String,
+    /// Diagnostics read by the web server
+    pub diagnostics: Arc<RwLock<Diagnostics>>,
+    /// Prometheus metrics
+    pub metrics: Metrics,
+}
+
+impl Context {
+    pub fn new(
+        client: Client,
+        rce_store: Store<RestateCloudEnvironment>,
+        metrics: Metrics,
+        state: State,
+    ) -> Arc<Context> {
+        Arc::new(Context {
+            client: client.clone(),
+            recorder: Recorder::new(client, "restate-operator".into()),
+            rce_store,
+            cluster_dns: state.cluster_dns.clone(),
+            kafka_integration_default_image: state.kafka_integration_default_image.clone(),
+            metrics,
+            diagnostics: state.diagnostics.clone(),
+        })
+    }
+}
+
+#[instrument(skip(ctx, rki), fields(trace_id))]
+async fn reconcile(rki: Arc<RestateKafkaIntegration>, ctx: Arc<Context>) -> Result<Action> {
+    if let Some(trace_id) = telemetry::get_trace_id() {
+        Span::current().record("trace_id", field::display(&trace_id));
+    }
+    let _timer = ctx.metrics.count_and_measure::<RestateKafkaIntegration>();
+    ctx.diagnostics.write().await.last_event = Utc::now();
+
+    let namespace = match rki.metadata.namespace.as_deref() {
+        Some("") | None => "default",
+        Some(namespace) => namespace,
+    };
+
+    debug!(
+        "Reconciling RestateKafkaIntegration {} in namespace {namespace}",
+        rki.name_any()
+    );
+
+    // There is nothing to deregister on the Restate side when a RestateKafkaIntegration goes
+    // away -- the Deployment and ConfigMap are owned, so garbage collection is enough -- so
+    // unlike the other controllers this one needs no finalizer.
+    match rki.reconcile_status(ctx.clone(), namespace).await {
+        Ok(action) => Ok(action),
+        Err(err) => {
+            warn!("reconcile failed: {err:?}");
+
+            ctx.recorder
+                .publish(
+                    &Event {
+                        type_: EventType::Warning,
+                        reason: "FailedReconcile".into(),
+                        note: Some(err.to_string()),
+                        action: "Reconcile".into(),
+                        secondary: None,
+                    },
+                    &rki.object_ref(&()),
+                )
+                .await?;
+
+            ctx.metrics.reconcile_failure(rki.as_ref(), &err);
+            Err(err)
+        }
+    }
+}
+
+fn error_policy<K, C>(_rki: Arc<K>, _err: &Error, _ctx: C) -> Action {
+    Action::requeue(Duration::from_secs(30))
+}
+
+/// The `Ready` condition a reconcile outcome implies.
+struct ReadyCondition {
+    status: &'static str,
+    reason: &'static str,
+    message: String,
+}
+
+/// Whether a Deployment status means the integration is running.
+///
+/// `replicas: 0` is a legitimate configuration (a paused integration), and there is nothing
+/// unready about it, so it counts as ready.
+fn ready_condition(desired_replicas: i32, status: Option<&DeploymentStatus>) -> ReadyCondition {
+    let available = status
+        .and_then(|status| status.available_replicas)
+        .unwrap_or(0);
+
+    if desired_replicas == 0 {
+        return ReadyCondition {
+            status: "True",
+            reason: "ScaledToZero",
+            message: "Scaled to zero replicas".into(),
+        };
+    }
+
+    if available >= 1 {
+        ReadyCondition {
+            status: "True",
+            reason: "Available",
+            message: format!("{available}/{desired_replicas} replicas available"),
+        }
+    } else {
+        ReadyCondition {
+            status: "False",
+            reason: "DeploymentNotAvailable",
+            message: format!("{available}/{desired_replicas} replicas available"),
+        }
+    }
+}
+
+/// The condition reason to report for a failed reconcile.
+fn error_reason(err: &Error) -> &'static str {
+    match err {
+        Error::InvalidRestateConfig(_) => "InvalidConfiguration",
+        Error::RestateCloudEnvironmentNotFound(_) => "RestateCloudEnvironmentNotFound",
+        Error::KubeError(_) => "ApiCallFailed",
+        _ => "FailedReconcile",
+    }
+}
+
+/// Reject a `cloud` reference with no bearer token to go with it.
+///
+/// `cloud` speaks to Restate Cloud over the public internet, which always wants a token. The
+/// operator cannot supply one itself: the RestateCloudEnvironment's own credentials live in a
+/// Secret in the operator's namespace, and reaching across namespaces to copy it would need a
+/// cluster-wide grant on Secrets. Failing here gives a legible condition instead of pods that
+/// crash-loop on 401s.
+fn validate_auth_token(spec: &RestateKafkaIntegrationSpec) -> Result<()> {
+    if spec.restate.ingress.cloud.is_some() && spec.restate.auth_token.is_none() {
+        return Err(Error::InvalidRestateConfig(
+            "spec.restate.ingress.cloud requires spec.restate.authToken, a Secret key in this namespace holding a Restate Cloud API token".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+impl RestateKafkaIntegration {
+    /// Reconcile the children, returning the Deployment status and the ingress URL used.
+    async fn reconcile(
+        &self,
+        ctx: &Context,
+        namespace: &str,
+    ) -> Result<(Option<DeploymentStatus>, String)> {
+        let name = self.name_any();
+        let oref = self
+            .controller_owner_ref(&())
+            .expect("RestateKafkaIntegration should have a uid");
+
+        let mut annotations = self.annotations().clone();
+        // if this is set on the RestateKafkaIntegration, don't propagate it to the children
+        annotations.remove("kubectl.kubernetes.io/last-applied-configuration");
+
+        let base_metadata = ObjectMeta {
+            name: Some(name.clone()),
+            namespace: Some(namespace.to_owned()),
+            labels: Some(self.labels().clone()),
+            annotations: Some(annotations),
+            owner_references: Some(vec![oref]),
+            ..Default::default()
+        };
+
+        validate_auth_token(&self.spec)?;
+
+        let ingress_url = self
+            .spec
+            .restate
+            .ingress
+            .ingress_url(&ctx.rce_store, &ctx.cluster_dns)?;
+
+        // Created before the Deployment that mounts it, and removed only after the Deployment
+        // has stopped mounting it, so neither switch between `config` and `configFrom` leaves
+        // running pods pointing at an object that is not there.
+        if let Some(config) = self.spec.config.as_deref() {
+            reconcilers::config::apply_config_map(ctx, namespace, &base_metadata, config).await?;
+        }
+
+        let status = reconcilers::deployment::reconcile_deployment(
+            ctx,
+            namespace,
+            &base_metadata,
+            &self.spec,
+            ingress_url.as_str(),
+        )
+        .await?;
+
+        if self.spec.config.is_none() {
+            reconcilers::config::delete_config_map(ctx, namespace, &base_metadata).await?;
+        }
+
+        Ok((status, ingress_url.into()))
+    }
+
+    /// Run [`Self::reconcile`] and write the outcome to `status`.
+    ///
+    /// The status is written whether the reconcile succeeded or not, so a misconfigured
+    /// object says why on `kubectl get rki`, and the error is then returned so the caller
+    /// still records the failure and requeues.
+    async fn reconcile_status(&self, ctx: Arc<Context>, namespace: &str) -> Result<Action> {
+        let name = self.name_any();
+        let result = self.reconcile(&ctx, namespace).await;
+
+        let (action, deployment_status, ingress_url, condition) = match &result {
+            Ok((deployment_status, ingress_url)) => {
+                let condition = ready_condition(self.spec.replicas, deployment_status.as_ref());
+                let action = if condition.status == "True" {
+                    Action::requeue(REQUEUE_INTERVAL)
+                } else {
+                    Action::requeue(NOT_READY_REQUEUE_INTERVAL)
+                };
+                (
+                    Some(action),
+                    deployment_status.clone(),
+                    Some(ingress_url.clone()),
+                    condition,
+                )
+            }
+            Err(err) => (
+                None,
+                None,
+                None,
+                ReadyCondition {
+                    status: "False",
+                    reason: error_reason(err),
+                    message: err.to_string(),
+                },
+            ),
+        };
+
+        // Only move lastTransitionTime when the status actually flipped, so a flapping
+        // message does not look like a state change.
+        let previous = self
+            .status
+            .as_ref()
+            .and_then(|status| status.conditions.as_ref())
+            .and_then(|conditions| conditions.iter().find(|c| c.r#type == "Ready"));
+        let last_transition_time = match previous {
+            Some(previous) if previous.status == condition.status => {
+                previous.last_transition_time.clone()
+            }
+            _ => Some(Time(Utc::now())),
+        };
+
+        // This is a server-side apply, so a field we leave out (or set to null) is *removed*.
+        // A failed reconcile says nothing about the pods that are still running, so carry the
+        // last observed numbers forward rather than reporting zero replicas.
+        let previous_status = self.status.as_ref();
+        let observed = deployment_status.as_ref();
+        let status = json!({
+            "apiVersion": RestateKafkaIntegration::api_version(&()),
+            "kind": RestateKafkaIntegration::kind(&()),
+            "status": {
+                "replicas": observed
+                    .and_then(|s| s.replicas)
+                    .or_else(|| previous_status.map(|s| s.replicas))
+                    .unwrap_or(0),
+                "readyReplicas": observed
+                    .and_then(|s| s.ready_replicas)
+                    .or_else(|| previous_status.and_then(|s| s.ready_replicas)),
+                "availableReplicas": observed
+                    .and_then(|s| s.available_replicas)
+                    .or_else(|| previous_status.and_then(|s| s.available_replicas)),
+                "unavailableReplicas": observed
+                    .and_then(|s| s.unavailable_replicas)
+                    .or_else(|| previous_status.and_then(|s| s.unavailable_replicas)),
+                "observedGeneration": self.metadata.generation,
+                "ingressUrl": ingress_url
+                    .or_else(|| previous_status.and_then(|s| s.ingress_url.clone())),
+                "labelSelector": reconcilers::deployment::label_selector_string(&name),
+                "conditions": vec![RestateKafkaIntegrationCondition {
+                    last_transition_time,
+                    message: Some(condition.message),
+                    reason: Some(condition.reason.to_owned()),
+                    status: condition.status.to_owned(),
+                    r#type: "Ready".to_owned(),
+                }],
+            },
+        });
+
+        let rki_api: Api<RestateKafkaIntegration> = Api::namespaced(ctx.client.clone(), namespace);
+        let params = PatchParams::apply("restate-operator").force();
+        rki_api
+            .patch_status(&name, &params, &Patch::Apply(status))
+            .await?;
+
+        match (action, result) {
+            (Some(action), _) => Ok(action),
+            (None, Err(err)) => Err(err),
+            // unreachable: an action is produced for every Ok
+            (None, Ok(_)) => Ok(Action::requeue(REQUEUE_INTERVAL)),
+        }
+    }
+}
+
+/// Run the RestateKafkaIntegration controller
+pub async fn run(client: Client, metrics: Metrics, state: State) {
+    let rki: Api<RestateKafkaIntegration> = Api::all(client.clone());
+    let deployments: Api<Deployment> = Api::all(client.clone());
+    let config_maps: Api<ConfigMap> = Api::all(client.clone());
+    let rce: Api<RestateCloudEnvironment> = Api::all(client.clone());
+
+    match wait_for_crd::<RestateKafkaIntegration>(
+        ReadinessGate::RestateKafkaIntegration,
+        &client,
+        &metrics,
+        &state,
+    )
+    .await
+    {
+        Ok(CrdWait::Available) => {}
+        Ok(CrdWait::ShuttingDown) => return,
+        Err(e) => {
+            error!(
+                "Could not determine whether the RestateKafkaIntegration CRD is installed; {e:?}"
+            );
+            std::process::exit(1);
+        }
+    }
+
+    // all resources we create have this label
+    let cfg = Config::default().labels("app.kubernetes.io/managed-by=restate-operator");
+    // but RestateKafkaIntegration and RestateCloudEnvironment don't
+    let not_created_cfg = Config::default();
+
+    let (rce_store, rce_writer) = kube::runtime::reflector::store();
+    let rce_reflector = kube::runtime::reflector(
+        rce_writer,
+        kube::runtime::watcher(rce, not_created_cfg.clone()),
+    )
+    .touched_objects()
+    .default_backoff();
+
+    controller::Controller::new(rki, not_created_cfg)
+        .shutdown_on_signal()
+        .owns(deployments, cfg.clone())
+        .owns(config_maps, cfg)
+        // just so that this gets polled; we have no way to figure out which
+        // RestateKafkaIntegration may use an updated RestateCloudEnvironment
+        .watches_stream(rce_reflector, |_| std::iter::empty())
+        .run(
+            reconcile,
+            error_policy,
+            Context::new(client, rce_store, metrics, state),
+        )
+        .filter_map(|x| async move { Result::ok(x) })
+        .for_each(|_| futures::future::ready(()))
+        .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::apps::v1::DeploymentStatus;
+
+    fn status(available: Option<i32>) -> DeploymentStatus {
+        DeploymentStatus {
+            available_replicas: available,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn one_available_replica_is_ready() {
+        let condition = ready_condition(2, Some(&status(Some(1))));
+        assert_eq!(condition.status, "True");
+        assert_eq!(condition.reason, "Available");
+        assert_eq!(condition.message, "1/2 replicas available");
+    }
+
+    #[test]
+    fn no_available_replicas_is_not_ready() {
+        let condition = ready_condition(2, Some(&status(Some(0))));
+        assert_eq!(condition.status, "False");
+        assert_eq!(condition.reason, "DeploymentNotAvailable");
+    }
+
+    #[test]
+    fn a_missing_status_is_not_ready() {
+        assert_eq!(ready_condition(1, None).status, "False");
+    }
+
+    #[test]
+    fn scaled_to_zero_is_ready() {
+        let condition = ready_condition(0, Some(&status(None)));
+        assert_eq!(condition.status, "True");
+        assert_eq!(condition.reason, "ScaledToZero");
+    }
+
+    #[test]
+    fn error_reasons_are_specific_where_it_helps() {
+        assert_eq!(
+            error_reason(&Error::InvalidRestateConfig("bad".into())),
+            "InvalidConfiguration"
+        );
+        assert_eq!(
+            error_reason(&Error::RestateCloudEnvironmentNotFound("env".into())),
+            "RestateCloudEnvironmentNotFound"
+        );
+        assert_eq!(error_reason(&Error::InvalidBearerToken), "FailedReconcile");
+    }
+
+    fn spec(json: serde_json::Value) -> RestateKafkaIntegrationSpec {
+        serde_json::from_value(json).expect("spec deserializes")
+    }
+
+    #[test]
+    fn cloud_without_an_auth_token_is_rejected() {
+        let err = validate_auth_token(&spec(json!({
+            "replicas": 1,
+            "restate": {"ingress": {"cloud": "my-env"}}
+        })))
+        .expect_err("cloud needs a token");
+        assert!(
+            matches!(err, Error::InvalidRestateConfig(message) if message.contains("authToken"))
+        );
+    }
+
+    #[test]
+    fn cloud_with_an_auth_token_is_accepted() {
+        assert!(
+            validate_auth_token(&spec(json!({
+                "replicas": 1,
+                "restate": {
+                    "ingress": {"cloud": "my-env"},
+                    "authToken": {"name": "tok", "key": "k"}
+                }
+            })))
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn other_references_do_not_need_an_auth_token() {
+        for ingress in [
+            json!({"cluster": "my-cluster"}),
+            json!({"url": "http://restate:8080/"}),
+        ] {
+            assert!(
+                validate_auth_token(&spec(
+                    json!({"replicas": 1, "restate": {"ingress": ingress}})
+                ))
+                .is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn error_policy_requeues() {
+        let action = error_policy(
+            Arc::new(()),
+            &Error::InvalidRestateConfig("bad".into()),
+            Arc::new(()),
+        );
+        assert_eq!(action, Action::requeue(Duration::from_secs(30)));
+    }
+}

--- a/src/controllers/restatekafkaintegration/controller.rs
+++ b/src/controllers/restatekafkaintegration/controller.rs
@@ -219,12 +219,17 @@ impl RestateKafkaIntegration {
             .ingress
             .ingress_url(&ctx.rce_store, &ctx.cluster_dns)?;
 
-        // Created before the Deployment that mounts it, and removed only after the Deployment
-        // has stopped mounting it, so neither switch between `config` and `configFrom` leaves
-        // running pods pointing at an object that is not there.
-        if let Some(config) = self.spec.config.as_deref() {
-            reconcilers::config::apply_config_map(ctx, namespace, &base_metadata, config).await?;
-        }
+        // Applied before the Deployment that mounts it. The operator's ConfigMap always exists
+        // -- it carries at least the resolved ingress URL -- so there is nothing to delete when
+        // `spec.config` is empty; server-side apply prunes any inline keys that went away.
+        reconcilers::config::apply_config_map(
+            ctx,
+            namespace,
+            &base_metadata,
+            ingress_url.as_str(),
+            self.spec.config.as_deref(),
+        )
+        .await?;
 
         let status = reconcilers::deployment::reconcile_deployment(
             ctx,
@@ -234,10 +239,6 @@ impl RestateKafkaIntegration {
             ingress_url.as_str(),
         )
         .await?;
-
-        if self.spec.config.is_none() {
-            reconcilers::config::delete_config_map(ctx, namespace, &base_metadata).await?;
-        }
 
         Ok((status, ingress_url.into()))
     }

--- a/src/controllers/restatekafkaintegration/merge.rs
+++ b/src/controllers/restatekafkaintegration/merge.rs
@@ -161,8 +161,8 @@ mod tests {
     #[test]
     fn env_merges_by_name() {
         let base = json!({"containers": [{"name": "c", "env": [
-            {"name": "RESTATE_INGRESS_URL", "value": "http://restate:8080/"},
-            {"name": "CONFIG_FILE", "value": "/etc/config.properties"}
+            {"name": "RESTATE_AUTH_TOKEN", "valueFrom": {"secretKeyRef": {"name": "tok", "key": "k"}}},
+            {"name": "CONFIG_FILE", "value": "/etc/restate-kafka/restate.properties"}
         ]}]});
         let merged = strategic_merge(
             base,
@@ -174,7 +174,7 @@ mod tests {
         assert_eq!(
             merged,
             json!({"containers": [{"name": "c", "env": [
-                {"name": "RESTATE_INGRESS_URL", "value": "http://restate:8080/"},
+                {"name": "RESTATE_AUTH_TOKEN", "valueFrom": {"secretKeyRef": {"name": "tok", "key": "k"}}},
                 {"name": "CONFIG_FILE", "value": "/somewhere/else.properties"},
                 {"name": "JDK_JAVA_OPTIONS", "value": "-Xmx512m"}
             ]}]})

--- a/src/controllers/restatekafkaintegration/merge.rs
+++ b/src/controllers/restatekafkaintegration/merge.rs
@@ -1,0 +1,245 @@
+//! A small strategic-merge implementation for the pod template overlay.
+//!
+//! `RestateKafkaIntegration` generates its own pod template and lets the user overlay
+//! `spec.template` on top of it. A plain deep merge would be wrong for the lists Kubernetes
+//! treats as maps -- overriding a container's image would drop every other container, and
+//! setting one environment variable would drop the rest -- so lists whose Kubernetes merge
+//! key we know are merged entry by entry instead.
+//!
+//! This deliberately implements only the subset of strategic-merge-patch semantics that a
+//! pod template needs: recursive object merge, `null` deletes a key, known lists merge by
+//! their merge key, every other list replaces. `$patch` directives are not supported.
+
+use serde_json::{Map, Value};
+
+/// The Kubernetes merge key for the lists we merge entry by entry, keyed by field name.
+///
+/// Anything absent from this table is an "atomic" list in Kubernetes terms and is replaced
+/// wholesale by the overlay, which is also the safer default for a list we do not recognise.
+fn merge_key(field: &str) -> Option<&'static str> {
+    match field {
+        "containers"
+        | "initContainers"
+        | "ephemeralContainers"
+        | "volumes"
+        | "imagePullSecrets"
+        | "env" => Some("name"),
+        "volumeMounts" => Some("mountPath"),
+        "ports" => Some("containerPort"),
+        "hostAliases" => Some("ip"),
+        _ => None,
+    }
+}
+
+/// Merge `overlay` onto `base`, returning the result.
+///
+/// - two objects merge recursively, key by key
+/// - a `null` in the overlay removes the key from the base
+/// - two lists merge entry by entry when [`merge_key`] knows the field's merge key, matching
+///   entries by that key and appending overlay-only entries; otherwise the overlay replaces
+/// - anything else: the overlay replaces the base
+pub fn strategic_merge(base: Value, overlay: &Value) -> Value {
+    match (base, overlay) {
+        (Value::Object(base), Value::Object(overlay)) => {
+            Value::Object(merge_objects(base, overlay))
+        }
+        // Not both objects, so there is nothing structural to preserve.
+        (_, overlay) => overlay.clone(),
+    }
+}
+
+fn merge_objects(mut base: Map<String, Value>, overlay: &Map<String, Value>) -> Map<String, Value> {
+    for (key, overlay_value) in overlay {
+        if overlay_value.is_null() {
+            // An explicit null removes a generated field, rather than setting it to null:
+            // that is what lets a user drop, say, the operator's securityContext.
+            base.remove(key);
+            continue;
+        }
+
+        let merged = match (base.remove(key), overlay_value) {
+            (Some(Value::Object(base_value)), Value::Object(overlay_value)) => {
+                Value::Object(merge_objects(base_value, overlay_value))
+            }
+            (Some(Value::Array(base_items)), Value::Array(overlay_items)) => match merge_key(key) {
+                Some(merge_key) => Value::Array(merge_lists(base_items, overlay_items, merge_key)),
+                None => Value::Array(overlay_items.clone()),
+            },
+            (_, overlay_value) => overlay_value.clone(),
+        };
+
+        base.insert(key.clone(), merged);
+    }
+
+    base
+}
+
+/// Merge two lists whose entries are identified by `merge_key`.
+///
+/// Base order is preserved and overlay-only entries are appended, so an overlay that adds a
+/// sidecar does not reorder the operator's own container.
+fn merge_lists(mut base: Vec<Value>, overlay: &[Value], merge_key: &str) -> Vec<Value> {
+    for overlay_item in overlay {
+        let key_value = overlay_item.get(merge_key);
+
+        // An entry without the merge key cannot be matched up, so it can only be appended.
+        let existing = key_value.and_then(|key_value| {
+            base.iter_mut()
+                .find(|base_item| base_item.get(merge_key) == Some(key_value))
+        });
+
+        match existing {
+            Some(base_item) => {
+                *base_item = strategic_merge(base_item.take(), overlay_item);
+            }
+            None => base.push(overlay_item.clone()),
+        }
+    }
+
+    base
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn scalars_and_missing_keys_are_taken_from_the_overlay() {
+        let merged = strategic_merge(
+            json!({"replicas": 1, "paused": false}),
+            &json!({"replicas": 3, "minReadySeconds": 5}),
+        );
+        assert_eq!(
+            merged,
+            json!({"replicas": 3, "paused": false, "minReadySeconds": 5})
+        );
+    }
+
+    #[test]
+    fn objects_merge_recursively() {
+        let merged = strategic_merge(
+            json!({"securityContext": {"runAsUser": 1000, "fsGroup": 2000}}),
+            &json!({"securityContext": {"runAsUser": 65534}}),
+        );
+        assert_eq!(
+            merged,
+            json!({"securityContext": {"runAsUser": 65534, "fsGroup": 2000}})
+        );
+    }
+
+    #[test]
+    fn null_removes_a_generated_field() {
+        let merged = strategic_merge(
+            json!({"automountServiceAccountToken": false, "securityContext": {"runAsUser": 1000}}),
+            &json!({"securityContext": null}),
+        );
+        assert_eq!(merged, json!({"automountServiceAccountToken": false}));
+    }
+
+    #[test]
+    fn containers_merge_by_name_without_dropping_the_others() {
+        let base = json!({"containers": [
+            {"name": "kafka-integration", "image": "upstream:1", "ports": [{"containerPort": 9464, "name": "metrics"}]}
+        ]});
+        let merged = strategic_merge(
+            base,
+            &json!({"containers": [
+                {"name": "kafka-integration", "image": "mine:2"},
+                {"name": "sidecar", "image": "sidecar:1"}
+            ]}),
+        );
+        assert_eq!(
+            merged,
+            json!({"containers": [
+                {"name": "kafka-integration", "image": "mine:2", "ports": [{"containerPort": 9464, "name": "metrics"}]},
+                {"name": "sidecar", "image": "sidecar:1"}
+            ]})
+        );
+    }
+
+    #[test]
+    fn env_merges_by_name() {
+        let base = json!({"containers": [{"name": "c", "env": [
+            {"name": "RESTATE_INGRESS_URL", "value": "http://restate:8080/"},
+            {"name": "CONFIG_FILE", "value": "/etc/config.properties"}
+        ]}]});
+        let merged = strategic_merge(
+            base,
+            &json!({"containers": [{"name": "c", "env": [
+                {"name": "CONFIG_FILE", "value": "/somewhere/else.properties"},
+                {"name": "JDK_JAVA_OPTIONS", "value": "-Xmx512m"}
+            ]}]}),
+        );
+        assert_eq!(
+            merged,
+            json!({"containers": [{"name": "c", "env": [
+                {"name": "RESTATE_INGRESS_URL", "value": "http://restate:8080/"},
+                {"name": "CONFIG_FILE", "value": "/somewhere/else.properties"},
+                {"name": "JDK_JAVA_OPTIONS", "value": "-Xmx512m"}
+            ]}]})
+        );
+    }
+
+    #[test]
+    fn volumes_and_mounts_merge_by_their_own_keys() {
+        let base = json!({
+            "volumes": [{"name": "config", "configMap": {"name": "generated"}}],
+            "containers": [{"name": "c", "volumeMounts": [
+                {"name": "config", "mountPath": "/etc/restate-kafka/config.properties", "readOnly": true}
+            ]}]
+        });
+        let merged = strategic_merge(
+            base,
+            &json!({
+                "volumes": [{"name": "extra-libs", "emptyDir": {}}],
+                "containers": [{"name": "c", "volumeMounts": [
+                    {"mountPath": "/app/extra-libs", "name": "extra-libs"}
+                ]}]
+            }),
+        );
+        assert_eq!(
+            merged,
+            json!({
+                "volumes": [
+                    {"name": "config", "configMap": {"name": "generated"}},
+                    {"name": "extra-libs", "emptyDir": {}}
+                ],
+                "containers": [{"name": "c", "volumeMounts": [
+                    {"name": "config", "mountPath": "/etc/restate-kafka/config.properties", "readOnly": true},
+                    {"mountPath": "/app/extra-libs", "name": "extra-libs"}
+                ]}]
+            })
+        );
+    }
+
+    #[test]
+    fn unknown_lists_are_replaced_wholesale() {
+        let merged = strategic_merge(
+            json!({"tolerations": [{"key": "a", "operator": "Exists"}]}),
+            &json!({"tolerations": [{"key": "b", "operator": "Exists"}]}),
+        );
+        assert_eq!(
+            merged,
+            json!({"tolerations": [{"key": "b", "operator": "Exists"}]})
+        );
+    }
+
+    #[test]
+    fn a_list_entry_without_the_merge_key_is_appended() {
+        let merged = strategic_merge(
+            json!({"containers": [{"name": "c", "image": "i"}]}),
+            &json!({"containers": [{"image": "anonymous"}]}),
+        );
+        assert_eq!(
+            merged,
+            json!({"containers": [{"name": "c", "image": "i"}, {"image": "anonymous"}]})
+        );
+    }
+
+    #[test]
+    fn a_list_replacing_a_scalar_just_wins() {
+        let merged = strategic_merge(json!({"env": "nonsense"}), &json!({"env": []}));
+        assert_eq!(merged, json!({"env": []}));
+    }
+}

--- a/src/controllers/restatekafkaintegration/mod.rs
+++ b/src/controllers/restatekafkaintegration/mod.rs
@@ -1,0 +1,5 @@
+pub mod controller;
+pub(crate) mod merge;
+mod reconcilers;
+
+pub use controller::run;

--- a/src/controllers/restatekafkaintegration/reconcilers/config.rs
+++ b/src/controllers/restatekafkaintegration/reconcilers/config.rs
@@ -1,0 +1,113 @@
+use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, DeleteParams, Patch, PatchParams};
+use sha2::Digest;
+use std::collections::BTreeMap;
+use tracing::debug;
+
+use super::object_meta;
+use crate::Error;
+use crate::controllers::restatekafkaintegration::controller::Context;
+use crate::resources::restatekafkaintegrations::CONFIG_FILE_KEY;
+
+/// The annotation carrying a digest of the inline `spec.config`.
+///
+/// Kubernetes does not restart pods when a mounted ConfigMap changes, so without this an
+/// edit to `spec.config` would only reach the pods on their next unrelated restart. Putting
+/// the digest on the pod template makes an edit a template change, which rolls them.
+pub const CONFIG_HASH_ANNOTATION: &str = "restate.dev/config-hash";
+
+pub fn config_hash(config: &str) -> String {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(config.as_bytes());
+    // Truncated to 8 bytes: this only has to distinguish revisions of one object's config,
+    // and it keeps the annotation readable. Same idiom as the RestateCluster config hash.
+    let digest = u64::from_le_bytes(hasher.finalize()[..8].try_into().unwrap());
+    format!("{digest:016x}")
+}
+
+fn config_map(base_metadata: &ObjectMeta, config: &str) -> ConfigMap {
+    ConfigMap {
+        metadata: object_meta(base_metadata),
+        data: Some(BTreeMap::from_iter([(
+            CONFIG_FILE_KEY.to_owned(),
+            config.to_owned(),
+        )])),
+        ..Default::default()
+    }
+}
+
+/// Apply the ConfigMap backing an inline `spec.config`.
+pub async fn apply_config_map(
+    ctx: &Context,
+    namespace: &str,
+    base_metadata: &ObjectMeta,
+    config: &str,
+) -> Result<(), Error> {
+    let name = base_metadata.name.as_ref().unwrap();
+    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
+    let params: PatchParams = PatchParams::apply("restate-operator").force();
+
+    debug!("Applying ConfigMap {name} in namespace {namespace}");
+    cm_api
+        .patch(
+            name,
+            &params,
+            &Patch::Apply(&config_map(base_metadata, config)),
+        )
+        .await?;
+
+    Ok(())
+}
+
+/// Remove the ConfigMap backing an inline `spec.config`, if there is one.
+///
+/// Called when `spec.config` is unset, so that switching to `spec.configFrom` does not leave
+/// a stale object behind. Deleting the RestateKafkaIntegration itself is handled by the owner
+/// reference, not here.
+pub async fn delete_config_map(
+    ctx: &Context,
+    namespace: &str,
+    base_metadata: &ObjectMeta,
+) -> Result<(), Error> {
+    let name = base_metadata.name.as_ref().unwrap();
+    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
+
+    debug!("Ensuring ConfigMap {name} in namespace {namespace} is absent");
+    match cm_api.delete(name, &DeleteParams::default()).await {
+        Ok(_) => Ok(()),
+        Err(kube::Error::Api(err)) if err.code == 404 => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_hash_is_stable_and_content_addressed() {
+        let a = config_hash("bootstrap.servers=broker:9092\n");
+        assert_eq!(a, config_hash("bootstrap.servers=broker:9092\n"));
+        assert_ne!(a, config_hash("bootstrap.servers=broker:9093\n"));
+        assert_eq!(a.len(), 16);
+    }
+
+    #[test]
+    fn config_map_carries_the_config_under_the_well_known_key() {
+        let meta = ObjectMeta {
+            name: Some("orders".into()),
+            namespace: Some("apps".into()),
+            ..Default::default()
+        };
+        let cm = config_map(&meta, "group.id=orders\n");
+        assert_eq!(cm.metadata.name.as_deref(), Some("orders"));
+        assert_eq!(
+            cm.data
+                .unwrap()
+                .get("config.properties")
+                .map(String::as_str),
+            Some("group.id=orders\n")
+        );
+    }
+}

--- a/src/controllers/restatekafkaintegration/reconcilers/config.rs
+++ b/src/controllers/restatekafkaintegration/reconcilers/config.rs
@@ -1,6 +1,6 @@
 use k8s_openapi::api::core::v1::ConfigMap;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-use kube::api::{Api, DeleteParams, Patch, PatchParams};
+use kube::api::{Api, Patch, PatchParams};
 use sha2::Digest;
 use std::collections::BTreeMap;
 use tracing::debug;
@@ -8,43 +8,74 @@ use tracing::debug;
 use super::object_meta;
 use crate::Error;
 use crate::controllers::restatekafkaintegration::controller::Context;
-use crate::resources::restatekafkaintegrations::CONFIG_FILE_KEY;
+use crate::resources::restatekafkaintegrations::{CONFIG_FILE_KEY, RESTATE_CONFIG_KEY};
 
-/// The annotation carrying a digest of the inline `spec.config`.
+/// The annotation carrying a digest of the ConfigMap the operator owns.
 ///
-/// Kubernetes does not restart pods when a mounted ConfigMap changes, so without this an
-/// edit to `spec.config` would only reach the pods on their next unrelated restart. Putting
-/// the digest on the pod template makes an edit a template change, which rolls them.
+/// Kubernetes does not restart pods when a mounted ConfigMap changes, so without this an edit
+/// to the resolved ingress URL or to the inline `spec.config` would only reach the pods on
+/// their next unrelated restart. Putting the digest on the pod template makes such a change a
+/// template change, which rolls them. `spec.configRefs` are not covered: the operator does not
+/// read them, so it cannot digest their contents.
 pub const CONFIG_HASH_ANNOTATION: &str = "restate.dev/config-hash";
 
-pub fn config_hash(config: &str) -> String {
+/// The contents of the ConfigMap the operator owns: the resolved Restate ingress location under
+/// `restate.properties`, plus the inline `spec.config` under `config.properties` if there is
+/// any.
+///
+/// This is the exact data [`apply_config_map`] writes and [`config_hash`] digests, so an edit
+/// to either the ingress URL or the inline config changes the hash and rolls the pods.
+pub fn managed_config_data(ingress_url: &str, inline: Option<&str>) -> BTreeMap<String, String> {
+    let mut data = BTreeMap::from_iter([(
+        RESTATE_CONFIG_KEY.to_owned(),
+        format!("restate.ingress.url={ingress_url}\n"),
+    )]);
+
+    if let Some(inline) = inline {
+        data.insert(CONFIG_FILE_KEY.to_owned(), inline.to_owned());
+    }
+
+    data
+}
+
+pub fn config_hash(data: &BTreeMap<String, String>) -> String {
     let mut hasher = sha2::Sha256::new();
-    hasher.update(config.as_bytes());
+    // Length-prefixed so that, e.g., moving a `=` between key and value cannot collide. The
+    // BTreeMap iterates in key order, so the digest is stable across reconciles.
+    for (key, value) in data {
+        hasher.update((key.len() as u64).to_le_bytes());
+        hasher.update(key.as_bytes());
+        hasher.update((value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
     // Truncated to 8 bytes: this only has to distinguish revisions of one object's config,
     // and it keeps the annotation readable. Same idiom as the RestateCluster config hash.
     let digest = u64::from_le_bytes(hasher.finalize()[..8].try_into().unwrap());
     format!("{digest:016x}")
 }
 
-fn config_map(base_metadata: &ObjectMeta, config: &str) -> ConfigMap {
+fn config_map(base_metadata: &ObjectMeta, data: BTreeMap<String, String>) -> ConfigMap {
     ConfigMap {
         metadata: object_meta(base_metadata),
-        data: Some(BTreeMap::from_iter([(
-            CONFIG_FILE_KEY.to_owned(),
-            config.to_owned(),
-        )])),
+        data: Some(data),
         ..Default::default()
     }
 }
 
-/// Apply the ConfigMap backing an inline `spec.config`.
+/// Apply the ConfigMap the operator owns.
+///
+/// Always present, because it always carries at least the resolved `restate.ingress.url`, so
+/// there is nothing to delete when `spec.config` is empty - server-side apply removes the
+/// inline key if it went away.
 pub async fn apply_config_map(
     ctx: &Context,
     namespace: &str,
     base_metadata: &ObjectMeta,
-    config: &str,
+    ingress_url: &str,
+    inline: Option<&str>,
 ) -> Result<(), Error> {
     let name = base_metadata.name.as_ref().unwrap();
+    let data = managed_config_data(ingress_url, inline);
     let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
     let params: PatchParams = PatchParams::apply("restate-operator").force();
 
@@ -53,32 +84,11 @@ pub async fn apply_config_map(
         .patch(
             name,
             &params,
-            &Patch::Apply(&config_map(base_metadata, config)),
+            &Patch::Apply(&config_map(base_metadata, data)),
         )
         .await?;
 
     Ok(())
-}
-
-/// Remove the ConfigMap backing an inline `spec.config`, if there is one.
-///
-/// Called when `spec.config` is unset, so that switching to `spec.configFrom` does not leave
-/// a stale object behind. Deleting the RestateKafkaIntegration itself is handled by the owner
-/// reference, not here.
-pub async fn delete_config_map(
-    ctx: &Context,
-    namespace: &str,
-    base_metadata: &ObjectMeta,
-) -> Result<(), Error> {
-    let name = base_metadata.name.as_ref().unwrap();
-    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
-
-    debug!("Ensuring ConfigMap {name} in namespace {namespace} is absent");
-    match cm_api.delete(name, &DeleteParams::default()).await {
-        Ok(_) => Ok(()),
-        Err(kube::Error::Api(err)) if err.code == 404 => Ok(()),
-        Err(err) => Err(err.into()),
-    }
 }
 
 #[cfg(test)]
@@ -86,27 +96,53 @@ mod tests {
     use super::*;
 
     #[test]
-    fn config_hash_is_stable_and_content_addressed() {
-        let a = config_hash("bootstrap.servers=broker:9092\n");
-        assert_eq!(a, config_hash("bootstrap.servers=broker:9092\n"));
-        assert_ne!(a, config_hash("bootstrap.servers=broker:9093\n"));
-        assert_eq!(a.len(), 16);
+    fn managed_data_carries_the_ingress_url_and_inline_config() {
+        let with_inline = managed_config_data("http://restate:8080/", Some("group.id=orders\n"));
+        assert_eq!(
+            with_inline.get("restate.properties").map(String::as_str),
+            Some("restate.ingress.url=http://restate:8080/\n")
+        );
+        assert_eq!(
+            with_inline.get("config.properties").map(String::as_str),
+            Some("group.id=orders\n")
+        );
+
+        // with no inline config, only the ingress file is present
+        let without_inline = managed_config_data("http://restate:8080/", None);
+        assert_eq!(without_inline.len(), 1);
+        assert!(without_inline.contains_key("restate.properties"));
     }
 
     #[test]
-    fn config_map_carries_the_config_under_the_well_known_key() {
+    fn config_hash_is_stable_and_content_addressed() {
+        let a = managed_config_data("http://restate:8080/", Some("a=b\n"));
+        assert_eq!(config_hash(&a), config_hash(&a.clone()));
+        // a different ingress URL changes the hash
+        let b = managed_config_data("http://other:8080/", Some("a=b\n"));
+        assert_ne!(config_hash(&a), config_hash(&b));
+        // a different inline config changes the hash
+        let c = managed_config_data("http://restate:8080/", Some("a=c\n"));
+        assert_ne!(config_hash(&a), config_hash(&c));
+        assert_eq!(config_hash(&a).len(), 16);
+    }
+
+    #[test]
+    fn config_map_carries_the_managed_data() {
         let meta = ObjectMeta {
             name: Some("orders".into()),
             namespace: Some("apps".into()),
             ..Default::default()
         };
-        let cm = config_map(&meta, "group.id=orders\n");
+        let data = managed_config_data("http://restate:8080/", Some("group.id=orders\n"));
+        let cm = config_map(&meta, data);
         assert_eq!(cm.metadata.name.as_deref(), Some("orders"));
+        let cm_data = cm.data.unwrap();
         assert_eq!(
-            cm.data
-                .unwrap()
-                .get("config.properties")
-                .map(String::as_str),
+            cm_data.get("restate.properties").map(String::as_str),
+            Some("restate.ingress.url=http://restate:8080/\n")
+        );
+        assert_eq!(
+            cm_data.get("config.properties").map(String::as_str),
             Some("group.id=orders\n")
         );
     }

--- a/src/controllers/restatekafkaintegration/reconcilers/deployment.rs
+++ b/src/controllers/restatekafkaintegration/reconcilers/deployment.rs
@@ -2,16 +2,16 @@ use k8s_openapi::api::apps::v1::{
     Deployment, DeploymentSpec, DeploymentStatus, DeploymentStrategy, RollingUpdateDeployment,
 };
 use k8s_openapi::api::core::v1::{
-    ConfigMapVolumeSource, Container, ContainerPort, EnvVar, EnvVarSource, KeyToPath,
-    PodSecurityContext, PodSpec, PodTemplateSpec, SeccompProfile, SecretKeySelector,
-    SecretVolumeSource, SecurityContext, Volume, VolumeMount,
+    ConfigMapVolumeSource, Container, ContainerPort, EnvVar, EnvVarSource, PodSecurityContext,
+    PodSpec, PodTemplateSpec, SeccompProfile, SecretKeySelector, SecretVolumeSource,
+    SecurityContext, Volume, VolumeMount,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::api::{Api, ApiResource, DynamicObject, Patch, PatchParams};
 use serde_json::{Map, Value, json};
 use tracing::debug;
 
-use super::config::{CONFIG_HASH_ANNOTATION, config_hash};
+use super::config::{CONFIG_HASH_ANNOTATION, config_hash, managed_config_data};
 use super::{
     CONFIG_VOLUME_NAME, CONTAINER_NAME, METRICS_PORT, label_selector, object_meta, selector_labels,
 };
@@ -19,25 +19,19 @@ use crate::Error;
 use crate::controllers::restatekafkaintegration::controller::Context;
 use crate::controllers::restatekafkaintegration::merge::strategic_merge;
 use crate::resources::restatekafkaintegrations::{
-    CONFIG_FILE_KEY, CONFIG_FILE_PATH, ConfigSourceKind, RestateKafkaIntegrationSpec,
+    CONFIG_DIR, CONFIG_FILE_KEY, ConfigRef, ConfigRefKind, RESTATE_CONFIG_KEY,
+    RestateKafkaIntegrationSpec,
 };
-
-/// The subPath the config key is projected to inside the volume, so that the mount lands as a
-/// single file at [`CONFIG_FILE_PATH`] rather than turning its parent into a directory.
-const CONFIG_SUB_PATH: &str = "config.properties";
 
 /// The environment variables the operator owns.
 ///
-/// The container prefers environment variables over the `.properties` file, which is exactly
-/// what we want here: the operator decides where Restate is, and a stale `restate.ingress.url`
-/// left in a config file must not silently win. Users who really need to override one of these
-/// can do so from `spec.template`, which is merged last.
-fn env(spec: &RestateKafkaIntegrationSpec, ingress_url: &str) -> Vec<EnvVar> {
-    let mut env = vec![EnvVar {
-        name: "RESTATE_INGRESS_URL".into(),
-        value: Some(ingress_url.to_owned()),
-        value_from: None,
-    }];
+/// No `RESTATE_INGRESS_URL`: the operator writes `restate.ingress.url` into the first config
+/// file instead, so a `spec.config` entry can override it. `RESTATE_AUTH_TOKEN` stays an
+/// environment variable so the bearer token stays in a Secret and never lands in a plain-text
+/// config file; the container prefers it over any `restate.auth.token` in a file. `CONFIG_FILE`
+/// is the comma-separated list of files to merge, always at least the operator's own.
+fn env(spec: &RestateKafkaIntegrationSpec, config_file: &str) -> Vec<EnvVar> {
+    let mut env = Vec::new();
 
     if let Some(auth_token) = spec.restate.auth_token.as_ref() {
         env.push(EnvVar {
@@ -54,71 +48,117 @@ fn env(spec: &RestateKafkaIntegrationSpec, ingress_url: &str) -> Vec<EnvVar> {
         });
     }
 
-    if spec.config.is_some() || spec.config_from.is_some() {
-        env.push(EnvVar {
-            name: "CONFIG_FILE".into(),
-            value: Some(CONFIG_FILE_PATH.to_owned()),
-            value_from: None,
-        });
-    }
+    env.push(EnvVar {
+        name: "CONFIG_FILE".into(),
+        value: Some(config_file.to_owned()),
+        value_from: None,
+    });
 
     env
 }
 
-/// The volume projecting the `.properties` configuration, if there is any.
+/// The mounted file name for the `spec.configRefs` entry at `index`.
+fn config_ref_file_name(index: usize) -> String {
+    format!("config-{index}.properties")
+}
+
+/// The volumes, mounts and `CONFIG_FILE` value backing the merged `.properties` configuration.
 ///
-/// Inline `spec.config` comes from the ConfigMap the operator owns (named after the
-/// RestateKafkaIntegration); `spec.configFrom` comes from the user's own Secret or ConfigMap.
-fn config_volume(name: &str, spec: &RestateKafkaIntegrationSpec) -> Result<Option<Volume>, Error> {
-    let items = |key: &str| {
-        Some(vec![KeyToPath {
-            key: key.to_owned(),
-            mode: None,
-            path: CONFIG_SUB_PATH.to_owned(),
-        }])
+/// Every source lands as its own read-only file under [`CONFIG_DIR`], listed in `CONFIG_FILE`
+/// in the order the container should merge them (later wins):
+/// - `restate.properties`, the operator's resolved ingress location, *first*, so an inline
+///   `spec.config` or a `spec.configRefs` entry can override it. From the operator's ConfigMap.
+/// - the inline `spec.config`, if any, as `config.properties`. Also from the operator's
+///   ConfigMap (mounting the same volume a second time by `subPath`).
+/// - each `spec.configRefs` entry, in order, as `config-<i>.properties`, from the user's own
+///   Secret or ConfigMap.
+///
+/// A `subPath` mount is deliberate: it projects a single key to a single file (rather than
+/// turning the mount point into a directory), and it does not pick up ConfigMap/Secret updates
+/// live -- which is what we want, since the pods are rolled by the config-hash annotation
+/// instead.
+struct ConfigLayout {
+    volumes: Vec<Volume>,
+    volume_mounts: Vec<VolumeMount>,
+    config_file: String,
+}
+
+fn config_layout(
+    cm_name: &str,
+    inline: Option<&str>,
+    refs: &[ConfigRef],
+) -> Result<ConfigLayout, Error> {
+    let mount = |volume: &str, sub_path: &str, path: String| VolumeMount {
+        name: volume.to_owned(),
+        mount_path: path,
+        sub_path: Some(sub_path.to_owned()),
+        read_only: Some(true),
+        ..Default::default()
     };
 
-    let volume = match (spec.config.as_deref(), spec.config_from.as_ref()) {
-        (Some(_), None) => Volume {
-            name: CONFIG_VOLUME_NAME.into(),
-            config_map: Some(ConfigMapVolumeSource {
-                name: name.to_owned(),
-                items: items(CONFIG_FILE_KEY),
-                ..Default::default()
-            }),
+    // The operator's own ConfigMap, referenced once as a volume and mounted per key it carries
+    // (the ingress file, plus the inline config if there is any).
+    let restate_path = format!("{CONFIG_DIR}/{RESTATE_CONFIG_KEY}");
+    let mut volumes = vec![Volume {
+        name: CONFIG_VOLUME_NAME.into(),
+        config_map: Some(ConfigMapVolumeSource {
+            name: cm_name.to_owned(),
             ..Default::default()
-        },
-        (None, Some(config_from)) => match config_from.resolve()? {
-            ConfigSourceKind::Secret(secret) => Volume {
-                name: CONFIG_VOLUME_NAME.into(),
-                secret: Some(SecretVolumeSource {
-                    secret_name: Some(secret.name.clone()),
-                    items: items(secret.key()),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            ConfigSourceKind::ConfigMap(config_map) => Volume {
-                name: CONFIG_VOLUME_NAME.into(),
-                config_map: Some(ConfigMapVolumeSource {
-                    name: config_map.name.clone(),
-                    items: items(config_map.key()),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-        },
-        (None, None) => return Ok(None),
-        // The CRD's CEL rule rejects this, but an older apiserver or a hand-edited object
-        // could still get here, and silently picking one would be worse than saying so.
-        (Some(_), Some(_)) => {
-            return Err(Error::InvalidRestateConfig(
-                "only one of spec.config and spec.configFrom may be set".into(),
-            ));
-        }
-    };
+        }),
+        ..Default::default()
+    }];
+    let mut volume_mounts = vec![mount(
+        CONFIG_VOLUME_NAME,
+        RESTATE_CONFIG_KEY,
+        restate_path.clone(),
+    )];
+    let mut files = vec![restate_path];
 
-    Ok(Some(volume))
+    if inline.is_some() {
+        let path = format!("{CONFIG_DIR}/{CONFIG_FILE_KEY}");
+        volume_mounts.push(mount(CONFIG_VOLUME_NAME, CONFIG_FILE_KEY, path.clone()));
+        files.push(path);
+    }
+
+    for (index, config_ref) in refs.iter().enumerate() {
+        let volume = format!("{CONFIG_VOLUME_NAME}-{index}");
+        let target = format!("{CONFIG_DIR}/{}", config_ref_file_name(index));
+
+        let (volume_source, key) = match config_ref.resolve()? {
+            ConfigRefKind::Secret(secret) => (
+                Volume {
+                    name: volume.clone(),
+                    secret: Some(SecretVolumeSource {
+                        secret_name: Some(secret.name.clone()),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                secret.key(),
+            ),
+            ConfigRefKind::ConfigMap(config_map) => (
+                Volume {
+                    name: volume.clone(),
+                    config_map: Some(ConfigMapVolumeSource {
+                        name: config_map.name.clone(),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                },
+                config_map.key(),
+            ),
+        };
+
+        volumes.push(volume_source);
+        volume_mounts.push(mount(&volume, key, target.clone()));
+        files.push(target);
+    }
+
+    Ok(ConfigLayout {
+        volumes,
+        volume_mounts,
+        config_file: files.join(","),
+    })
 }
 
 /// Build the Deployment the operator wants, before the user's `spec.template` overlay.
@@ -143,21 +183,19 @@ fn base_deployment(
         pod_labels.insert(format!("allow.restate.dev/{cluster}"), "true".to_owned());
     }
 
+    // The operator's ConfigMap always exists (it carries at least the ingress URL), so the
+    // hash is always present; a change to the ingress URL or the inline config rolls the pods.
     let mut pod_annotations = metadata.annotations.clone().unwrap_or_default();
-    if let Some(config) = spec.config.as_deref() {
-        pod_annotations.insert(CONFIG_HASH_ANNOTATION.to_owned(), config_hash(config));
-    }
+    pod_annotations.insert(
+        CONFIG_HASH_ANNOTATION.to_owned(),
+        config_hash(&managed_config_data(ingress_url, spec.config.as_deref())),
+    );
 
-    let config_volume = config_volume(name, spec)?;
-    let volume_mounts = config_volume.as_ref().map(|_| {
-        vec![VolumeMount {
-            name: CONFIG_VOLUME_NAME.into(),
-            mount_path: CONFIG_FILE_PATH.into(),
-            sub_path: Some(CONFIG_SUB_PATH.into()),
-            read_only: Some(true),
-            ..Default::default()
-        }]
-    });
+    let ConfigLayout {
+        volumes,
+        volume_mounts,
+        config_file,
+    } = config_layout(name, spec.config.as_deref(), &spec.config_refs)?;
 
     Ok(Deployment {
         metadata,
@@ -189,7 +227,7 @@ fn base_deployment(
                         name: CONTAINER_NAME.into(),
                         image: Some(spec.image.as_deref().unwrap_or(default_image).to_owned()),
                         image_pull_policy: spec.image_pull_policy.clone(),
-                        env: Some(env(spec, ingress_url)),
+                        env: Some(env(spec, &config_file)),
                         ports: Some(vec![ContainerPort {
                             name: Some("metrics".into()),
                             container_port: METRICS_PORT,
@@ -200,7 +238,7 @@ fn base_deployment(
                             allow_privilege_escalation: Some(false),
                             ..Default::default()
                         }),
-                        volume_mounts,
+                        volume_mounts: Some(volume_mounts),
                         ..Default::default()
                     }],
                     security_context: Some(PodSecurityContext {
@@ -218,7 +256,7 @@ fn base_deployment(
                     // Long enough for in-flight records to finish and their offsets to be
                     // committed before the consumer is killed.
                     termination_grace_period_seconds: Some(60),
-                    volumes: config_volume.map(|volume| vec![volume]),
+                    volumes: Some(volumes),
                     ..Default::default()
                 }),
             },
@@ -388,26 +426,42 @@ mod tests {
         &deployment["spec"]["template"]["spec"]["containers"][0]
     }
 
+    const CLUSTER_URL: &str = "http://restate.my-cluster.svc.cluster.local:8080/";
+
     #[test]
-    fn the_ingress_url_and_defaults_are_set() {
+    fn the_ingress_file_and_defaults_are_set() {
         let deployment = built(&minimal(json!({})));
         let container = container(&deployment);
 
         assert_eq!(container["name"], "kafka-integration");
         assert_eq!(container["image"], "default-image:1");
+        // no RESTATE_INGRESS_URL env: the ingress URL is a config file now. With no config
+        // entries, CONFIG_FILE is just the operator's own file.
         assert_eq!(
             container["env"],
             json!([{
-                "name": "RESTATE_INGRESS_URL",
-                "value": "http://restate.my-cluster.svc.cluster.local:8080/"
+                "name": "CONFIG_FILE",
+                "value": "/etc/restate-kafka/restate.properties"
             }])
         );
-        // no config source, so no CONFIG_FILE, no volume and no mount
-        assert!(container.get("volumeMounts").is_none());
-        assert!(
-            deployment["spec"]["template"]["spec"]
-                .get("volumes")
-                .is_none()
+        // the operator's ConfigMap is always mounted, at the front of CONFIG_FILE
+        assert_eq!(
+            container["volumeMounts"],
+            json!([{
+                "name": "config",
+                "mountPath": "/etc/restate-kafka/restate.properties",
+                "subPath": "restate.properties",
+                "readOnly": true
+            }])
+        );
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["volumes"],
+            json!([{"name": "config", "configMap": {"name": "orders"}}])
+        );
+        // always hashed, because the ingress URL always lives in the ConfigMap
+        assert_eq!(
+            deployment["spec"]["template"]["metadata"]["annotations"]["restate.dev/config-hash"],
+            config_hash(&managed_config_data(CLUSTER_URL, None))
         );
         assert_eq!(deployment["spec"]["replicas"], 1);
         assert_eq!(
@@ -442,13 +496,15 @@ mod tests {
             json!({"restate": {"ingress": {"cloud": "my-env"}, "authToken": {"name": "tok", "key": "k"}}}),
         ));
         let env = &container(&deployment)["env"];
+        // the token stays a secretKeyRef env var, ahead of CONFIG_FILE; it never enters a file
         assert_eq!(
-            env[1],
+            env[0],
             json!({
                 "name": "RESTATE_AUTH_TOKEN",
                 "valueFrom": {"secretKeyRef": {"name": "tok", "key": "k"}}
             })
         );
+        assert_eq!(env[1]["name"], "CONFIG_FILE");
     }
 
     #[test]
@@ -456,80 +512,128 @@ mod tests {
         let deployment = built(&minimal(json!({"config": "group.id=orders\n"})));
         let container = container(&deployment);
 
+        // the ingress file is first, then the inline config, so the inline can override the URL
         assert_eq!(
-            container["env"][1],
-            json!({"name": "CONFIG_FILE", "value": "/etc/restate-kafka/config.properties"})
+            container["env"][0],
+            json!({
+                "name": "CONFIG_FILE",
+                "value": "/etc/restate-kafka/restate.properties,/etc/restate-kafka/config.properties"
+            })
         );
         assert_eq!(
             container["volumeMounts"],
-            json!([{
-                "name": "config",
-                "mountPath": "/etc/restate-kafka/config.properties",
-                "subPath": "config.properties",
-                "readOnly": true
-            }])
+            json!([
+                {
+                    "name": "config",
+                    "mountPath": "/etc/restate-kafka/restate.properties",
+                    "subPath": "restate.properties",
+                    "readOnly": true
+                },
+                {
+                    "name": "config",
+                    "mountPath": "/etc/restate-kafka/config.properties",
+                    "subPath": "config.properties",
+                    "readOnly": true
+                }
+            ])
         );
+        // inline config lives in the operator's ConfigMap, so it is the only config volume
         assert_eq!(
             deployment["spec"]["template"]["spec"]["volumes"],
-            json!([{
-                "name": "config",
-                "configMap": {
-                    "name": "orders",
-                    "items": [{"key": "config.properties", "path": "config.properties"}]
-                }
-            }])
+            json!([{"name": "config", "configMap": {"name": "orders"}}])
         );
         assert_eq!(
             deployment["spec"]["template"]["metadata"]["annotations"]["restate.dev/config-hash"],
-            config_hash("group.id=orders\n")
+            config_hash(&managed_config_data(CLUSTER_URL, Some("group.id=orders\n")))
         );
     }
 
     #[test]
-    fn config_from_a_secret_mounts_the_users_secret_and_is_not_hashed() {
+    fn a_config_ref_mounts_the_users_secret_after_the_operators() {
         let deployment = built(&minimal(
-            json!({"configFrom": {"secretRef": {"name": "kafka-config", "key": "kafka.properties"}}}),
+            json!({"configRefs": [{"secretRef": {"name": "kafka-config", "key": "kafka.properties"}}]}),
         ));
 
+        assert_eq!(
+            container(&deployment)["env"][0]["value"],
+            "/etc/restate-kafka/restate.properties,/etc/restate-kafka/config-0.properties"
+        );
+        // the operator's ConfigMap first, then a dedicated volume for the user's Secret
         assert_eq!(
             deployment["spec"]["template"]["spec"]["volumes"],
-            json!([{
-                "name": "config",
-                "secret": {
-                    "secretName": "kafka-config",
-                    "items": [{"key": "kafka.properties", "path": "config.properties"}]
-                }
-            }])
+            json!([
+                {"name": "config", "configMap": {"name": "orders"}},
+                {"name": "config-0", "secret": {"secretName": "kafka-config"}}
+            ])
         );
-        // we never read the Secret, so we cannot hash its contents
-        assert!(
-            deployment["spec"]["template"]["metadata"]["annotations"]
-                .get("restate.dev/config-hash")
-                .is_none()
-        );
-    }
-
-    #[test]
-    fn config_from_a_configmap_defaults_the_key() {
-        let deployment = built(&minimal(
-            json!({"configFrom": {"configMapRef": {"name": "kafka-config"}}}),
-        ));
         assert_eq!(
-            deployment["spec"]["template"]["spec"]["volumes"][0]["configMap"],
+            container(&deployment)["volumeMounts"][1],
             json!({
-                "name": "kafka-config",
-                "items": [{"key": "config.properties", "path": "config.properties"}]
+                "name": "config-0",
+                "mountPath": "/etc/restate-kafka/config-0.properties",
+                "subPath": "kafka.properties",
+                "readOnly": true
             })
         );
+        // the Secret contents are not hashed (we do not read them), so the hash matches the
+        // ingress-only hash: editing the Secret does not roll the pods
+        assert_eq!(
+            deployment["spec"]["template"]["metadata"]["annotations"]["restate.dev/config-hash"],
+            config_hash(&managed_config_data(CLUSTER_URL, None))
+        );
     }
 
     #[test]
-    fn both_config_sources_is_rejected() {
+    fn a_config_ref_to_a_configmap_defaults_the_key() {
+        let deployment = built(&minimal(
+            json!({"configRefs": [{"configMapRef": {"name": "kafka-config"}}]}),
+        ));
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["volumes"][1],
+            json!({"name": "config-0", "configMap": {"name": "kafka-config"}})
+        );
+        assert_eq!(
+            container(&deployment)["volumeMounts"][1]["subPath"],
+            "config.properties"
+        );
+    }
+
+    #[test]
+    fn config_and_refs_merge_in_order_after_the_ingress_file() {
+        let deployment = built(&minimal(json!({
+            "config": "group.id=orders\n",
+            "configRefs": [
+                {"secretRef": {"name": "creds"}},
+                {"configMapRef": {"name": "tuning"}}
+            ]
+        })));
+
+        // ingress, then inline config, then each ref in order
+        assert_eq!(
+            container(&deployment)["env"][0]["value"],
+            "/etc/restate-kafka/restate.properties,\
+             /etc/restate-kafka/config.properties,\
+             /etc/restate-kafka/config-0.properties,\
+             /etc/restate-kafka/config-1.properties"
+        );
+        // the operator volume (ingress + inline) plus one per ref
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["volumes"],
+            json!([
+                {"name": "config", "configMap": {"name": "orders"}},
+                {"name": "config-0", "secret": {"secretName": "creds"}},
+                {"name": "config-1", "configMap": {"name": "tuning"}}
+            ])
+        );
+    }
+
+    #[test]
+    fn a_config_ref_with_two_sources_is_rejected() {
         let spec = minimal(json!({
-            "config": "a=b\n",
-            "configFrom": {"secretRef": {"name": "s"}}
+            "configRefs": [{"secretRef": {"name": "s"}, "configMapRef": {"name": "c"}}]
         }));
-        let err = base_deployment(&meta(), &spec, "http://restate:8080/", "img").expect_err("both");
+        let err = base_deployment(&meta(), &spec, "http://restate:8080/", "img")
+            .expect_err("two sources");
         assert!(matches!(err, Error::InvalidRestateConfig(_)));
     }
 
@@ -550,7 +654,7 @@ mod tests {
         assert_eq!(container["image"], "mine:2");
         assert_eq!(container["resources"]["requests"]["cpu"], "500m");
         // the operator's own env survives, and the user's is appended
-        assert_eq!(container["env"][0]["name"], "RESTATE_INGRESS_URL");
+        assert_eq!(container["env"][0]["name"], "CONFIG_FILE");
         assert_eq!(container["env"][1]["name"], "JDK_JAVA_OPTIONS");
         // the generated port is untouched
         assert_eq!(container["ports"][0]["containerPort"], METRICS_PORT);

--- a/src/controllers/restatekafkaintegration/reconcilers/deployment.rs
+++ b/src/controllers/restatekafkaintegration/reconcilers/deployment.rs
@@ -1,0 +1,613 @@
+use k8s_openapi::api::apps::v1::{
+    Deployment, DeploymentSpec, DeploymentStatus, DeploymentStrategy, RollingUpdateDeployment,
+};
+use k8s_openapi::api::core::v1::{
+    ConfigMapVolumeSource, Container, ContainerPort, EnvVar, EnvVarSource, KeyToPath,
+    PodSecurityContext, PodSpec, PodTemplateSpec, SeccompProfile, SecretKeySelector,
+    SecretVolumeSource, SecurityContext, Volume, VolumeMount,
+};
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::api::{Api, ApiResource, DynamicObject, Patch, PatchParams};
+use serde_json::{Map, Value, json};
+use tracing::debug;
+
+use super::config::{CONFIG_HASH_ANNOTATION, config_hash};
+use super::{
+    CONFIG_VOLUME_NAME, CONTAINER_NAME, METRICS_PORT, label_selector, object_meta, selector_labels,
+};
+use crate::Error;
+use crate::controllers::restatekafkaintegration::controller::Context;
+use crate::controllers::restatekafkaintegration::merge::strategic_merge;
+use crate::resources::restatekafkaintegrations::{
+    CONFIG_FILE_KEY, CONFIG_FILE_PATH, ConfigSourceKind, RestateKafkaIntegrationSpec,
+};
+
+/// The subPath the config key is projected to inside the volume, so that the mount lands as a
+/// single file at [`CONFIG_FILE_PATH`] rather than turning its parent into a directory.
+const CONFIG_SUB_PATH: &str = "config.properties";
+
+/// The environment variables the operator owns.
+///
+/// The container prefers environment variables over the `.properties` file, which is exactly
+/// what we want here: the operator decides where Restate is, and a stale `restate.ingress.url`
+/// left in a config file must not silently win. Users who really need to override one of these
+/// can do so from `spec.template`, which is merged last.
+fn env(spec: &RestateKafkaIntegrationSpec, ingress_url: &str) -> Vec<EnvVar> {
+    let mut env = vec![EnvVar {
+        name: "RESTATE_INGRESS_URL".into(),
+        value: Some(ingress_url.to_owned()),
+        value_from: None,
+    }];
+
+    if let Some(auth_token) = spec.restate.auth_token.as_ref() {
+        env.push(EnvVar {
+            name: "RESTATE_AUTH_TOKEN".into(),
+            value: None,
+            value_from: Some(EnvVarSource {
+                secret_key_ref: Some(SecretKeySelector {
+                    name: auth_token.name.clone(),
+                    key: auth_token.key.clone(),
+                    optional: None,
+                }),
+                ..Default::default()
+            }),
+        });
+    }
+
+    if spec.config.is_some() || spec.config_from.is_some() {
+        env.push(EnvVar {
+            name: "CONFIG_FILE".into(),
+            value: Some(CONFIG_FILE_PATH.to_owned()),
+            value_from: None,
+        });
+    }
+
+    env
+}
+
+/// The volume projecting the `.properties` configuration, if there is any.
+///
+/// Inline `spec.config` comes from the ConfigMap the operator owns (named after the
+/// RestateKafkaIntegration); `spec.configFrom` comes from the user's own Secret or ConfigMap.
+fn config_volume(name: &str, spec: &RestateKafkaIntegrationSpec) -> Result<Option<Volume>, Error> {
+    let items = |key: &str| {
+        Some(vec![KeyToPath {
+            key: key.to_owned(),
+            mode: None,
+            path: CONFIG_SUB_PATH.to_owned(),
+        }])
+    };
+
+    let volume = match (spec.config.as_deref(), spec.config_from.as_ref()) {
+        (Some(_), None) => Volume {
+            name: CONFIG_VOLUME_NAME.into(),
+            config_map: Some(ConfigMapVolumeSource {
+                name: name.to_owned(),
+                items: items(CONFIG_FILE_KEY),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        (None, Some(config_from)) => match config_from.resolve()? {
+            ConfigSourceKind::Secret(secret) => Volume {
+                name: CONFIG_VOLUME_NAME.into(),
+                secret: Some(SecretVolumeSource {
+                    secret_name: Some(secret.name.clone()),
+                    items: items(secret.key()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+            ConfigSourceKind::ConfigMap(config_map) => Volume {
+                name: CONFIG_VOLUME_NAME.into(),
+                config_map: Some(ConfigMapVolumeSource {
+                    name: config_map.name.clone(),
+                    items: items(config_map.key()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        },
+        (None, None) => return Ok(None),
+        // The CRD's CEL rule rejects this, but an older apiserver or a hand-edited object
+        // could still get here, and silently picking one would be worse than saying so.
+        (Some(_), Some(_)) => {
+            return Err(Error::InvalidRestateConfig(
+                "only one of spec.config and spec.configFrom may be set".into(),
+            ));
+        }
+    };
+
+    Ok(Some(volume))
+}
+
+/// Build the Deployment the operator wants, before the user's `spec.template` overlay.
+///
+/// Deliberately absent: any readiness or liveness probe. The image exposes no health
+/// endpoint, and it exits non-zero on unrecoverable errors (bad configuration, exhausted
+/// reconnect retries), so the restart policy is the real liveness mechanism. A probe on the
+/// metrics port would also be wrong the moment someone sets `restate.metrics.enabled=false`.
+fn base_deployment(
+    base_metadata: &ObjectMeta,
+    spec: &RestateKafkaIntegrationSpec,
+    ingress_url: &str,
+    default_image: &str,
+) -> Result<Deployment, Error> {
+    let metadata = object_meta(base_metadata);
+    let name = base_metadata.name.as_ref().unwrap();
+
+    let mut pod_labels = metadata.labels.clone().unwrap_or_default();
+    // The cluster's NetworkPolicies select peers by this label; see the RestateDeployment
+    // pods, which are labelled the same way.
+    if let Some(cluster) = spec.restate.ingress.cluster() {
+        pod_labels.insert(format!("allow.restate.dev/{cluster}"), "true".to_owned());
+    }
+
+    let mut pod_annotations = metadata.annotations.clone().unwrap_or_default();
+    if let Some(config) = spec.config.as_deref() {
+        pod_annotations.insert(CONFIG_HASH_ANNOTATION.to_owned(), config_hash(config));
+    }
+
+    let config_volume = config_volume(name, spec)?;
+    let volume_mounts = config_volume.as_ref().map(|_| {
+        vec![VolumeMount {
+            name: CONFIG_VOLUME_NAME.into(),
+            mount_path: CONFIG_FILE_PATH.into(),
+            sub_path: Some(CONFIG_SUB_PATH.into()),
+            read_only: Some(true),
+            ..Default::default()
+        }]
+    });
+
+    Ok(Deployment {
+        metadata,
+        spec: Some(DeploymentSpec {
+            replicas: Some(spec.replicas),
+            selector: label_selector(base_metadata),
+            // Surging would add consumers to the group before the old ones leave, costing an
+            // extra Kafka rebalance on every rollout.
+            strategy: Some(DeploymentStrategy {
+                type_: Some("RollingUpdate".into()),
+                rolling_update: Some(RollingUpdateDeployment {
+                    max_surge: Some(
+                        k8s_openapi::apimachinery::pkg::util::intstr::IntOrString::Int(0),
+                    ),
+                    max_unavailable: Some(
+                        k8s_openapi::apimachinery::pkg::util::intstr::IntOrString::Int(1),
+                    ),
+                }),
+            }),
+            template: PodTemplateSpec {
+                metadata: Some(ObjectMeta {
+                    labels: Some(pod_labels),
+                    annotations: Some(pod_annotations),
+                    ..Default::default()
+                }),
+                spec: Some(PodSpec {
+                    automount_service_account_token: Some(false),
+                    containers: vec![Container {
+                        name: CONTAINER_NAME.into(),
+                        image: Some(spec.image.as_deref().unwrap_or(default_image).to_owned()),
+                        image_pull_policy: spec.image_pull_policy.clone(),
+                        env: Some(env(spec, ingress_url)),
+                        ports: Some(vec![ContainerPort {
+                            name: Some("metrics".into()),
+                            container_port: METRICS_PORT,
+                            ..Default::default()
+                        }]),
+                        security_context: Some(SecurityContext {
+                            read_only_root_filesystem: Some(true),
+                            allow_privilege_escalation: Some(false),
+                            ..Default::default()
+                        }),
+                        volume_mounts,
+                        ..Default::default()
+                    }],
+                    security_context: Some(PodSecurityContext {
+                        run_as_non_root: Some(true),
+                        run_as_user: Some(1000),
+                        run_as_group: Some(3000),
+                        fs_group: Some(2000),
+                        fs_group_change_policy: Some("OnRootMismatch".into()),
+                        seccomp_profile: Some(SeccompProfile {
+                            type_: "RuntimeDefault".into(),
+                            localhost_profile: None,
+                        }),
+                        ..Default::default()
+                    }),
+                    // Long enough for in-flight records to finish and their offsets to be
+                    // committed before the consumer is killed.
+                    termination_grace_period_seconds: Some(60),
+                    volumes: config_volume.map(|volume| vec![volume]),
+                    ..Default::default()
+                }),
+            },
+            ..Default::default()
+        }),
+        status: None,
+    })
+}
+
+/// Apply the user's `spec.template` on top of the generated pod template.
+///
+/// The generated template goes through JSON because `spec.template.spec` is an opaque
+/// pass-through: it may legitimately carry fields this build of the operator does not know
+/// about, so it can never be deserialized into a typed `PodSpec`.
+fn apply_template_overlay(
+    deployment: &Deployment,
+    base_metadata: &ObjectMeta,
+    spec: &RestateKafkaIntegrationSpec,
+) -> Result<Value, Error> {
+    let mut deployment = serde_json::to_value(deployment)?;
+
+    if let Some(template) = spec.template.as_ref() {
+        // Built key by key rather than with `json!`, because an absent field must stay absent:
+        // a `null` in the overlay *deletes* the generated value, so serializing `None` here
+        // would silently strip the labels and annotations the operator just computed.
+        let mut metadata = Map::new();
+        if let Some(labels) = template.metadata.as_ref().and_then(|m| m.labels.as_ref()) {
+            metadata.insert("labels".into(), serde_json::to_value(labels)?);
+        }
+        if let Some(annotations) = template
+            .metadata
+            .as_ref()
+            .and_then(|m| m.annotations.as_ref())
+        {
+            metadata.insert("annotations".into(), serde_json::to_value(annotations)?);
+        }
+
+        let mut overlay = Map::new();
+        if !metadata.is_empty() {
+            overlay.insert("metadata".into(), Value::Object(metadata));
+        }
+        if let Some(pod_spec) = template.spec.as_ref() {
+            overlay.insert("spec".into(), pod_spec.clone());
+        }
+
+        let merged = strategic_merge(
+            deployment["spec"]["template"].take(),
+            &Value::Object(overlay),
+        );
+        deployment["spec"]["template"] = merged;
+    }
+
+    // A Deployment whose template labels no longer match its (immutable) selector is
+    // rejected outright by the apiserver, so put ours back rather than letting an overlay
+    // produce an object that can never be applied.
+    let labels = deployment["spec"]["template"]["metadata"]["labels"]
+        .as_object_mut()
+        .ok_or_else(|| {
+            Error::InvalidRestateConfig(
+                "spec.template.metadata.labels must be an object".to_owned(),
+            )
+        })?;
+    for (key, value) in selector_labels(base_metadata) {
+        labels.insert(key, Value::String(value));
+    }
+
+    Ok(deployment)
+}
+
+/// Reconcile the Deployment, returning its observed status.
+pub async fn reconcile_deployment(
+    ctx: &Context,
+    namespace: &str,
+    base_metadata: &ObjectMeta,
+    spec: &RestateKafkaIntegrationSpec,
+    ingress_url: &str,
+) -> Result<Option<DeploymentStatus>, Error> {
+    let name = base_metadata.name.as_ref().unwrap();
+
+    let deployment = base_deployment(
+        base_metadata,
+        spec,
+        ingress_url,
+        &ctx.kafka_integration_default_image,
+    )?;
+    let mut deployment = apply_template_overlay(&deployment, base_metadata, spec)?;
+
+    // The pod template is passed through verbatim, so it cannot round-trip through the typed
+    // Deployment; write it as a DynamicObject instead, as the RestateDeployment controller
+    // does for its ReplicaSets.
+    let resource = ApiResource::erase::<Deployment>(&());
+    let types = json!({
+        "apiVersion": resource.api_version,
+        "kind": resource.kind,
+    });
+    let deployment = strategic_merge(deployment.take(), &types);
+
+    let dp_api: Api<DynamicObject> = Api::namespaced_with(ctx.client.clone(), namespace, &resource);
+    let params: PatchParams = PatchParams::apply("restate-operator").force();
+
+    debug!("Applying Deployment {name} in namespace {namespace}");
+    let applied = dp_api
+        .patch(name, &params, &Patch::Apply(&deployment))
+        .await?;
+
+    // Only the status is read back, and that part is always a well-known shape.
+    let applied: Deployment = serde_json::from_value(serde_json::to_value(applied)?)?;
+
+    Ok(applied.status)
+}
+
+/// The Deployment's label selector as a string, for `status.labelSelector` / the scale
+/// subresource.
+pub fn label_selector_string(name: &str) -> String {
+    selector_labels(&ObjectMeta {
+        name: Some(name.to_owned()),
+        ..Default::default()
+    })
+    .into_iter()
+    .map(|(key, value)| format!("{key}={value}"))
+    .collect::<Vec<_>>()
+    .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta() -> ObjectMeta {
+        ObjectMeta {
+            name: Some("orders".into()),
+            namespace: Some("apps".into()),
+            ..Default::default()
+        }
+    }
+
+    fn spec(json: Value) -> RestateKafkaIntegrationSpec {
+        serde_json::from_value(json).expect("spec deserializes")
+    }
+
+    fn minimal(extra: Value) -> RestateKafkaIntegrationSpec {
+        let mut base = json!({
+            "replicas": 1,
+            "restate": {"ingress": {"cluster": "my-cluster"}}
+        });
+        let Value::Object(extra) = extra else {
+            panic!("extra must be an object")
+        };
+        for (key, value) in extra {
+            base[key] = value;
+        }
+        spec(base)
+    }
+
+    fn built(spec: &RestateKafkaIntegrationSpec) -> Value {
+        let deployment = base_deployment(
+            &meta(),
+            spec,
+            "http://restate.my-cluster.svc.cluster.local:8080/",
+            "default-image:1",
+        )
+        .expect("builds");
+        apply_template_overlay(&deployment, &meta(), spec).expect("overlay applies")
+    }
+
+    fn container(deployment: &Value) -> &Value {
+        &deployment["spec"]["template"]["spec"]["containers"][0]
+    }
+
+    #[test]
+    fn the_ingress_url_and_defaults_are_set() {
+        let deployment = built(&minimal(json!({})));
+        let container = container(&deployment);
+
+        assert_eq!(container["name"], "kafka-integration");
+        assert_eq!(container["image"], "default-image:1");
+        assert_eq!(
+            container["env"],
+            json!([{
+                "name": "RESTATE_INGRESS_URL",
+                "value": "http://restate.my-cluster.svc.cluster.local:8080/"
+            }])
+        );
+        // no config source, so no CONFIG_FILE, no volume and no mount
+        assert!(container.get("volumeMounts").is_none());
+        assert!(
+            deployment["spec"]["template"]["spec"]
+                .get("volumes")
+                .is_none()
+        );
+        assert_eq!(deployment["spec"]["replicas"], 1);
+        assert_eq!(
+            deployment["spec"]["strategy"]["rollingUpdate"]["maxSurge"],
+            0
+        );
+    }
+
+    #[test]
+    fn the_cluster_reference_labels_the_pods_for_network_policies() {
+        let deployment = built(&minimal(json!({})));
+        assert_eq!(
+            deployment["spec"]["template"]["metadata"]["labels"]["allow.restate.dev/my-cluster"],
+            "true"
+        );
+    }
+
+    #[test]
+    fn a_url_reference_does_not_label_the_pods() {
+        let spec = spec(json!({
+            "replicas": 1,
+            "restate": {"ingress": {"url": "https://restate.example:8080/"}}
+        }));
+        let deployment = built(&spec);
+        let labels = &deployment["spec"]["template"]["metadata"]["labels"];
+        assert!(labels.get("allow.restate.dev/my-cluster").is_none());
+    }
+
+    #[test]
+    fn an_auth_token_is_referenced_not_read() {
+        let deployment = built(&minimal(
+            json!({"restate": {"ingress": {"cloud": "my-env"}, "authToken": {"name": "tok", "key": "k"}}}),
+        ));
+        let env = &container(&deployment)["env"];
+        assert_eq!(
+            env[1],
+            json!({
+                "name": "RESTATE_AUTH_TOKEN",
+                "valueFrom": {"secretKeyRef": {"name": "tok", "key": "k"}}
+            })
+        );
+    }
+
+    #[test]
+    fn inline_config_mounts_the_operators_configmap_and_hashes_it() {
+        let deployment = built(&minimal(json!({"config": "group.id=orders\n"})));
+        let container = container(&deployment);
+
+        assert_eq!(
+            container["env"][1],
+            json!({"name": "CONFIG_FILE", "value": "/etc/restate-kafka/config.properties"})
+        );
+        assert_eq!(
+            container["volumeMounts"],
+            json!([{
+                "name": "config",
+                "mountPath": "/etc/restate-kafka/config.properties",
+                "subPath": "config.properties",
+                "readOnly": true
+            }])
+        );
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["volumes"],
+            json!([{
+                "name": "config",
+                "configMap": {
+                    "name": "orders",
+                    "items": [{"key": "config.properties", "path": "config.properties"}]
+                }
+            }])
+        );
+        assert_eq!(
+            deployment["spec"]["template"]["metadata"]["annotations"]["restate.dev/config-hash"],
+            config_hash("group.id=orders\n")
+        );
+    }
+
+    #[test]
+    fn config_from_a_secret_mounts_the_users_secret_and_is_not_hashed() {
+        let deployment = built(&minimal(
+            json!({"configFrom": {"secretRef": {"name": "kafka-config", "key": "kafka.properties"}}}),
+        ));
+
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["volumes"],
+            json!([{
+                "name": "config",
+                "secret": {
+                    "secretName": "kafka-config",
+                    "items": [{"key": "kafka.properties", "path": "config.properties"}]
+                }
+            }])
+        );
+        // we never read the Secret, so we cannot hash its contents
+        assert!(
+            deployment["spec"]["template"]["metadata"]["annotations"]
+                .get("restate.dev/config-hash")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn config_from_a_configmap_defaults_the_key() {
+        let deployment = built(&minimal(
+            json!({"configFrom": {"configMapRef": {"name": "kafka-config"}}}),
+        ));
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["volumes"][0]["configMap"],
+            json!({
+                "name": "kafka-config",
+                "items": [{"key": "config.properties", "path": "config.properties"}]
+            })
+        );
+    }
+
+    #[test]
+    fn both_config_sources_is_rejected() {
+        let spec = minimal(json!({
+            "config": "a=b\n",
+            "configFrom": {"secretRef": {"name": "s"}}
+        }));
+        let err = base_deployment(&meta(), &spec, "http://restate:8080/", "img").expect_err("both");
+        assert!(matches!(err, Error::InvalidRestateConfig(_)));
+    }
+
+    #[test]
+    fn the_template_overlay_reaches_the_operators_container() {
+        let deployment = built(&minimal(json!({"template": {"spec": {
+            "containers": [{
+                "name": "kafka-integration",
+                "image": "mine:2",
+                "resources": {"requests": {"cpu": "500m"}},
+                "env": [{"name": "JDK_JAVA_OPTIONS", "value": "-Xmx512m"}]
+            }],
+            "serviceAccountName": "kafka",
+            "nodeSelector": {"kubernetes.io/arch": "arm64"}
+        }}})));
+        let container = container(&deployment);
+
+        assert_eq!(container["image"], "mine:2");
+        assert_eq!(container["resources"]["requests"]["cpu"], "500m");
+        // the operator's own env survives, and the user's is appended
+        assert_eq!(container["env"][0]["name"], "RESTATE_INGRESS_URL");
+        assert_eq!(container["env"][1]["name"], "JDK_JAVA_OPTIONS");
+        // the generated port is untouched
+        assert_eq!(container["ports"][0]["containerPort"], METRICS_PORT);
+        assert_eq!(
+            deployment["spec"]["template"]["spec"]["serviceAccountName"],
+            "kafka"
+        );
+    }
+
+    #[test]
+    fn the_template_overlay_can_add_a_sidecar_and_a_probe() {
+        let deployment = built(&minimal(json!({"template": {"spec": {
+            "containers": [
+                {"name": "kafka-integration", "readinessProbe": {"tcpSocket": {"port": 9464}}},
+                {"name": "sidecar", "image": "sidecar:1"}
+            ]
+        }}})));
+
+        let containers = &deployment["spec"]["template"]["spec"]["containers"];
+        assert_eq!(containers.as_array().unwrap().len(), 2);
+        assert_eq!(containers[0]["readinessProbe"]["tcpSocket"]["port"], 9464);
+        assert_eq!(containers[1]["name"], "sidecar");
+    }
+
+    #[test]
+    fn the_template_overlay_cannot_break_the_selector() {
+        let deployment = built(&minimal(json!({"template": {"metadata": {
+            "labels": {"app.kubernetes.io/name": "something-else", "team": "payments"}
+        }}})));
+        let labels = &deployment["spec"]["template"]["metadata"]["labels"];
+
+        assert_eq!(
+            labels["app.kubernetes.io/name"],
+            "restate-kafka-integration"
+        );
+        assert_eq!(labels["app.kubernetes.io/instance"], "orders");
+        // unrelated labels the user added are kept
+        assert_eq!(labels["team"], "payments");
+    }
+
+    #[test]
+    fn the_template_overlay_can_remove_a_generated_field() {
+        let deployment = built(&minimal(
+            json!({"template": {"spec": {"securityContext": null}}}),
+        ));
+        assert!(
+            deployment["spec"]["template"]["spec"]
+                .get("securityContext")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn the_label_selector_string_matches_the_selector() {
+        assert_eq!(
+            label_selector_string("orders"),
+            "app.kubernetes.io/instance=orders,app.kubernetes.io/name=restate-kafka-integration"
+        );
+    }
+}

--- a/src/controllers/restatekafkaintegration/reconcilers/mod.rs
+++ b/src/controllers/restatekafkaintegration/reconcilers/mod.rs
@@ -1,0 +1,63 @@
+use std::collections::BTreeMap;
+
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
+
+pub mod config;
+pub mod deployment;
+
+/// The name of the container the operator generates. Users target it by name from
+/// `spec.template` to override its fields.
+pub const CONTAINER_NAME: &str = "kafka-integration";
+
+/// The name of the volume the `.properties` configuration is projected through.
+pub const CONFIG_VOLUME_NAME: &str = "config";
+
+/// The port the image documents for its Prometheus scrape endpoint
+/// (`restate.metrics.port`, default 9464). Declared on the container so the port has a name;
+/// the container decides whether it actually listens.
+pub const METRICS_PORT: i32 = 9464;
+
+/// The labels that identify a RestateKafkaIntegration's pods.
+///
+/// These end up in the Deployment's `spec.selector`, which is immutable once created, so
+/// nothing may be added here without a migration.
+pub fn selector_labels(base_metadata: &ObjectMeta) -> BTreeMap<String, String> {
+    BTreeMap::from_iter([
+        (
+            "app.kubernetes.io/name".into(),
+            "restate-kafka-integration".into(),
+        ),
+        (
+            "app.kubernetes.io/instance".into(),
+            base_metadata.name.clone().unwrap(),
+        ),
+    ])
+}
+
+/// Labels applied to every object the operator creates for a RestateKafkaIntegration, on top
+/// of the labels copied from the RestateKafkaIntegration itself.
+pub fn mandatory_labels(base_metadata: &ObjectMeta) -> BTreeMap<String, String> {
+    let mut labels = selector_labels(base_metadata);
+    // This is what the controller's `owns` watch filters on, so a child object without it is
+    // invisible to the controller until the next periodic requeue.
+    labels.insert(
+        "app.kubernetes.io/managed-by".into(),
+        "restate-operator".into(),
+    );
+    labels
+}
+
+pub fn label_selector(base_metadata: &ObjectMeta) -> LabelSelector {
+    LabelSelector {
+        match_labels: Some(selector_labels(base_metadata)),
+        match_expressions: None,
+    }
+}
+
+pub fn object_meta(base_metadata: &ObjectMeta) -> ObjectMeta {
+    let mut meta = base_metadata.clone();
+    meta.labels
+        .get_or_insert_with(Default::default)
+        .extend(mandatory_labels(base_metadata));
+    meta
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,14 @@ struct Arguments {
     tunnel_client_default_image: String,
 
     #[arg(
+        long = "kafka-integration-default-image",
+        env = "OPERATOR_KAFKA_INTEGRATION_DEFAULT_IMAGE",
+        value_name = "IMAGE",
+        default_value = "ghcr.io/restatedev/ingress-integration-kafka:latest"
+    )]
+    kafka_integration_default_image: String,
+
+    #[arg(
         long = "cluster-dns",
         env = "CLUSTER_DNS",
         value_name = "CLUSTER_DNS",
@@ -153,6 +161,7 @@ async fn main() -> anyhow::Result<()> {
         args.operator_label_name,
         args.operator_label_value,
         args.tunnel_client_default_image,
+        args.kafka_integration_default_image,
         args.cluster_dns,
         args.canary_image,
         args.operator_pod_name,
@@ -180,6 +189,11 @@ async fn main() -> anyhow::Result<()> {
     );
     let deployment_controller = restate_operator::controllers::restatedeployment::run(
         client.clone(),
+        metric.clone(),
+        state.clone(),
+    );
+    let kafka_integration_controller = restate_operator::controllers::restatekafkaintegration::run(
+        client.clone(),
         metric,
         state.clone(),
     );
@@ -191,6 +205,7 @@ async fn main() -> anyhow::Result<()> {
     tokio::pin!(cluster_controller);
     tokio::pin!(cloud_environment_controller);
     tokio::pin!(deployment_controller);
+    tokio::pin!(kafka_integration_controller);
     tokio::pin!(crd_wait_reporter);
 
     // Start web server
@@ -214,10 +229,11 @@ async fn main() -> anyhow::Result<()> {
     tokio::pin!(server);
 
     // Both runtimes implements graceful shutdown, so poll until both are done
-    let (_, _, _, _, server_result) = tokio::join!(
+    let (_, _, _, _, _, server_result) = tokio::join!(
         cluster_controller,
         cloud_environment_controller,
         deployment_controller,
+        kafka_integration_controller,
         crd_wait_reporter,
         server
     );

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -4,5 +4,6 @@ pub mod podidentityassociations;
 pub mod restatecloudenvironments;
 pub mod restateclusters;
 pub mod restatedeployments;
+pub mod restatekafkaintegrations;
 pub mod secretproviderclasses;
 pub mod securitygrouppolicies;

--- a/src/resources/restatecloudenvironments.rs
+++ b/src/resources/restatecloudenvironments.rs
@@ -86,6 +86,14 @@ impl RestateCloudEnvironment {
         ))
     }
 
+    pub fn ingress_url(&self) -> Result<Url, url::ParseError> {
+        Url::parse(&format!(
+            "https://{}.env.{}.restate.cloud:8080",
+            self.unprefixed_environment_id(),
+            self.spec.region
+        ))
+    }
+
     pub fn tunnel_url(&self, service_url: Url) -> Result<Url, url::ParseError> {
         let unprefixed_env = self.unprefixed_environment_id();
 

--- a/src/resources/restatekafkaintegrations.rs
+++ b/src/resources/restatekafkaintegrations.rs
@@ -1,0 +1,580 @@
+use std::fmt::Display;
+
+use kube::{
+    CustomResource, KubeSchema,
+    runtime::reflector::{ObjectRef, Store},
+};
+use schemars::{JsonSchema, Schema};
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+use crate::{
+    controllers::service_url,
+    resources::{
+        restatecloudenvironments::RestateCloudEnvironment,
+        restatedeployments::{PodTemplateMetadata, ServiceReference},
+    },
+};
+
+/// The path the operator mounts `spec.config` / `spec.configFrom` at, and the value it
+/// gives the container's `CONFIG_FILE` environment variable.
+pub const CONFIG_FILE_PATH: &str = "/etc/restate-kafka/config.properties";
+
+/// The key the operator writes inline `spec.config` under in the ConfigMap it owns, and the
+/// default key read from a `spec.configFrom` Secret or ConfigMap.
+pub const CONFIG_FILE_KEY: &str = "config.properties";
+
+/// RestateKafkaIntegration runs the Restate Kafka ingress integration
+/// (`ghcr.io/restatedev/ingress-integration-kafka`), which consumes Kafka topics and turns
+/// each record into a Restate invocation.
+///
+/// The operator only models where Restate is and how to authenticate to it; everything else
+/// (Kafka connection, consumer settings, record mapper, metrics, retry policy) is the
+/// container's own configuration surface and is passed through verbatim as a `.properties`
+/// file via `spec.config` or `spec.configFrom`.
+#[derive(CustomResource, Deserialize, Serialize, Clone, Debug, KubeSchema)]
+#[kube(
+    kind = "RestateKafkaIntegration",
+    group = "restate.dev",
+    version = "v1alpha1",
+    namespaced,
+    scale = r#"{"specReplicasPath": ".spec.replicas", "statusReplicasPath": ".status.replicas", "labelSelectorPath": ".status.labelSelector"}"#,
+    printcolumn = r#"{"name":"Desired", "type":"integer", "jsonPath":".spec.replicas"}"#,
+    printcolumn = r#"{"name":"Ready", "type":"integer", "jsonPath":".status.readyReplicas"}"#,
+    printcolumn = r#"{"name":"Available", "type":"integer", "jsonPath":".status.availableReplicas"}"#,
+    printcolumn = r#"{"name":"Age", "type":"date", "jsonPath":".metadata.creationTimestamp"}"#,
+    printcolumn = r#"{"name":"Ingress", "type":"string", "jsonPath":".status.ingressUrl", "priority": 1}"#,
+    printcolumn = r#"{"name":"Status", "type":"string", "jsonPath":".status.conditions[?(@.type==\"Ready\")].message", "priority": 1}"#
+)]
+#[kube(status = "RestateKafkaIntegrationStatus", shortname = "rki")]
+#[serde(rename_all = "camelCase")]
+// The two config sources are alternatives, not layers: the container reads a single
+// CONFIG_FILE, so there is nothing sensible to do with both.
+#[x_kube(validation = Rule::new("!(has(self.config) && has(self.configFrom))")
+    .message("only one of spec.config and spec.configFrom may be set"))]
+pub struct RestateKafkaIntegrationSpec {
+    /// Number of desired pods. Defaults to 1.
+    ///
+    /// Kafka distributes the subscribed partitions across the whole consumer group, so
+    /// throughput scales with replicas up to the partition count; replicas beyond that sit
+    /// idle. Note that each pod itself runs `restate.kafka.consumer.instances` consumers
+    /// (defaulting to twice the container's CPU count).
+    #[schemars(default = "default_replicas", range(min = 0))]
+    pub replicas: i32,
+
+    /// Container image name. Defaults to a suggested version of
+    /// ghcr.io/restatedev/ingress-integration-kafka.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+
+    /// Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest
+    /// tag is specified, or IfNotPresent otherwise.
+    /// More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub image_pull_policy: Option<String>,
+
+    /// Where to send the invocations produced from Kafka records, and how to authenticate.
+    pub restate: RestateIngressSpec,
+
+    /// Inline configuration for the integration, in Java `.properties` format. The operator
+    /// stores this in a ConfigMap it owns, mounts it, and points the container's
+    /// `CONFIG_FILE` at it. Editing it rolls the pods.
+    ///
+    /// Every option documented at
+    /// https://github.com/restatedev/ingress-integration-kafka/blob/main/CONFIGURATION.md
+    /// is accepted, using the property-key spelling (not the environment-variable one).
+    /// At a minimum the integration needs `bootstrap.servers`, `group.id` and `topics`.
+    ///
+    /// `restate.ingress.url` and `restate.auth.token` set here have no effect: the operator
+    /// supplies both as environment variables, which the container prefers over the file.
+    ///
+    /// This is the CR's own body, so it is stored and displayed in plain text - keep
+    /// credentials (`sasl.jaas.config`, `sasl.password`, ...) in `spec.configFrom` with a
+    /// Secret instead.
+    ///
+    /// Mutually exclusive with `configFrom`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<String>,
+
+    /// Configuration for the integration, read from a Secret or ConfigMap in this namespace
+    /// and mounted as the container's `CONFIG_FILE`. Use this rather than `config` when the
+    /// configuration contains credentials.
+    ///
+    /// The operator does not read the referenced object, so changing its contents does not
+    /// restart the pods; run `kubectl rollout restart deployment/<name>` to pick a change up.
+    ///
+    /// Mutually exclusive with `config`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(default, schema_with = "config_source_schema")]
+    pub config_from: Option<ConfigSource>,
+
+    /// Overrides applied on top of the pod template the operator generates.
+    ///
+    /// This is a partial pod template, strategic-merged over the generated one: objects are
+    /// merged key by key, and lists whose Kubernetes merge key the operator knows
+    /// (`containers`, `initContainers`, `volumes`, `env`, `volumeMounts`, `ports`,
+    /// `imagePullSecrets`, `hostAliases`) are merged entry by entry, so you can override a
+    /// single field without restating the rest. Any other list replaces the generated one,
+    /// and an explicit `null` removes a generated field.
+    ///
+    /// The operator's own container is named `kafka-integration`; target it by name to set
+    /// resources, probes, extra environment variables or volume mounts. The generated pod
+    /// deliberately has no readiness or liveness probe (the image exposes no health endpoint
+    /// and exits non-zero on unrecoverable errors), so add one here if you want one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<PodTemplateOverlay>,
+}
+
+/// A partial pod template, merged over the one the operator generates.
+///
+/// Both halves are optional: unlike a RestateDeployment's `spec.template`, this is an overlay
+/// rather than the whole template, so setting only `metadata.labels` is valid.
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct PodTemplateOverlay {
+    /// Labels and annotations to merge into the generated pod template's metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<PodTemplateMetadata>,
+
+    /// Pod spec fields to merge over the generated pod spec.
+    ///
+    /// Passed through verbatim, so it accepts any field the target Kubernetes version
+    /// understands.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(default, schema_with = "pod_spec_overlay_schema")]
+    pub spec: Option<serde_json::Value>,
+}
+
+fn pod_spec_overlay_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "description": "Pod spec fields to merge over the generated pod spec. Passed through verbatim, so it accepts any field the target Kubernetes version understands.",
+        "nullable": true,
+        "x-kubernetes-preserve-unknown-fields": true
+    })
+}
+
+fn config_source_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
+    // Hand-wrapped rather than left to `Option<ConfigSource>`: schemars represents an
+    // optional field whose type has a custom schema as `anyOf: [<schema>, {nullable: true}]`,
+    // and a structural schema may not set `nullable` inside a logical combinator, so the
+    // apiserver rejects the whole CRD.
+    let mut schema = generator.subschema_for::<ConfigSource>();
+    schema.insert("nullable".into(), serde_json::Value::Bool(true));
+    schema
+}
+
+fn default_replicas() -> i32 {
+    1
+}
+
+/// Where to send the invocations produced from Kafka records, and how to authenticate.
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RestateIngressSpec {
+    /// The location of the Restate ingress to send invocations to.
+    pub ingress: RestateIngressEndpoint,
+
+    /// A Secret key in this namespace holding a bearer token for the Restate ingress,
+    /// supplied to the container as `RESTATE_AUTH_TOKEN`.
+    ///
+    /// Required when `ingress.cloud` is set; optional (and usually unnecessary) otherwise.
+    /// The operator never reads this Secret - it is referenced from the pod spec, so the
+    /// kubelet resolves it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<SecretKeyRef>,
+}
+
+/// A reference to a single key of a Secret in the same namespace as the RestateKafkaIntegration
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct SecretKeyRef {
+    /// The name of the referenced Secret. It must be in the same namespace as this resource.
+    pub name: String,
+    /// The key to read from the referenced Secret
+    pub key: String,
+}
+
+/// Configuration read from a Secret or ConfigMap and mounted as the container's `CONFIG_FILE`
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigSource {
+    /// A Secret in this namespace holding the `.properties` configuration.
+    /// Exactly one of `secretRef` or `configMapRef` must be specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub secret_ref: Option<ConfigKeyRef>,
+    /// A ConfigMap in this namespace holding the `.properties` configuration.
+    /// Exactly one of `secretRef` or `configMapRef` must be specified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_map_ref: Option<ConfigKeyRef>,
+}
+
+// Custom JsonSchema implementation so that exactly one of secretRef, configMapRef is required.
+impl JsonSchema for ConfigSource {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ConfigSource".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
+        let mut secret_schema = generator.subschema_for::<ConfigKeyRef>();
+        secret_schema.insert(
+            "description".into(),
+            serde_json::Value::String(
+                "A Secret in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified".into(),
+            ),
+        );
+        let mut config_map_schema = generator.subschema_for::<ConfigKeyRef>();
+        config_map_schema.insert(
+            "description".into(),
+            serde_json::Value::String(
+                "A ConfigMap in this namespace holding the `.properties` configuration. Exactly one of `secretRef` or `configMapRef` must be specified".into(),
+            ),
+        );
+
+        schemars::json_schema!({
+            "description": "Configuration read from a Secret or ConfigMap and mounted as the container's `CONFIG_FILE`",
+            "properties": {
+                "secretRef": secret_schema,
+                "configMapRef": config_map_schema
+            },
+            "oneOf": [
+                {"required": ["secretRef"]},
+                {"required": ["configMapRef"]}
+            ],
+            "type": "object"
+        })
+    }
+}
+
+impl ConfigSource {
+    /// The referenced object, or an error if not exactly one of the two was given.
+    pub fn resolve(&self) -> crate::Result<ConfigSourceKind<'_>> {
+        match (self.secret_ref.as_ref(), self.config_map_ref.as_ref()) {
+            (Some(secret), None) => Ok(ConfigSourceKind::Secret(secret)),
+            (None, Some(config_map)) => Ok(ConfigSourceKind::ConfigMap(config_map)),
+            _ => Err(crate::Error::InvalidRestateConfig(
+                "Exactly one of `secretRef` or `configMapRef` must be specified in spec.configFrom"
+                    .into(),
+            )),
+        }
+    }
+}
+
+/// The resolved form of a [`ConfigSource`]
+#[derive(Debug, Clone, Copy)]
+pub enum ConfigSourceKind<'a> {
+    Secret(&'a ConfigKeyRef),
+    ConfigMap(&'a ConfigKeyRef),
+}
+
+/// A reference to a single key of a Secret or ConfigMap in the same namespace
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+pub struct ConfigKeyRef {
+    /// The name of the referenced object. It must be in the same namespace as this resource.
+    pub name: String,
+    /// The key to read the `.properties` configuration from. Defaults to `config.properties`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key: Option<String>,
+}
+
+impl ConfigKeyRef {
+    pub fn key(&self) -> &str {
+        self.key.as_deref().unwrap_or(CONFIG_FILE_KEY)
+    }
+}
+
+/// The location of the Restate ingress to send invocations to
+#[derive(Deserialize, Serialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RestateIngressEndpoint {
+    /// The name of a RestateCluster whose ingress to send invocations to.
+    /// Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+    pub cluster: Option<String>,
+    /// The name of a RestateCloudEnvironment whose ingress to send invocations to.
+    /// Requires `spec.restate.authToken`.
+    /// Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+    pub cloud: Option<String>,
+    /// A reference to a Service hosting the Restate ingress.
+    /// Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+    pub service: Option<ServiceReference>,
+    /// A url of the Restate ingress to send invocations to.
+    /// Exactly one of `cluster`, `cloud`, `service` or `url` must be specified
+    pub url: Option<Url>,
+}
+
+impl Display for RestateIngressEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (&self.cluster, &self.cloud, &self.service, &self.url) {
+            (Some(cluster), _, _, _) => write!(f, "RestateCluster/{cluster}"),
+            (_, Some(cloud), _, _) => write!(f, "RestateCloudEnvironment/{cloud}"),
+            (_, _, Some(service), _) => write!(f, "Service/{}/{}", service.namespace, service.name),
+            (_, _, _, Some(url)) => write!(f, "{url}"),
+            _ => write!(f, "N/A"),
+        }
+    }
+}
+
+// Custom JsonSchema implementation so that we can make one of cluster, cloud, service, url
+// required. Mirrors RestateAdminEndpoint, which resolves the admin API rather than the ingress.
+impl JsonSchema for RestateIngressEndpoint {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "RestateIngressEndpoint".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
+        let mut service_schema = generator.subschema_for::<ServiceReference>();
+        service_schema.insert(
+            "description".into(),
+            serde_json::Value::String(
+                "A reference to a Service hosting the Restate ingress. If `port` is unset it defaults to 8080. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified".into(),
+            ),
+        );
+
+        schemars::json_schema!({
+            "description": "The location of the Restate ingress to send invocations to",
+            "properties": {
+                "cluster": {
+                    "description": "The name of a RestateCluster whose ingress to send invocations to. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified",
+                    "type": "string"
+                },
+                "cloud": {
+                    "description": "The name of a RestateCloudEnvironment whose ingress to send invocations to. Requires `spec.restate.authToken`. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified",
+                    "type": "string"
+                },
+                "service": service_schema,
+                "url": {
+                    "description": "A url of the Restate ingress to send invocations to. Exactly one of `cluster`, `cloud`, `service` or `url` must be specified",
+                    "type": "string"
+                }
+            },
+            "oneOf": [
+                {"required": ["cluster"]},
+                {"required": ["cloud"]},
+                {"required": ["service"]},
+                {"required": ["url"]}
+            ],
+            "type": "object"
+        })
+    }
+}
+
+/// The default port the Restate ingress is served on
+pub const RESTATE_INGRESS_PORT: i32 = 8080;
+
+impl RestateIngressEndpoint {
+    /// The URL to give the integration as `RESTATE_INGRESS_URL`.
+    pub fn ingress_url(
+        &self,
+        rce_store: &Store<RestateCloudEnvironment>,
+        cluster_dns: &str,
+    ) -> crate::Result<Url> {
+        match (
+            self.cluster.as_deref(),
+            self.cloud.as_deref(),
+            self.service.as_ref(),
+            self.url.as_ref(),
+        ) {
+            // A RestateCluster named X runs a Service named `restate` in namespace X, serving
+            // the ingress on 8080.
+            (Some(cluster), None, None, None) => Ok(service_url(
+                "restate",
+                cluster,
+                RESTATE_INGRESS_PORT,
+                None,
+                cluster_dns,
+            )?),
+            (None, Some(cloud), None, None) => {
+                let Some(rce) = rce_store.get(&ObjectRef::new(cloud)) else {
+                    return Err(crate::Error::RestateCloudEnvironmentNotFound(cloud.into()));
+                };
+
+                Ok(rce.ingress_url()?)
+            }
+            (None, None, Some(service), None) => Ok(service_url(
+                &service.name,
+                &service.namespace,
+                service.port.unwrap_or(RESTATE_INGRESS_PORT),
+                service.path.as_deref(),
+                cluster_dns,
+            )?),
+            (None, None, None, Some(url)) => Ok(url.clone()),
+            _ => Err(crate::Error::InvalidRestateConfig(
+                "Exactly one of `cluster`, `cloud`, `service` or `url` must be specified in spec.restate.ingress"
+                    .into(),
+            )),
+        }
+    }
+
+    /// The RestateCluster this integration talks to, if any. Its pods are labelled
+    /// `allow.restate.dev/<cluster>` so that the cluster's NetworkPolicies can select them.
+    pub fn cluster(&self) -> Option<&str> {
+        self.cluster.as_deref()
+    }
+}
+
+/// Status of the RestateKafkaIntegration
+/// This is set and managed automatically by the controller
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RestateKafkaIntegrationStatus {
+    /// Total number of non-terminated pods targeted by this RestateKafkaIntegration
+    pub replicas: i32,
+
+    /// Total number of ready pods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ready_replicas: Option<i32>,
+
+    /// Total number of available pods (ready for at least minReadySeconds)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_replicas: Option<i32>,
+
+    /// Total number of unavailable pods
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unavailable_replicas: Option<i32>,
+
+    /// The generation observed by the controller
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_generation: Option<i64>,
+
+    /// The resolved Restate ingress URL the integration was configured with
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ingress_url: Option<String>,
+
+    /// The label selector of this RestateKafkaIntegration as a string, for the scale subresource
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label_selector: Option<String>,
+
+    /// Represents the latest available observations of current state
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conditions: Option<Vec<RestateKafkaIntegrationCondition>>,
+}
+
+/// A condition of a RestateKafkaIntegration
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RestateKafkaIntegrationCondition {
+    /// Last time the condition transitioned from one status to another.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_transition_time: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Time>,
+
+    /// Human-readable message indicating details about last transition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// Unique, one-word, CamelCase reason for the condition's last transition.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+
+    /// Status is the status of the condition. Can be True, False, Unknown.
+    pub status: String,
+
+    /// Type of the condition, known values are (`Ready`).
+    pub r#type: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kube::runtime::reflector;
+
+    fn empty_rce_store() -> Store<RestateCloudEnvironment> {
+        reflector::store::<RestateCloudEnvironment>().0
+    }
+
+    fn endpoint(json: serde_json::Value) -> RestateIngressEndpoint {
+        serde_json::from_value(json).expect("endpoint deserializes")
+    }
+
+    #[test]
+    fn cluster_resolves_to_the_ingress_port() {
+        let url = endpoint(serde_json::json!({"cluster": "my-cluster"}))
+            .ingress_url(&empty_rce_store(), "cluster.local")
+            .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "http://restate.my-cluster.svc.cluster.local:8080/"
+        );
+    }
+
+    #[test]
+    fn service_defaults_to_the_ingress_port() {
+        let url =
+            endpoint(serde_json::json!({"service": {"name": "restate", "namespace": "other"}}))
+                .ingress_url(&empty_rce_store(), "cluster.local")
+                .unwrap();
+        assert_eq!(url.as_str(), "http://restate.other.svc.cluster.local:8080/");
+    }
+
+    #[test]
+    fn service_honours_an_explicit_port_and_path() {
+        let url = endpoint(serde_json::json!({
+            "service": {"name": "restate", "namespace": "other", "port": 9090, "path": "/ingress"}
+        }))
+        .ingress_url(&empty_rce_store(), "cluster.local")
+        .unwrap();
+        assert_eq!(
+            url.as_str(),
+            "http://restate.other.svc.cluster.local:9090/ingress"
+        );
+    }
+
+    #[test]
+    fn url_is_passed_through() {
+        let url = endpoint(serde_json::json!({"url": "https://restate.example:8080/"}))
+            .ingress_url(&empty_rce_store(), "cluster.local")
+            .unwrap();
+        assert_eq!(url.as_str(), "https://restate.example:8080/");
+    }
+
+    #[test]
+    fn cloud_requires_the_environment_to_exist() {
+        let err = endpoint(serde_json::json!({"cloud": "my-env"}))
+            .ingress_url(&empty_rce_store(), "cluster.local")
+            .expect_err("no such RestateCloudEnvironment");
+        assert!(matches!(
+            err,
+            crate::Error::RestateCloudEnvironmentNotFound(name) if name == "my-env"
+        ));
+    }
+
+    #[test]
+    fn exactly_one_reference_is_required() {
+        for json in [
+            serde_json::json!({}),
+            serde_json::json!({"cluster": "a", "url": "http://b:8080/"}),
+            serde_json::json!({"cluster": "a", "cloud": "b"}),
+        ] {
+            let err = endpoint(json.clone())
+                .ingress_url(&empty_rce_store(), "cluster.local")
+                .expect_err(&format!("{json}"));
+            assert!(matches!(err, crate::Error::InvalidRestateConfig(_)));
+        }
+    }
+
+    #[test]
+    fn config_source_resolves_exactly_one_reference() {
+        let secret: ConfigSource =
+            serde_json::from_value(serde_json::json!({"secretRef": {"name": "s"}})).unwrap();
+        assert!(matches!(
+            secret.resolve().unwrap(),
+            ConfigSourceKind::Secret(r) if r.name == "s" && r.key() == "config.properties"
+        ));
+
+        let config_map: ConfigSource = serde_json::from_value(
+            serde_json::json!({"configMapRef": {"name": "c", "key": "other.properties"}}),
+        )
+        .unwrap();
+        assert!(matches!(
+            config_map.resolve().unwrap(),
+            ConfigSourceKind::ConfigMap(r) if r.name == "c" && r.key() == "other.properties"
+        ));
+
+        for json in [
+            serde_json::json!({}),
+            serde_json::json!({"secretRef": {"name": "s"}, "configMapRef": {"name": "c"}}),
+        ] {
+            let source: ConfigSource = serde_json::from_value(json).unwrap();
+            assert!(matches!(
+                source.resolve(),
+                Err(crate::Error::InvalidRestateConfig(_))
+            ));
+        }
+    }
+}

--- a/src/resources/restatekafkaintegrations.rs
+++ b/src/resources/restatekafkaintegrations.rs
@@ -16,12 +16,17 @@ use crate::{
     },
 };
 
-/// The path the operator mounts `spec.config` / `spec.configFrom` at, and the value it
-/// gives the container's `CONFIG_FILE` environment variable.
-pub const CONFIG_FILE_PATH: &str = "/etc/restate-kafka/config.properties";
+/// The directory the operator mounts every configuration file under. The container's
+/// `CONFIG_FILE` is a comma-separated list of paths inside it.
+pub const CONFIG_DIR: &str = "/etc/restate-kafka";
 
-/// The key the operator writes inline `spec.config` under in the ConfigMap it owns, and the
-/// default key read from a `spec.configFrom` Secret or ConfigMap.
+/// The ConfigMap key (and mounted file name) the operator writes the resolved Restate ingress
+/// location under. It is listed *first* in `CONFIG_FILE`, so any `spec.config` entry a user
+/// adds can override it.
+pub const RESTATE_CONFIG_KEY: &str = "restate.properties";
+
+/// The default key read from a `secretRef` / `configMapRef` `spec.config` entry when the
+/// entry does not name one.
 pub const CONFIG_FILE_KEY: &str = "config.properties";
 
 /// RestateKafkaIntegration runs the Restate Kafka ingress integration
@@ -30,8 +35,8 @@ pub const CONFIG_FILE_KEY: &str = "config.properties";
 ///
 /// The operator only models where Restate is and how to authenticate to it; everything else
 /// (Kafka connection, consumer settings, record mapper, metrics, retry policy) is the
-/// container's own configuration surface and is passed through verbatim as a `.properties`
-/// file via `spec.config` or `spec.configFrom`.
+/// container's own configuration surface and is passed through verbatim as one or more
+/// `.properties` files via `spec.config`.
 #[derive(CustomResource, Deserialize, Serialize, Clone, Debug, KubeSchema)]
 #[kube(
     kind = "RestateKafkaIntegration",
@@ -48,10 +53,6 @@ pub const CONFIG_FILE_KEY: &str = "config.properties";
 )]
 #[kube(status = "RestateKafkaIntegrationStatus", shortname = "rki")]
 #[serde(rename_all = "camelCase")]
-// The two config sources are alternatives, not layers: the container reads a single
-// CONFIG_FILE, so there is nothing sensible to do with both.
-#[x_kube(validation = Rule::new("!(has(self.config) && has(self.configFrom))")
-    .message("only one of spec.config and spec.configFrom may be set"))]
 pub struct RestateKafkaIntegrationSpec {
     /// Number of desired pods. Defaults to 1.
     ///
@@ -76,37 +77,32 @@ pub struct RestateKafkaIntegrationSpec {
     /// Where to send the invocations produced from Kafka records, and how to authenticate.
     pub restate: RestateIngressSpec,
 
-    /// Inline configuration for the integration, in Java `.properties` format. The operator
-    /// stores this in a ConfigMap it owns, mounts it, and points the container's
-    /// `CONFIG_FILE` at it. Editing it rolls the pods.
+    /// Inline configuration for the integration, in Java `.properties` format.
     ///
     /// Every option documented at
     /// https://github.com/restatedev/ingress-integration-kafka/blob/main/CONFIGURATION.md
     /// is accepted, using the property-key spelling (not the environment-variable one).
     /// At a minimum the integration needs `bootstrap.servers`, `group.id` and `topics`.
     ///
-    /// `restate.ingress.url` and `restate.auth.token` set here have no effect: the operator
-    /// supplies both as environment variables, which the container prefers over the file.
+    /// The operator stores this in a ConfigMap it owns and mounts it as a config file, merged
+    /// after its own resolved `restate.ingress.url` (so this can override the ingress URL) and
+    /// before `spec.configRefs` (so a ref can override this). Editing it rolls the pods.
     ///
-    /// This is the CR's own body, so it is stored and displayed in plain text - keep
-    /// credentials (`sasl.jaas.config`, `sasl.password`, ...) in `spec.configFrom` with a
-    /// Secret instead.
-    ///
-    /// Mutually exclusive with `configFrom`.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// This is part of the custom resource, so it is stored and displayed in plain text - keep
+    /// credentials (`sasl.jaas.config`, `sasl.password`, ...) in a `spec.configRefs` Secret,
+    /// and the Restate ingress bearer token in `spec.restate.authToken`, never here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<String>,
 
-    /// Configuration for the integration, read from a Secret or ConfigMap in this namespace
-    /// and mounted as the container's `CONFIG_FILE`. Use this rather than `config` when the
-    /// configuration contains credentials.
+    /// Additional configuration sources, read from Secrets or ConfigMaps in this namespace and
+    /// merged on top of `spec.config` in order - a later ref overrides an earlier one, and any
+    /// ref overrides `spec.config`.
     ///
-    /// The operator does not read the referenced object, so changing its contents does not
-    /// restart the pods; run `kubectl rollout restart deployment/<name>` to pick a change up.
-    ///
-    /// Mutually exclusive with `config`.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(default, schema_with = "config_source_schema")]
-    pub config_from: Option<ConfigSource>,
+    /// Each entry is a `secretRef` or a `configMapRef`; use a `secretRef` for anything
+    /// sensitive. The operator does not read these objects, so changing their contents does not
+    /// restart the pods; run `kubectl rollout restart deployment/<name>` afterwards.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub config_refs: Vec<ConfigRef>,
 
     /// Overrides applied on top of the pod template the operator generates.
     ///
@@ -152,16 +148,6 @@ fn pod_spec_overlay_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
     })
 }
 
-fn config_source_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
-    // Hand-wrapped rather than left to `Option<ConfigSource>`: schemars represents an
-    // optional field whose type has a custom schema as `anyOf: [<schema>, {nullable: true}]`,
-    // and a structural schema may not set `nullable` inside a logical combinator, so the
-    // apiserver rejects the whole CRD.
-    let mut schema = generator.subschema_for::<ConfigSource>();
-    schema.insert("nullable".into(), serde_json::Value::Bool(true));
-    schema
-}
-
 fn default_replicas() -> i32 {
     1
 }
@@ -174,7 +160,11 @@ pub struct RestateIngressSpec {
     pub ingress: RestateIngressEndpoint,
 
     /// A Secret key in this namespace holding a bearer token for the Restate ingress,
-    /// supplied to the container as `RESTATE_AUTH_TOKEN`.
+    /// supplied to the container as the `RESTATE_AUTH_TOKEN` environment variable.
+    ///
+    /// This is where the token belongs: it stays in a Secret and is never written into the
+    /// plain-text `.properties` files. The container prefers the environment variable over any
+    /// `restate.auth.token` in a config file, so nothing in `spec.config` can shadow it.
     ///
     /// Required when `ingress.cloud` is set; optional (and usually unnecessary) otherwise.
     /// The operator never reads this Secret - it is referenced from the pod spec, so the
@@ -192,10 +182,10 @@ pub struct SecretKeyRef {
     pub key: String,
 }
 
-/// Configuration read from a Secret or ConfigMap and mounted as the container's `CONFIG_FILE`
+/// One additional source of `.properties` configuration: a Secret key or a ConfigMap key.
 #[derive(Deserialize, Serialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct ConfigSource {
+pub struct ConfigRef {
     /// A Secret in this namespace holding the `.properties` configuration.
     /// Exactly one of `secretRef` or `configMapRef` must be specified.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -207,9 +197,9 @@ pub struct ConfigSource {
 }
 
 // Custom JsonSchema implementation so that exactly one of secretRef, configMapRef is required.
-impl JsonSchema for ConfigSource {
+impl JsonSchema for ConfigRef {
     fn schema_name() -> std::borrow::Cow<'static, str> {
-        "ConfigSource".into()
+        "ConfigRef".into()
     }
 
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
@@ -229,7 +219,7 @@ impl JsonSchema for ConfigSource {
         );
 
         schemars::json_schema!({
-            "description": "Configuration read from a Secret or ConfigMap and mounted as the container's `CONFIG_FILE`",
+            "description": "One additional source of `.properties` configuration: a Secret key or a ConfigMap key",
             "properties": {
                 "secretRef": secret_schema,
                 "configMapRef": config_map_schema
@@ -243,23 +233,23 @@ impl JsonSchema for ConfigSource {
     }
 }
 
-impl ConfigSource {
+impl ConfigRef {
     /// The referenced object, or an error if not exactly one of the two was given.
-    pub fn resolve(&self) -> crate::Result<ConfigSourceKind<'_>> {
+    pub fn resolve(&self) -> crate::Result<ConfigRefKind<'_>> {
         match (self.secret_ref.as_ref(), self.config_map_ref.as_ref()) {
-            (Some(secret), None) => Ok(ConfigSourceKind::Secret(secret)),
-            (None, Some(config_map)) => Ok(ConfigSourceKind::ConfigMap(config_map)),
+            (Some(secret), None) => Ok(ConfigRefKind::Secret(secret)),
+            (None, Some(config_map)) => Ok(ConfigRefKind::ConfigMap(config_map)),
             _ => Err(crate::Error::InvalidRestateConfig(
-                "Exactly one of `secretRef` or `configMapRef` must be specified in spec.configFrom"
+                "Exactly one of `secretRef` or `configMapRef` must be specified in each spec.configRefs entry"
                     .into(),
             )),
         }
     }
 }
 
-/// The resolved form of a [`ConfigSource`]
+/// The resolved form of a [`ConfigRef`]
 #[derive(Debug, Clone, Copy)]
-pub enum ConfigSourceKind<'a> {
+pub enum ConfigRefKind<'a> {
     Secret(&'a ConfigKeyRef),
     ConfigMap(&'a ConfigKeyRef),
 }
@@ -359,7 +349,8 @@ impl JsonSchema for RestateIngressEndpoint {
 pub const RESTATE_INGRESS_PORT: i32 = 8080;
 
 impl RestateIngressEndpoint {
-    /// The URL to give the integration as `RESTATE_INGRESS_URL`.
+    /// The resolved ingress URL, which the operator writes as `restate.ingress.url` into the
+    /// first (lowest-precedence) config file it mounts.
     pub fn ingress_url(
         &self,
         rce_store: &Store<RestateCloudEnvironment>,
@@ -549,30 +540,30 @@ mod tests {
     }
 
     #[test]
-    fn config_source_resolves_exactly_one_reference() {
-        let secret: ConfigSource =
+    fn config_ref_resolves_exactly_one_reference() {
+        let secret: ConfigRef =
             serde_json::from_value(serde_json::json!({"secretRef": {"name": "s"}})).unwrap();
         assert!(matches!(
             secret.resolve().unwrap(),
-            ConfigSourceKind::Secret(r) if r.name == "s" && r.key() == "config.properties"
+            ConfigRefKind::Secret(r) if r.name == "s" && r.key() == "config.properties"
         ));
 
-        let config_map: ConfigSource = serde_json::from_value(
+        let config_map: ConfigRef = serde_json::from_value(
             serde_json::json!({"configMapRef": {"name": "c", "key": "other.properties"}}),
         )
         .unwrap();
         assert!(matches!(
             config_map.resolve().unwrap(),
-            ConfigSourceKind::ConfigMap(r) if r.name == "c" && r.key() == "other.properties"
+            ConfigRefKind::ConfigMap(r) if r.name == "c" && r.key() == "other.properties"
         ));
 
         for json in [
             serde_json::json!({}),
             serde_json::json!({"secretRef": {"name": "s"}, "configMapRef": {"name": "c"}}),
         ] {
-            let source: ConfigSource = serde_json::from_value(json).unwrap();
+            let entry: ConfigRef = serde_json::from_value(json).unwrap();
             assert!(matches!(
-                source.resolve(),
+                entry.resolve(),
                 Err(crate::Error::InvalidRestateConfig(_))
             ));
         }


### PR DESCRIPTION
Runs the Restate Kafka ingress integration github.com/restatedev/ingress-integration-kafka as an operator-managed Deployment: a container that consumes Kafka topics and turns each record into a Restate invocation. 

Usage example:

```yaml
apiVersion: restate.dev/v1alpha1
kind: RestateKafkaIntegration
metadata:
  name: orders-to-restate
spec:
  replicas: 2
  restate:
    ingress:
      cluster: restate          # -> http://restate.restate.svc.cluster.local:8080
  config: |
    bootstrap.servers=kafka.kafka.svc.cluster.local:9092
    group.id=orders-to-restate
    topics=orders
    auto.offset.reset=earliest
    restate.record.mapper.service=OrderService
    restate.record.mapper.handler=onKafkaEvent
```

Another example with secrets:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: kafka-config
stringData:
  config.properties: |
    bootstrap.servers=broker.example:9093
    group.id=orders-to-restate
    topics=orders
    security.protocol=SASL_SSL
    sasl.mechanism=PLAIN
    sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="user" password="hunter2";
    restate.record.mapper.service=OrderService
    restate.record.mapper.handler=onKafkaEvent
---
apiVersion: restate.dev/v1alpha1
kind: RestateKafkaIntegration
metadata:
  name: orders-to-restate
spec:
  restate:
    ingress:
      cluster: restate
  configFrom:
    secretRef:
      name: kafka-config     # `key` defaults to config.properties
```


--- Slop slop slop  ---

Only the Restate destination is modelled as CRD fields:

- spec.restate.ingress is the same cluster/cloud/service/url union as RestateDeployment's spec.restate.register, resolved to the ingress port (8080) rather than the admin port.
- spec.restate.authToken references a Secret key in the custom resource's own namespace, passed through as RESTATE_AUTH_TOKEN. Required with ingress.cloud, since the RestateCloudEnvironment's own credentials live in the operator's namespace and copying them across namespaces would mean granting the operator cluster-wide read access to Secrets.

Everything Kafka-side -- connection, consumer settings, record mapper, metrics, retry policy -- is the container's own configuration surface and is passed through verbatim as a Java .properties file, inline via spec.config (held in a ConfigMap the operator owns, digested into the pod template so an edit rolls the pods) or from a Secret/ConfigMap via spec.configFrom. Mirroring those options as typed fields would mean a CRD change for every upstream addition, for no validation worth having.

spec.template is a partial pod template strategic-merged over the generated one: objects merge key by key, and lists whose Kubernetes merge key we know merge entry by entry, so overriding a container's image does not drop its ports and adding an env var does not drop the operator's. The labels backing the Deployment's immutable selector are re-applied after the merge.

The generated pod has no probes on purpose: the image exposes no health endpoint and exits non-zero on unrecoverable errors, so the restart policy is the real liveness mechanism, and a probe on the metrics port would break for anyone setting restate.metrics.enabled=false. Rollouts use maxSurge: 0 to avoid an extra Kafka rebalance.

No finalizer: there is nothing to deregister, so owner references and garbage collection are enough.

RBAC gains cluster-wide apps/deployments and delete on configmaps, since unlike the RestateCloudEnvironment tunnel these children land in the user's namespace.

Note: reaching a RestateCluster's ingress requires spec.security.networkPeers.ingress on that cluster -- documented in the README and examples, since the failure otherwise presents as a hang.


Claude-Session: https://claude.ai/code/session_01PNVbxD7hyaHFyCQTowMdXi