### PR TITLE
Pause annotation: add magical annotation

### DIFF
--- a/crd/RestateCloudEnvironment.pkl
+++ b/crd/RestateCloudEnvironment.pkl
@@ -25,6 +25,10 @@ metadata: ObjectMeta?
 /// Represents the configuration of a Restate Cloud environment
 spec: Spec
 
+/// Status of the RestateCloudEnvironment. This is set and managed automatically by the controller.
+/// Read-only.
+status: Status?
+
 /// Represents the configuration of a Restate Cloud environment
 class Spec {
   /// Where to get credentials for communication with the Cloud environment
@@ -102,4 +106,32 @@ class Tunnel {
 
   /// If specified, the pod's tolerations.
   tolerations: Listing<Toleration>?
+}
+
+/// Status of the RestateCloudEnvironment. This is set and managed automatically by the controller.
+/// Read-only.
+class Status {
+  conditions: Listing<Condition>?
+
+  /// What the operator is currently doing with this environment: `Reconciling`, `Disabled` (suspended by
+  /// the `restate.dev/reconcile: disabled` annotation), or `ResumingReconciliation` (the annotation has
+  /// gone but the tunnel is not ready yet).
+  reconciliation: ("Reconciling"|"Disabled"|"ResumingReconciliation")?
+}
+
+class Condition {
+  /// Last time the condition transitioned from one status to another.
+  lastTransitionTime: String?
+
+  /// Human-readable message indicating details about last transition.
+  message: String?
+
+  /// Unique, one-word, CamelCase reason for the condition's last transition.
+  reason: String?
+
+  /// Status is the status of the condition. Can be True, False, Unknown.
+  status: String
+
+  /// Type of the condition, known values are (`Ready`, `Reconciling`).
+  type: String
 }

--- a/crd/RestateCluster.pkl
+++ b/crd/RestateCluster.pkl
@@ -278,6 +278,11 @@ class Status {
   /// Whether the cluster has been provisioned by the operator. This is set to true after successful
   /// provisioning to avoid repeated provisioning attempts.
   provisioned: Boolean?
+
+  /// What the operator is currently doing with this cluster: `Reconciling`, `Disabled` (suspended by the
+  /// `restate.dev/reconcile: disabled` annotation), or `ResumingReconciliation` (the annotation has gone
+  /// but the cluster is not ready yet).
+  reconciliation: ("Reconciling"|"Disabled"|"ResumingReconciliation")?
 }
 
 class Condition {

--- a/crd/RestateDeployment.pkl
+++ b/crd/RestateDeployment.pkl
@@ -204,6 +204,11 @@ class Status {
   /// Total number of updated ready pods
   readyReplicas: Int?
 
+  /// What the operator is currently doing with this deployment: `Reconciling`, `Disabled` (suspended by
+  /// the `restate.dev/reconcile: disabled` annotation), or `ResumingReconciliation` (the annotation has
+  /// gone but the deployment is not ready yet).
+  reconciliation: ("Reconciling"|"Disabled"|"ResumingReconciliation")?
+
   /// Total number of updated non-terminated pods targeted by this RestateDeployment
   replicas: Int
 

--- a/crd/restatecloudenvironments.yaml
+++ b/crd/restatecloudenvironments.yaml
@@ -803,6 +803,53 @@ spec:
             - region
             - signingPublicKey
             type: object
+          status:
+            description: |-
+              Status of the RestateCloudEnvironment.
+              This is set and managed automatically by the controller.
+              Read-only.
+            nullable: true
+            properties:
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status to another.
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about last transition.
+                      nullable: true
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's last transition.
+                      nullable: true
+                      type: string
+                    status:
+                      description: Status is the status of the condition. Can be True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of the condition, known values are (`Ready`, `Reconciling`).
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                nullable: true
+                type: array
+              reconciliation:
+                description: |-
+                  What the operator is currently doing with this environment: `Reconciling`, `Disabled`
+                  (suspended by the `restate.dev/reconcile: disabled` annotation), or
+                  `ResumingReconciliation` (the annotation has gone but the tunnel is not ready yet).
+                enum:
+                - Reconciling
+                - Disabled
+                - ResumingReconciliation
+                nullable: true
+                type: string
+            type: object
         required:
         - metadata
         - spec
@@ -810,4 +857,5 @@ spec:
         type: object
     served: true
     storage: true
-    subresources: {}
+    subresources:
+      status: {}

--- a/crd/restateclusters.yaml
+++ b/crd/restateclusters.yaml
@@ -3895,6 +3895,17 @@ spec:
                   This is set to true after successful provisioning to avoid repeated provisioning attempts.
                 nullable: true
                 type: boolean
+              reconciliation:
+                description: |-
+                  What the operator is currently doing with this cluster: `Reconciling`, `Disabled`
+                  (suspended by the `restate.dev/reconcile: disabled` annotation), or
+                  `ResumingReconciliation` (the annotation has gone but the cluster is not ready yet).
+                enum:
+                - Reconciling
+                - Disabled
+                - ResumingReconciliation
+                nullable: true
+                type: string
             type: object
         required:
         - metadata

--- a/crd/restatedeployments.yaml
+++ b/crd/restatedeployments.yaml
@@ -430,6 +430,17 @@ spec:
                 format: int32
                 nullable: true
                 type: integer
+              reconciliation:
+                description: |-
+                  What the operator is currently doing with this deployment: `Reconciling`, `Disabled`
+                  (suspended by the `restate.dev/reconcile: disabled` annotation), or
+                  `ResumingReconciliation` (the annotation has gone but the deployment is not ready yet).
+                enum:
+                - Reconciling
+                - Disabled
+                - ResumingReconciliation
+                nullable: true
+                type: string
               replicas:
                 description: Total number of updated non-terminated pods targeted by this RestateDeployment
                 format: int32

--- a/release-notes/unreleased/suspend-reconciliation.md
+++ b/release-notes/unreleased/suspend-reconciliation.md
@@ -1,0 +1,15 @@
+# Suspend reconciliation by annotation
+
+## New Feature
+
+Annotating a `RestateCluster`, `RestateDeployment` or `RestateCloudEnvironment` with
+`restate.dev/reconcile: disabled` makes the operator leave that resource and everything it owns
+alone until the annotation is removed — Flux's `suspend`, per resource, for hand-editing
+generated objects during an incident without scaling the whole operator to zero. Only the exact
+value `disabled` suspends, so a typo cannot silently stop reconciliation; `.status.reconciliation`
+reports `Reconciling`, `Disabled` or `ResumingReconciliation` (annotation gone, not `Ready`
+again yet), and the rest of the status stays frozen as of the last real reconcile. Deletion is
+not suspended — the annotation stops the operator managing a resource, not tearing it down, so a
+suspended resource still deletes and cleans up normally. `RestateCloudEnvironment`
+gained a status subresource for this, so if you manage CRDs yourself (`installCrds: false`),
+apply the new CRDs before rolling the operator image

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -16,6 +16,7 @@ use tracing::{debug, info, warn};
 use url::Url;
 
 use crate::Metrics;
+use crate::resources::ReconciliationState;
 
 pub mod restatecloudenvironment;
 pub mod restatecluster;
@@ -24,6 +25,63 @@ pub mod restatedeployment;
 /// How often each controller re-checks for its missing CRD, and how often the aggregate
 /// `WaitingForCRD` event is re-published while any are missing.
 const CRD_POLL_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Break-glass annotation. Set to `disabled` on a resource and every controller leaves it,
+/// and everything it owns, completely alone until the annotation is removed.
+pub const RECONCILE_ANNOTATION: &str = "restate.dev/reconcile";
+
+/// The one annotation value that suspends reconciliation.
+pub const RECONCILE_DISABLED: &str = "disabled";
+
+/// The condition we write while a resource is suspended. It says in words what
+/// [`ReconciliationState`] says as a value, and the normal status writes replace the whole
+/// condition list, so it clears itself on resume.
+pub const RECONCILING_CONDITION: &str = "Reconciling";
+
+/// Whether reconciliation of this resource is suspended by [`RECONCILE_ANNOTATION`].
+///
+/// Deletion is deliberately not covered: the annotation suspends management of the resource,
+/// not its teardown, so a resource with a deletion timestamp reconciles as normal.
+pub fn reconciliation_suspended<K: kube::ResourceExt>(obj: &K) -> bool {
+    obj.meta().deletion_timestamp.is_none()
+        && obj
+            .annotations()
+            .get(RECONCILE_ANNOTATION)
+            .is_some_and(|value| value == RECONCILE_DISABLED)
+}
+
+/// The `Reconciling` condition message for a suspended resource.
+pub fn suspended_message() -> String {
+    format!(
+        "Reconciliation is suspended by the {RECONCILE_ANNOTATION}={RECONCILE_DISABLED} \
+         annotation."
+    )
+}
+
+/// Log a skipped reconcile: once at info when the suspension starts, at debug for as long as
+/// it lasts. A resource can sit suspended for days, and every watch resync comes back here.
+pub fn log_suspended(kind: &str, name: &str, previous: Option<ReconciliationState>) {
+    if previous == Some(ReconciliationState::Disabled) {
+        debug!("Skipping {kind} {name}: {}", suspended_message());
+    } else {
+        info!("Skipping {kind} {name}: {}", suspended_message());
+    }
+}
+
+/// The state to report after a reconcile that actually ran.
+pub fn state_after_reconcile(
+    previous: Option<ReconciliationState>,
+    ready_status: &str,
+) -> ReconciliationState {
+    match previous {
+        Some(ReconciliationState::Disabled | ReconciliationState::ResumingReconciliation)
+            if ready_status != "True" =>
+        {
+            ReconciliationState::ResumingReconciliation
+        }
+        _ => ReconciliationState::Reconciling,
+    }
+}
 
 /// Diagnostics to be exposed by the web server
 #[derive(Clone, Serialize)]
@@ -609,7 +667,89 @@ async fn publish_crd_wait_event(
 
 #[cfg(test)]
 mod tests {
-    use super::{Readiness, ReadinessGate, pending_crds_note};
+    use super::{
+        RECONCILE_ANNOTATION, Readiness, ReadinessGate, pending_crds_note,
+        reconciliation_suspended, state_after_reconcile, suspended_message,
+    };
+    use crate::resources::ReconciliationState;
+    use crate::resources::restateclusters::{RestateCluster, RestateClusterSpec};
+    use chrono::Utc;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+    use kube::ResourceExt;
+
+    fn annotated(annotations: &[(&str, &str)]) -> RestateCluster {
+        let mut rc = RestateCluster::new("cluster", RestateClusterSpec::default());
+        rc.annotations_mut().extend(
+            annotations
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string())),
+        );
+        rc
+    }
+
+    /// Only `disabled` suspends, so a typo in the annotation can't quietly stop the operator.
+    #[test]
+    fn only_disabled_suspends_reconciliation() {
+        assert!(!reconciliation_suspended(&annotated(&[])));
+        assert!(reconciliation_suspended(&annotated(&[(
+            RECONCILE_ANNOTATION,
+            "disabled"
+        )])));
+
+        for value in ["enabled", "", "Disabled", "true", "suspended"] {
+            assert!(
+                !reconciliation_suspended(&annotated(&[(RECONCILE_ANNOTATION, value)])),
+                "{RECONCILE_ANNOTATION}={value} must not suspend reconciliation"
+            );
+        }
+    }
+
+    /// The suspension has to name the annotation, or there's no way to tell what stopped it.
+    #[test]
+    fn the_suspension_message_names_the_annotation() {
+        let message = suspended_message();
+        assert!(message.contains(RECONCILE_ANNOTATION), "{message}");
+    }
+
+    /// The annotation suspends management, not teardown: a delete goes through regardless.
+    #[test]
+    fn deletion_is_not_suspended() {
+        let mut rc = annotated(&[(RECONCILE_ANNOTATION, "disabled")]);
+        assert!(reconciliation_suspended(&rc));
+
+        rc.metadata.deletion_timestamp = Some(Time(Utc::now()));
+        assert!(!reconciliation_suspended(&rc));
+    }
+
+    /// Resuming lasts until the resource is ready again, not just until the annotation goes.
+    #[test]
+    fn resuming_lasts_until_the_resource_is_ready_again() {
+        use ReconciliationState::*;
+
+        // still converging after the annotation was removed
+        assert_eq!(
+            state_after_reconcile(Some(Disabled), "False"),
+            ResumingReconciliation
+        );
+        assert_eq!(
+            state_after_reconcile(Some(ResumingReconciliation), "Unknown"),
+            ResumingReconciliation
+        );
+
+        // ready again, so the resume is over
+        assert_eq!(
+            state_after_reconcile(Some(ResumingReconciliation), "True"),
+            Reconciling
+        );
+        assert_eq!(state_after_reconcile(Some(Disabled), "True"), Reconciling);
+
+        // never suspended, so never resuming, however unready it is
+        assert_eq!(state_after_reconcile(None, "False"), Reconciling);
+        assert_eq!(
+            state_after_reconcile(Some(Reconciling), "False"),
+            Reconciling
+        );
+    }
 
     /// One event has to describe every controller's wait, so the note is the only place the
     /// missing CRDs get named.

--- a/src/controllers/restatecloudenvironment/controller.rs
+++ b/src/controllers/restatecloudenvironment/controller.rs
@@ -6,7 +6,7 @@ use futures::StreamExt;
 
 use k8s_openapi::api::apps::v1::Deployment;
 
-use kube::api::{Api, ObjectMeta};
+use kube::api::{Api, ObjectMeta, Patch, PatchParams};
 use kube::client::Client;
 use kube::runtime::controller;
 use kube::runtime::controller::Action;
@@ -15,13 +15,19 @@ use kube::runtime::finalizer::{Event as Finalizer, finalizer};
 use kube::runtime::watcher::Config;
 
 use kube::{Resource, ResourceExt};
+use serde_json::json;
 use tokio::sync::RwLock;
 use tracing::*;
 
-use crate::controllers::{CrdWait, Diagnostics, ReadinessGate, State, wait_for_crd};
+use crate::controllers::{
+    CrdWait, Diagnostics, RECONCILING_CONDITION, ReadinessGate, State, log_suspended,
+    reconciliation_suspended, state_after_reconcile, suspended_message, wait_for_crd,
+};
 use crate::metrics::Metrics;
+use crate::resources::ReconciliationState;
 use crate::resources::restatecloudenvironments::{
-    RESTATE_CLOUD_ENVIRONMENT_FINALIZER, RestateCloudEnvironment,
+    RESTATE_CLOUD_ENVIRONMENT_FINALIZER, RestateCloudEnvironment, RestateCloudEnvironmentCondition,
+    RestateCloudEnvironmentStatus,
 };
 use crate::telemetry;
 use crate::{Error, Result};
@@ -67,6 +73,12 @@ async fn reconcile(rs: Arc<RestateCloudEnvironment>, ctx: Arc<Context>) -> Resul
 
     let services_api: Api<RestateCloudEnvironment> = Api::all(ctx.client.clone());
 
+    // Check this before the finalizer helper, which adds our finalizer to resources that
+    // don't have one yet. That's a write, and we've been asked not to write to this one.
+    if reconciliation_suspended(rs.as_ref()) {
+        return rs.reconcile_suspended(&services_api).await;
+    }
+
     info!("Reconciling RestateCloudEnvironment {}", rs.name_any(),);
     match finalizer(
         &services_api,
@@ -74,7 +86,7 @@ async fn reconcile(rs: Arc<RestateCloudEnvironment>, ctx: Arc<Context>) -> Resul
         rs.clone(),
         |event| async {
             match event {
-                Finalizer::Apply(rs) => rs.reconcile(ctx.clone(), &rs.name_any()).await,
+                Finalizer::Apply(rs) => rs.reconcile_status(ctx.clone()).await,
                 Finalizer::Cleanup(rs) => rs.cleanup(ctx.clone()).await,
             }
         },
@@ -110,6 +122,128 @@ fn error_policy<K, C>(_rs: Arc<K>, _: &Error, _ctx: C) -> Action {
 }
 
 impl RestateCloudEnvironment {
+    /// Note the suspension in the status, and leave everything else alone.
+    async fn reconcile_suspended(&self, rces: &Api<RestateCloudEnvironment>) -> Result<Action> {
+        let name = self.name_any();
+        let message = suspended_message();
+        let previous = self.status.as_ref().and_then(|s| s.reconciliation);
+
+        log_suspended("RestateCloudEnvironment", &name, previous);
+
+        let existing = self
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.as_ref())
+            .and_then(|c| c.iter().find(|cond| cond.r#type == RECONCILING_CONDITION));
+        let now = k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(Utc::now());
+
+        let suspended = RestateCloudEnvironmentCondition {
+            last_transition_time: Some(
+                match existing {
+                    Some(cond) if cond.status == "False" => cond.last_transition_time.clone(),
+                    _ => None,
+                }
+                .unwrap_or(now),
+            ),
+            message: Some(message),
+            reason: Some(ReconciliationState::Disabled.as_str().into()),
+            status: "False".into(),
+            r#type: RECONCILING_CONDITION.into(),
+        };
+
+        let mut conditions: Vec<_> = self
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|cond| cond.r#type != RECONCILING_CONDITION)
+            .collect();
+        conditions.push(suspended);
+
+        let new_status = Patch::Apply(json!({
+            "apiVersion": RestateCloudEnvironment::api_version(&()),
+            "kind": RestateCloudEnvironment::kind(&()),
+            "status": RestateCloudEnvironmentStatus {
+                conditions: Some(conditions),
+                reconciliation: Some(ReconciliationState::Disabled),
+            }
+        }));
+        let ps = PatchParams::apply("restate-operator").force();
+        rces.patch_status(&name, &ps, &new_status).await?;
+
+        Ok(Action::await_change())
+    }
+
+    /// Reconcile, then record the outcome in the status.
+    ///
+    /// Without this write a resumed environment would keep the `Disabled` left over from its
+    /// suspension, and claim forever that we aren't managing it.
+    async fn reconcile_status(&self, ctx: Arc<Context>) -> Result<Action> {
+        let rces: Api<RestateCloudEnvironment> = Api::all(ctx.client.clone());
+        let name = self.name_any();
+
+        let (result, message, reason, status) = match self.reconcile(ctx, &name).await {
+            Ok(action) => (
+                Ok(action),
+                "Restate Cloud environment reconciled successfully".into(),
+                "Reconciled".into(),
+                "True".into(),
+            ),
+            Err(err) => {
+                let message = err.to_string();
+                (
+                    Err(err),
+                    message,
+                    "FailedReconcile".into(),
+                    "Unknown".into(),
+                )
+            }
+        };
+
+        let existing_ready = self
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.as_ref())
+            .and_then(|c| c.iter().find(|cond| cond.r#type == "Ready"));
+        let now = k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(Utc::now());
+
+        let mut ready = RestateCloudEnvironmentCondition {
+            last_transition_time: Some(
+                existing_ready
+                    .and_then(|r| r.last_transition_time.clone())
+                    .unwrap_or_else(|| now.clone()),
+            ),
+            message: Some(message),
+            reason: Some(reason),
+            status,
+            r#type: "Ready".into(),
+        };
+
+        if existing_ready.map(|r| &r.status) != Some(&ready.status) {
+            ready.last_transition_time = Some(now)
+        }
+
+        let ready_status = ready.status.clone();
+        let new_status = Patch::Apply(json!({
+            "apiVersion": RestateCloudEnvironment::api_version(&()),
+            "kind": RestateCloudEnvironment::kind(&()),
+            "status": RestateCloudEnvironmentStatus {
+                // Replacing the whole list is what clears the `Reconciling` condition after
+                // a suspension.
+                conditions: Some(vec![ready]),
+                reconciliation: Some(state_after_reconcile(
+                    self.status.as_ref().and_then(|s| s.reconciliation),
+                    &ready_status,
+                )),
+            }
+        }));
+        let ps = PatchParams::apply("restate-operator").force();
+        rces.patch_status(&name, &ps, &new_status).await?;
+
+        result
+    }
+
     // Reconcile (for non-finalizer related changes)
     async fn reconcile(&self, ctx: Arc<Context>, name: &str) -> Result<Action> {
         let oref = self.controller_owner_ref(&()).unwrap();

--- a/src/controllers/restatecluster/controller.rs
+++ b/src/controllers/restatecluster/controller.rs
@@ -35,8 +35,11 @@ use tokio::{sync::RwLock, time::Duration};
 use tracing::*;
 
 use crate::controllers::{
-    CrdWait, Diagnostics, ReadinessGate, State, wait_for_api_groups, wait_for_crd,
+    CrdWait, Diagnostics, RECONCILING_CONDITION, ReadinessGate, State, log_suspended,
+    reconciliation_suspended, state_after_reconcile, suspended_message, wait_for_api_groups,
+    wait_for_crd,
 };
+use crate::resources::ReconciliationState;
 use crate::resources::iampolicymembers::IAMPolicyMember;
 use crate::resources::podidentityassociations::PodIdentityAssociation;
 use crate::resources::restateclusters::{
@@ -127,6 +130,12 @@ async fn reconcile(rc: Arc<RestateCluster>, ctx: Arc<Context>) -> Result<Action>
     let _timer = ctx.metrics.count_and_measure::<RestateCluster>();
     ctx.diagnostics.write().await.last_event = Utc::now();
     let rcs: Api<RestateCluster> = Api::all(ctx.client.clone());
+
+    // Check this before the finalizer helper, which adds our finalizer to resources that
+    // don't have one yet. That's a write, and we've been asked not to write to this one.
+    if reconciliation_suspended(rc.as_ref()) {
+        return rc.reconcile_suspended(&rcs).await;
+    }
 
     info!("Reconciling RestateCluster \"{}\"", rc.name_any());
     match finalizer(&rcs, RESTATE_CLUSTER_FINALIZER, rc.clone(), |event| async {
@@ -248,6 +257,68 @@ impl RestateCluster {
         Ok(())
     }
 
+    /// Note the suspension in the status, and leave everything else alone.
+    ///
+    /// The status is ours to write, so this doesn't disturb anything that was changed by hand.
+    /// The rest of it stays as the last real reconcile left it, `observedGeneration` included:
+    /// if the spec has moved on since, that's how you can tell.
+    async fn reconcile_suspended(&self, rcs: &Api<RestateCluster>) -> Result<Action> {
+        let name = self.name_any();
+        let message = suspended_message();
+        let reason = ReconciliationState::Disabled.as_str();
+        let previous = self.status.as_ref().and_then(|s| s.reconciliation);
+
+        log_suspended("RestateCluster", &name, previous);
+
+        let existing = self
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.as_ref())
+            .and_then(|c| c.iter().find(|cond| cond.r#type == RECONCILING_CONDITION));
+        let now = k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(Utc::now());
+
+        let suspended = RestateClusterCondition {
+            // Only the start of the suspension is a transition.
+            last_transition_time: Some(
+                match existing {
+                    Some(cond) if cond.status == "False" => cond.last_transition_time.clone(),
+                    _ => None,
+                }
+                .unwrap_or(now),
+            ),
+            message: Some(message),
+            reason: Some(reason.into()),
+            status: "False".into(),
+            r#type: RECONCILING_CONDITION.into(),
+        };
+
+        // Leave the other conditions alone. A stale `Ready` is still worth having, and it
+        // says when it was last true.
+        let mut conditions: Vec<_> = self
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.clone())
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|cond| cond.r#type != RECONCILING_CONDITION)
+            .collect();
+        conditions.push(suspended);
+
+        let new_status = Patch::Apply(json!({
+            "apiVersion": "restate.dev/v1",
+            "kind": "RestateCluster",
+            "status": RestateClusterStatus {
+                conditions: Some(conditions),
+                reconciliation: Some(ReconciliationState::Disabled),
+                provisioned: self.status.as_ref().and_then(|s| s.provisioned),
+            }
+        }));
+        let ps = PatchParams::apply("restate-operator").force();
+        rcs.patch_status(&name, &ps, &new_status).await?;
+
+        Ok(Action::await_change())
+    }
+
     async fn reconcile_status(&self, ctx: Arc<Context>) -> Result<Action> {
         let rcs: Api<RestateCluster> = Api::all(ctx.client.clone());
 
@@ -345,6 +416,8 @@ impl RestateCluster {
             ready.last_transition_time = Some(now)
         }
 
+        let ready_status = ready.status.clone();
+
         // Preserve the provisioned status from the existing status, or set it if we just provisioned
         let provisioned = if set_provisioned {
             Some(true)
@@ -355,7 +428,13 @@ impl RestateCluster {
             "apiVersion": "restate.dev/v1",
             "kind": "RestateCluster",
             "status": RestateClusterStatus {
+                // Replacing the whole list is what clears the `Reconciling` condition after
+                // a suspension.
                 conditions: Some(vec![ready]),
+                reconciliation: Some(state_after_reconcile(
+                    self.status.as_ref().and_then(|s| s.reconciliation),
+                    &ready_status,
+                )),
                 provisioned,
             }
         }));

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -30,9 +30,12 @@ use tokio::sync::RwLock;
 use tracing::*;
 
 use crate::controllers::{
-    CrdWait, Diagnostics, ReadinessGate, State, prewarmed_reflector, wait_for_crd,
+    CrdWait, Diagnostics, RECONCILING_CONDITION, ReadinessGate, State, log_suspended,
+    prewarmed_reflector, reconciliation_suspended, state_after_reconcile, suspended_message,
+    wait_for_crd,
 };
 use crate::metrics::Metrics;
+use crate::resources::ReconciliationState;
 use crate::resources::knative::{Configuration, Revision, Route};
 use crate::resources::restatecloudenvironments::{InProcessTunnelParams, RestateCloudEnvironment};
 use crate::resources::restateclusters::RestateCluster;
@@ -169,6 +172,12 @@ async fn reconcile(rs: Arc<RestateDeployment>, ctx: Arc<Context>) -> Result<Acti
     };
 
     let services_api: Api<RestateDeployment> = Api::namespaced(ctx.client.clone(), namespace);
+
+    // Check this before the finalizer helper, which adds our finalizer to resources that
+    // don't have one yet. That's a write, and we've been asked not to write to this one.
+    if reconciliation_suspended(rs.as_ref()) {
+        return rs.reconcile_suspended(&services_api).await;
+    }
 
     info!(
         "Reconciling RestateDeployment {} in namespace {namespace}",
@@ -676,6 +685,66 @@ impl RestateDeployment {
         Ok((replicaset, next_removal))
     }
 
+    /// Note the suspension in the status, and leave everything else alone.
+    async fn reconcile_suspended(&self, rsd_api: &Api<RestateDeployment>) -> Result<Action> {
+        let name = self.name_any();
+        let message = suspended_message();
+        let reason = ReconciliationState::Disabled.as_str();
+        let previous = self.status.as_ref().and_then(|s| s.reconciliation);
+
+        log_suspended("RestateDeployment", &name, previous);
+
+        let existing = self
+            .status
+            .as_ref()
+            .and_then(|s| s.conditions.as_ref())
+            .and_then(|c| c.iter().find(|cond| cond.r#type == RECONCILING_CONDITION));
+        let now = Time(Utc::now());
+
+        let suspended = RestateDeploymentCondition {
+            // Only the start of the suspension is a transition.
+            last_transition_time: Some(
+                match existing {
+                    Some(cond) if cond.status == "False" => cond.last_transition_time.clone(),
+                    _ => None,
+                }
+                .unwrap_or(now),
+            ),
+            message: Some(message),
+            reason: Some(reason.into()),
+            status: "False".into(),
+            r#type: RECONCILING_CONDITION.into(),
+        };
+
+        let mut rsd_status = self.status.clone().unwrap_or_default();
+
+        // Leave the other conditions alone. A stale `Ready` is still worth having, and it
+        // says when it was last true.
+        let mut conditions: Vec<_> = rsd_status
+            .conditions
+            .take()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|cond| cond.r#type != RECONCILING_CONDITION)
+            .collect();
+        conditions.push(suspended);
+        rsd_status.conditions = Some(conditions);
+        rsd_status.reconciliation = Some(ReconciliationState::Disabled);
+
+        let new_status = json!({
+            "apiVersion": RestateDeployment::api_version(&()),
+            "kind": RestateDeployment::kind(&()),
+            "status": rsd_status,
+        });
+
+        let ps = PatchParams::apply("restate-operator").force();
+        rsd_api
+            .patch_status(&name, &ps, &Patch::Apply(new_status))
+            .await?;
+
+        Ok(Action::await_change())
+    }
+
     async fn reconcile_status(&self, ctx: Arc<Context>, namespace: &str) -> Result<Action> {
         use crate::resources::restatedeployments::DeploymentMode;
 
@@ -1035,8 +1104,15 @@ impl RestateDeployment {
             status,
             r#type: "Ready".into(),
         };
+        let ready_status = ready_condition.status.clone();
 
+        // Replacing the whole list is what clears the `Reconciling` condition after a
+        // suspension.
         rsd_status.conditions = Some(vec![ready_condition]);
+        rsd_status.reconciliation = Some(state_after_reconcile(
+            self.status.as_ref().and_then(|s| s.reconciliation),
+            &ready_status,
+        ));
 
         // Only set labelSelector for ReplicaSet mode (Knative manages pods directly)
         if !is_knative {

--- a/src/resources/mod.rs
+++ b/src/resources/mod.rs
@@ -6,3 +6,72 @@ pub mod restateclusters;
 pub mod restatedeployments;
 pub mod secretproviderclasses;
 pub mod securitygrouppolicies;
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+// What the operator is doing with a resource, written on every reconcile.
+//
+// Not a doc comment: give the type a description and schemars renders `Option<T>` as an
+// `anyOf`, which the API server won't accept. Each status field documents itself instead.
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
+pub enum ReconciliationState {
+    /// The operator is managing this resource normally.
+    Reconciling,
+    /// Suspended by the `restate.dev/reconcile: disabled` annotation. The operator won't
+    /// change this resource or anything it owns, though deleting it still works normally.
+    /// The rest of the status is whatever the last real reconcile left behind.
+    Disabled,
+    /// The annotation is gone, but the resource isn't ready again yet. Anything changed by
+    /// hand during the suspension is being undone. Worth a look if it stays here.
+    ResumingReconciliation,
+}
+
+impl ReconciliationState {
+    /// Every state, in the order they appear in the CRD.
+    pub const ALL: [Self; 3] = [
+        Self::Reconciling,
+        Self::Disabled,
+        Self::ResumingReconciliation,
+    ];
+
+    /// Used for the status field and for the `Reconciling` condition's reason, so the two
+    /// always agree.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Reconciling => "Reconciling",
+            Self::Disabled => "Disabled",
+            Self::ResumingReconciliation => "ResumingReconciliation",
+        }
+    }
+}
+
+/// Schema for a `.status.reconciliation` field.
+///
+/// Written by hand: the status structs derive plain `JsonSchema`, which renders
+/// `Option<ReconciliationState>` as an `anyOf` the API server won't accept. Values come from
+/// [`ReconciliationState::ALL`], so this can't drift from the enum.
+pub fn reconciliation_schema(_g: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "string",
+        "enum": ReconciliationState::ALL.map(ReconciliationState::as_str).to_vec(),
+        "nullable": true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ReconciliationState;
+
+    /// The CRD's enum comes from `as_str`, but the status is written through serde. If those
+    /// two ever disagreed, every status write would start failing validation.
+    #[test]
+    fn the_schema_values_are_the_ones_serde_writes() {
+        for state in ReconciliationState::ALL {
+            assert_eq!(
+                serde_json::to_value(state).expect("state serializes"),
+                serde_json::Value::String(state.as_str().to_owned()),
+            );
+        }
+    }
+}

--- a/src/resources/restatecloudenvironments.rs
+++ b/src/resources/restatecloudenvironments.rs
@@ -24,7 +24,7 @@ pub static RESTATE_CLOUD_ENVIRONMENT_FINALIZER: &str = "cloudenvironments.restat
     printcolumn = r#"{"name":"Region", "type":"string", "jsonPath":".spec.region"}"#,
     printcolumn = r#"{"name":"Age", "description": "CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC", "type":"date", "jsonPath":".metadata.creationTimestamp"}"#
 )]
-#[kube(shortname = "rce")]
+#[kube(status = "RestateCloudEnvironmentStatus", shortname = "rce")]
 #[serde(rename_all = "camelCase")]
 pub struct RestateCloudEnvironmentSpec {
     /// The ID of your environment, which begins `env_`
@@ -49,6 +49,7 @@ impl schemars::JsonSchema for RestateCloudEnvironment {
     }
     fn json_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
         let spec_schema = generator.subschema_for::<RestateCloudEnvironmentSpec>();
+        let status_schema = generator.subschema_for::<Option<RestateCloudEnvironmentStatus>>();
 
         schemars::json_schema!({
             "type": "object",
@@ -65,11 +66,46 @@ impl schemars::JsonSchema for RestateCloudEnvironment {
                         }
                     }
                 },
-                "spec": spec_schema
+                "spec": spec_schema,
+                "status": status_schema
             },
             "required": ["metadata", "spec"]
         })
     }
+}
+
+/// Status of the RestateCloudEnvironment.
+/// This is set and managed automatically by the controller.
+/// Read-only.
+#[derive(Deserialize, Serialize, Clone, Default, Debug, JsonSchema)]
+pub struct RestateCloudEnvironmentStatus {
+    pub conditions: Option<Vec<RestateCloudEnvironmentCondition>>,
+
+    /// What the operator is currently doing with this environment: `Reconciling`, `Disabled`
+    /// (suspended by the `restate.dev/reconcile: disabled` annotation), or
+    /// `ResumingReconciliation` (the annotation has gone but the tunnel is not ready yet).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(default, schema_with = "crate::resources::reconciliation_schema")]
+    pub reconciliation: Option<crate::resources::ReconciliationState>,
+}
+
+#[derive(Deserialize, Serialize, Clone, Default, Debug, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct RestateCloudEnvironmentCondition {
+    /// Last time the condition transitioned from one status to another.
+    pub last_transition_time: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Time>,
+
+    /// Human-readable message indicating details about last transition.
+    pub message: Option<String>,
+
+    /// Unique, one-word, CamelCase reason for the condition's last transition.
+    pub reason: Option<String>,
+
+    /// Status is the status of the condition. Can be True, False, Unknown.
+    pub status: String,
+
+    /// Type of the condition, known values are (`Ready`, `Reconciling`).
+    pub r#type: String,
 }
 
 impl RestateCloudEnvironment {

--- a/src/resources/restateclusters.rs
+++ b/src/resources/restateclusters.rs
@@ -367,6 +367,10 @@ pub struct SecretProviderSigningKeySource {
 #[derive(Deserialize, Serialize, Clone, Default, Debug, JsonSchema)]
 pub struct RestateClusterStatus {
     pub conditions: Option<Vec<RestateClusterCondition>>,
+    /// What the operator is currently doing with this cluster.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(default, schema_with = "crate::resources::reconciliation_schema")]
+    pub reconciliation: Option<crate::resources::ReconciliationState>,
     /// Whether the cluster has been provisioned by the operator.
     /// This is set to true after successful provisioning to avoid repeated provisioning attempts.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -543,6 +543,11 @@ pub struct RestateDeploymentStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deployment_id: Option<String>,
 
+    /// What the operator is currently doing with this deployment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(default, schema_with = "crate::resources::reconciliation_schema")]
+    pub reconciliation: Option<crate::resources::ReconciliationState>,
+
     /// Knative-specific status
     #[serde(skip_serializing_if = "Option::is_none")]
     pub knative: Option<KnativeDeploymentStatus>,


### PR DESCRIPTION
This adds a magical annotation that pauses the reconcilation in the three controllers.