### PR TITLE
Add Deletion policies to the Deployment Sepc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,11 @@ Error types are defined in `src/lib.rs`. Use the `Error` enum for controller err
 
 Both RestateCluster and RestateDeployment use finalizers for cleanup:
 - `clusters.restate.dev` - Ensures namespace deletion
-- `deployments.restate.dev` - Ensures service deregistration and ReplicaSet cleanup
+- `deployments.restate.dev` - Ensures service deregistration and ReplicaSet cleanup.
+  How long deletion waits for in-flight invocations is set by
+  `spec.restate.deletePolicy` (`drain` | `force`) and, for a drain,
+  `spec.restate.drain` (`timeoutSeconds` and `onTimeout`: `hold` | `force`);
+  progress is reported on `.status.deletion`. See `docs/delete-policy.md`
 
 ### Restate Invocation Lifecycle and Deployment Status
 

--- a/crd/RestateDeployment.pkl
+++ b/crd/RestateDeployment.pkl
@@ -113,6 +113,15 @@ class Knative {
 
 /// Restate specific configuration
 class Restate {
+  /// What to do about in-flight invocations when this RestateDeployment is deleted. Defaults to `drain`.
+  /// - `drain`: wait for in-flight invocations to finish, on the terms set by `drain`. - `force`:
+  /// deregister and tear down immediately, without draining.
+  deletePolicy: ("drain"|"force")?
+
+  /// How `deletePolicy: drain` waits: how long, and whether it eventually gives up. Ignored by
+  /// `deletePolicy: force`, which never waits.
+  drain: Drain?
+
   /// Seconds to wait before removing old versions after they are drained. Defaults to 300 (5 minutes).
   drainDelaySeconds: Int(isPositive)?
 
@@ -134,6 +143,18 @@ class Restate {
 
   /// Force the use of HTTP/1.1 when registering with Restate
   useHttp11: Boolean?
+}
+
+/// How `deletePolicy: drain` waits: how long, and whether it eventually gives up. Ignored by
+/// `deletePolicy: force`, which never waits.
+class Drain {
+  /// What to do once `timeoutSeconds` has passed. Defaults to `hold`. - `hold`: keep waiting, and report
+  /// the drain as overdue - `force`: force-deregister, abandoning whatever is left
+  onTimeout: ("hold"|"force")?
+
+  /// Seconds to wait for in-flight invocations to finish. Defaults to 3600 (1 hour). Under `onTimeout:
+  /// hold` this only sets when the drain reports itself overdue; it never lets the deletion through
+  timeoutSeconds: Int(isPositive)?
 }
 
 /// The location of the Restate Admin API to register this deployment against
@@ -185,6 +206,10 @@ class Status {
   /// Represents the latest available observations of current state
   conditions: Listing<Condition>?
 
+  /// Progress of an in-flight deletion. Only set once the RestateDeployment has been deleted and the
+  /// operator is working through `spec.restate.deletePolicy`
+  deletion: Deletion?
+
   /// Restate deployment ID for the current tag
   deploymentId: String?
 
@@ -204,9 +229,7 @@ class Status {
   /// Total number of updated ready pods
   readyReplicas: Int?
 
-  /// What the operator is currently doing with this deployment: `Reconciling`, `Disabled` (suspended by
-  /// the `restate.dev/reconcile: disabled` annotation), or `ResumingReconciliation` (the annotation has
-  /// gone but the deployment is not ready yet).
+  /// What the operator is currently doing with this deployment.
   reconciliation: ("Reconciling"|"Disabled"|"ResumingReconciliation")?
 
   /// Total number of updated non-terminated pods targeted by this RestateDeployment
@@ -232,6 +255,52 @@ class Condition {
 
   /// Type of condition (Ready, Progressing, Available)
   type: String
+}
+
+/// Progress of an in-flight deletion. Only set once the RestateDeployment has been deleted and the
+/// operator is working through `spec.restate.deletePolicy`
+class Deletion {
+  /// When the drain timeout expires. Unset under `deletePolicy: force`
+  deadline: String?
+
+  /// Human-readable explanation of what the deletion is waiting for
+  message: String?
+
+  /// What happens at the `deadline`: `hold` keeps waiting, `force` gives up and deregisters. Unset under
+  /// `deletePolicy: force`, which has no deadline to reach
+  onTimeout: ("hold"|"force")?
+
+  /// The versions holding the deletion, and the invocations they are waiting on
+  pendingInvocations: Listing<PendingInvocation>?
+
+  /// Where the deletion has got to
+  phase: "Draining"|"Overdue"|"Forcing"
+
+  /// The policy being applied
+  policy: "drain"|"force"
+
+  /// When deletion was requested
+  startedAt: String?
+
+  /// Total invocations across all versions holding the deletion
+  totalPendingInvocations: Int
+}
+
+/// Invocations holding one version of a deleting RestateDeployment
+class PendingInvocation {
+  /// The Restate deployment ID this version is registered as
+  deploymentId: String?
+
+  /// Unfinished invocations already bound to this version
+  pinned: Int
+
+  /// Unfinished invocations not yet bound to any version, but targeting a service this version is the
+  /// endpoint for. Not counted under `deletePolicy: force`, which does not run the query that attributes
+  /// them
+  unpinned: Int
+
+  /// The ReplicaSet (or Knative Configuration) name
+  version: String
 }
 
 /// Knative-specific status

--- a/crd/restatedeployments.yaml
+++ b/crd/restatedeployments.yaml
@@ -44,6 +44,14 @@ spec:
       name: Selector
       priority: 1
       type: string
+    - jsonPath: .status.deletion.phase
+      name: Deletion
+      priority: 1
+      type: string
+    - jsonPath: .status.deletion.totalPendingInvocations
+      name: Pending Invocations
+      priority: 1
+      type: integer
     name: v1beta1
     schema:
       openAPIV3Schema:
@@ -162,6 +170,43 @@ spec:
               restate:
                 description: Restate specific configuration
                 properties:
+                  deletePolicy:
+                    description: |-
+                      What to do about in-flight invocations when this RestateDeployment is deleted.
+                      Defaults to `drain`.
+                      - `drain`: wait for in-flight invocations to finish, on the terms set by `drain`.
+                      - `force`: deregister and tear down immediately, without draining.
+                    enum:
+                    - drain
+                    - force
+                    nullable: true
+                    type: string
+                  drain:
+                    description: |-
+                      How `deletePolicy: drain` waits: how long, and whether it eventually gives up.
+                      Ignored by `deletePolicy: force`, which never waits.
+                    nullable: true
+                    properties:
+                      onTimeout:
+                        description: |-
+                          What to do once `timeoutSeconds` has passed. Defaults to `hold`.
+                          - `hold`: keep waiting, and report the drain as overdue
+                          - `force`: force-deregister, abandoning whatever is left
+                        enum:
+                        - hold
+                        - force
+                        nullable: true
+                        type: string
+                      timeoutSeconds:
+                        description: |-
+                          Seconds to wait for in-flight invocations to finish. Defaults to 3600 (1 hour).
+                          Under `onTimeout: hold` this only sets when the drain reports itself overdue; it
+                          never lets the deletion through
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                    type: object
                   drainDelaySeconds:
                     description: |-
                       Seconds to wait before removing old versions after they are drained.
@@ -383,6 +428,86 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              deletion:
+                description: |-
+                  Progress of an in-flight deletion. Only set once the RestateDeployment has been
+                  deleted and the operator is working through `spec.restate.deletePolicy`
+                nullable: true
+                properties:
+                  deadline:
+                    description: 'When the drain timeout expires. Unset under `deletePolicy: force`'
+                    format: date-time
+                    nullable: true
+                    type: string
+                  message:
+                    description: Human-readable explanation of what the deletion is waiting for
+                    nullable: true
+                    type: string
+                  onTimeout:
+                    description: |-
+                      What happens at the `deadline`: `hold` keeps waiting, `force` gives up and
+                      deregisters. Unset under `deletePolicy: force`, which has no deadline to reach
+                    enum:
+                    - hold
+                    - force
+                    nullable: true
+                    type: string
+                  pendingInvocations:
+                    description: The versions holding the deletion, and the invocations they are waiting on
+                    items:
+                      description: Invocations holding one version of a deleting RestateDeployment
+                      properties:
+                        deploymentId:
+                          description: The Restate deployment ID this version is registered as
+                          nullable: true
+                          type: string
+                        pinned:
+                          description: Unfinished invocations already bound to this version
+                          format: int64
+                          type: integer
+                        unpinned:
+                          description: |-
+                            Unfinished invocations not yet bound to any version, but targeting a service this
+                            version is the endpoint for. Not counted under `deletePolicy: force`, which does
+                            not run the query that attributes them
+                          format: int64
+                          type: integer
+                        version:
+                          description: The ReplicaSet (or Knative Configuration) name
+                          type: string
+                      required:
+                      - pinned
+                      - unpinned
+                      - version
+                      type: object
+                    type: array
+                  phase:
+                    description: Where the deletion has got to
+                    enum:
+                    - Draining
+                    - Overdue
+                    - Forcing
+                    type: string
+                  policy:
+                    description: The policy being applied
+                    enum:
+                    - drain
+                    - force
+                    type: string
+                  startedAt:
+                    description: When deletion was requested
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalPendingInvocations:
+                    description: Total invocations across all versions holding the deletion
+                    format: int64
+                    type: integer
+                required:
+                - phase
+                - policy
+                - totalPendingInvocations
+                type: object
               deploymentId:
                 description: Restate deployment ID for the current tag
                 nullable: true
@@ -431,10 +556,7 @@ spec:
                 nullable: true
                 type: integer
               reconciliation:
-                description: |-
-                  What the operator is currently doing with this deployment: `Reconciling`, `Disabled`
-                  (suspended by the `restate.dev/reconcile: disabled` annotation), or
-                  `ResumingReconciliation` (the annotation has gone but the deployment is not ready yet).
+                description: What the operator is currently doing with this deployment.
                 enum:
                 - Reconciling
                 - Disabled

--- a/docs/delete-policy.md
+++ b/docs/delete-policy.md
@@ -1,0 +1,136 @@
+# Deleting a RestateDeployment: `deletePolicy`
+
+A Restate deployment is immutable and may have invocations pinned to it, so deleting a
+`RestateDeployment` is not just a matter of removing its ReplicaSets. The operator holds a
+finalizer (`deployments.restate.dev`) and, by default, waits for Restate to finish with
+every version it registered before it deregisters them and lets the object go.
+
+`spec.restate.deletePolicy` decides whether there is a wait at all, and `spec.restate.drain`
+decides its terms: `timeoutSeconds` (default `3600`) sets the deadline, and `onTimeout`
+(default `hold`) says what happens when it arrives. The clock starts at
+`metadata.deletionTimestamp`, not at the last reconcile.
+
+| `deletePolicy` | `drain.onTimeout` | Waits for invocations | At the deadline                             |
+|----------------|-------------------|-----------------------|---------------------------------------------|
+| `drain` (default) | `hold` (default) | yes, indefinitely   | keeps waiting, reports `Overdue`            |
+| `drain`        | `force`           | yes                   | deregisters anyway, abandoning what is left |
+| `force`        | n/a               | no                    | n/a — `drain` is ignored entirely            |
+
+Under `onTimeout: hold` the timeout never lets the deletion through; it only decides when
+the drain starts reporting itself `Overdue`, which is the signal that it needs a human.
+
+```yaml
+spec:
+  restate:
+    register:
+      cluster: my-cluster
+    deletePolicy: drain
+    drain:
+      timeoutSeconds: 1800
+      onTimeout: force
+```
+
+## What counts as an invocation still in flight
+
+Per version, the operator asks Restate for two counts:
+
+- **pinned**: unfinished invocations already bound to that deployment id.
+- **unpinned**: unfinished invocations not yet bound to any deployment, but targeting a
+  service this version is the registered endpoint for. This includes scheduled
+  invocations, whose execution time can be arbitrarily far out — a deletion held by one of
+  these may never clear on its own.
+
+Completed invocations don't count, even though Restate keeps them in
+`sys_invocation_status` for the retention window (24h by default).
+
+A `force` deletion blocks on nothing, so it doesn't run the query that attributes unpinned
+work; the counts it reports for what it walked over are labelled pinned-only for that
+reason. (An `onTimeout: force` drain whose deadline expires after the query has already
+run does have both counts, and reports both.)
+
+## Watching a deletion
+
+`.status.deletion` is written while the deletion is in progress:
+
+```yaml
+status:
+  deletion:
+    policy: drain
+    phase: Overdue
+    startedAt: "2026-08-31T10:00:00Z"
+    deadline: "2026-08-31T11:00:00Z"
+    onTimeout: hold
+    message: Still waiting on greeter-7d9f4c (3 pinned, 7 unpinned invocations) after the 3600s drain timeout
+    totalPendingInvocations: 10
+    pendingInvocations:
+    - version: greeter-7d9f4c
+      deploymentId: dp_abc123
+      pinned: 3
+      unpinned: 7
+```
+
+Phases are `Draining` (waiting on invocations, or on `drainDelaySeconds` once they have
+finished), `Overdue` (past `drain.timeoutSeconds` and still waiting) and `Forcing`.
+`onTimeout` is echoed back so the `deadline` reads unambiguously: it is when the drain
+gives up under `force`, and only when it starts complaining under `hold`.
+
+`kubectl get rsd -o wide` shows the phase and the total. A force deletion that abandoned
+work also leaves a `ForcedDeletion` warning event, which is the only lasting record of it —
+the object is gone moments later.
+
+## Unsticking a deletion
+
+The deletion is blocked, `phase: Overdue`, and the invocations are not going to finish.
+Either deal with the invocations:
+
+```bash
+restate invocations cancel <id>     # or: purge, for completed ones
+```
+
+or change the terms on the terminating object — Kubernetes allows spec updates while a
+finalizer is pending. To give up on what is left:
+
+```bash
+kubectl patch rsd greeter --type=merge \
+  -p '{"spec":{"restate":{"drain":{"onTimeout":"force"}}}}'
+```
+
+The next reconcile deregisters the remaining versions with `force=true` and removes the
+finalizer. `{"deletePolicy":"force"}` does the same thing and additionally skips the
+drain delay and revision history limit; either works, since the drain is already overdue.
+
+To keep waiting but stop the reporting, raise the timeout instead:
+
+```bash
+kubectl patch rsd greeter --type=merge \
+  -p '{"spec":{"restate":{"drain":{"timeoutSeconds":86400}}}}'
+```
+
+### If Restate itself is unreachable
+
+`force` skips the *wait*, not the *deregistration*: every pass still queries the admin API
+to find out which versions are registered, and a version whose registration the operator
+can't confirm is never torn down blind. So if the deletion is stuck because Restate is
+down or gone, `force` will not move it -- `.status.deletion` reports `phase: Forcing` while
+a `FailedReconcile` event and the operator log show the underlying `AdminCallFailed`.
+
+If the Restate cluster is genuinely gone for good, delete the `RestateCluster` -- cleanup
+short-circuits on a `spec.restate.register.cluster` that no longer exists and lets the
+object go. Failing that (a `register.url` endpoint, say), remove the finalizer by hand,
+accepting that the registrations are orphaned:
+
+```bash
+kubectl patch rsd greeter --type=json \
+  -p '[{"op":"remove","path":"/metadata/finalizers"}]'
+```
+
+## What `force` skips
+
+Beyond not waiting for invocations, a force deletion also skips `drainDelaySeconds` (the
+grace period between a version being drained and its removal) and the revision history
+limit. Every version it owns is deregistered and torn down on the first pass.
+
+It does not change how *rollouts* retire old versions: `drainDelaySeconds` and
+`revisionHistoryLimit` still apply there, and old versions with invocations in flight are
+still kept alive. `deletePolicy` only takes effect once the `RestateDeployment` itself has
+been deleted.

--- a/release-notes/unreleased/delete-policy.md
+++ b/release-notes/unreleased/delete-policy.md
@@ -50,6 +50,9 @@ There is now a bounded option, and a status field that answers "what is this wai
   Restate is down. See `docs/delete-policy.md`.
 - `spec.restate.deletePolicy` and `spec.restate.drain` are new optional fields; the CRD
   must be updated before they can be set.
+- A paused RestateDeployment (`restate.dev/reconcile: disabled`) still deletes normally,
+  and now drops the `Disabled` reconciliation state and its `Reconciling` condition when
+  the deletion starts, rather than reporting itself suspended throughout the teardown.
 
 ### Migration Guidance
 

--- a/release-notes/unreleased/delete-policy.md
+++ b/release-notes/unreleased/delete-policy.md
@@ -1,0 +1,65 @@
+# Release Notes: `deletePolicy` for RestateDeployment
+
+## New Feature
+
+### What Changed
+
+Deleting a `RestateDeployment` is now governed by `spec.restate.deletePolicy`, whose terms
+are set by `spec.restate.drain`:
+
+- `deletePolicy: drain` (default): the existing behaviour — wait for in-flight invocations
+  to finish before deregistering. `drain.timeoutSeconds` (default `3600`) sets the deadline
+  and `drain.onTimeout` decides what happens there:
+  - `hold` (default): keep waiting, and report the drain as overdue.
+  - `force`: deregister anyway, abandoning whatever is left.
+- `deletePolicy: force`: deregister and tear down immediately, skipping the drain,
+  `drainDelaySeconds` and the revision history limit. `drain` is ignored entirely.
+
+Progress is reported on `.status.deletion`, which names the versions holding the deletion
+and their pinned/unpinned invocation counts, alongside the phase (`Draining`, `Overdue`,
+`Forcing`), the deadline, what happens at it, and a total. `kubectl get rsd -o wide` shows
+the phase and total.
+
+A force deletion that walked over unfinished invocations raises a `ForcedDeletion` warning
+event naming what it abandoned.
+
+See `docs/delete-policy.md`.
+
+### Why This Matters
+
+A deletion blocked by a scheduled invocation days out, or by a workflow that will never
+complete, previously had no deadline and no visible reason: the only signal was a warning
+event and the operator log, and the only way out was to find and cancel the invocations.
+There is now a bounded option, and a status field that answers "what is this waiting for".
+
+### Impact on Users
+
+- Existing deployments keep the current behaviour: no `deletePolicy` means `drain`, which
+  still waits indefinitely for invocations to finish.
+- After one hour, a blocked `drain` deletion now reports `phase: Overdue` and raises
+  `DeletionDrainOverdue` instead of `DeploymentInUse`. The deletion itself is still held,
+  and the Kubernetes event reason is unchanged (`FailedReconcile`) -- only its message
+  changes, to name the timeout and point at the ways out of it.
+- **Metric label change.** `restate_operator_reconciliation_errors_total` now labels
+  RestateDeployment failures with the error the reconciler actually raised
+  (`DeletionDrainOverdue`, `DeploymentInUse`, `AdminCallFailed`, ...) instead of
+  collapsing all of them into `FinalizerError`. Alerts or dashboards matching
+  `error="FinalizerError"` for this controller need updating.
+- `deletePolicy: force` skips the wait, not the deregistration: it still needs the Restate
+  admin API to be reachable, so it will not unstick a deletion that is blocked because
+  Restate is down. See `docs/delete-policy.md`.
+- `spec.restate.deletePolicy` and `spec.restate.drain` are new optional fields; the CRD
+  must be updated before they can be set.
+
+### Migration Guidance
+
+Apply the updated CRDs (`helm upgrade` of `restate-operator-crds`, or
+`kubectl apply --server-side -f crd/restatedeployments.yaml`). No changes are required to
+existing `RestateDeployment` resources.
+
+To unstick a deletion that is already blocked, patch the terminating object:
+
+```bash
+kubectl patch rsd greeter --type=merge \
+  -p '{"spec":{"restate":{"deletePolicy":"force"}}}'
+```

--- a/src/controllers/restatedeployment/cleanup.rs
+++ b/src/controllers/restatedeployment/cleanup.rs
@@ -15,24 +15,59 @@ use tracing::{debug, info};
 
 use crate::Result;
 
+use crate::resources::restatedeployments::{DeletePolicy, OnTimeout, RestateDeployment};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CleanupMode {
     Rollout,
     Deleting,
+    /// Deleting without waiting: `deletePolicy: force`, or a drain with
+    /// `onTimeout: force` whose timeout has run out.
+    ForceDeleting,
 }
 
 impl CleanupMode {
-    pub(crate) fn for_rsd(rsd: &crate::resources::restatedeployments::RestateDeployment) -> Self {
-        if rsd.metadata.deletion_timestamp.is_some() {
-            Self::Deleting
-        } else {
-            Self::Rollout
+    pub(crate) fn for_rsd(rsd: &RestateDeployment) -> Self {
+        if rsd.metadata.deletion_timestamp.is_none() {
+            return Self::Rollout;
+        }
+
+        match rsd.spec.restate.delete_policy() {
+            DeletePolicy::Force => Self::ForceDeleting,
+            DeletePolicy::Drain => match rsd.spec.restate.drain_on_timeout() {
+                OnTimeout::Hold => Self::Deleting,
+                OnTimeout::Force => match drain_deadline(rsd) {
+                    Some(deadline) if deadline <= chrono::Utc::now() => Self::ForceDeleting,
+                    _ => Self::Deleting,
+                },
+            },
         }
     }
 
     pub(crate) fn is_deleting(self) -> bool {
+        !matches!(self, Self::Rollout)
+    }
+
+    /// Whether a version is due for removal the moment it stops being needed, rather
+    /// than after `drainDelaySeconds`.
+    pub(crate) fn skips_drain_delay(self) -> bool {
+        matches!(self, Self::ForceDeleting)
+    }
+
+    /// Whether the usage query has to attribute unpinned invocations. Only a drain
+    /// blocks on them; see [`deployment_usage_query`].
+    fn needs_unpinned_count(self) -> bool {
         matches!(self, Self::Deleting)
     }
+}
+
+/// When a drain stops waiting: under `onTimeout: force` it force-deregisters, under
+/// `onTimeout: hold` it keeps waiting but reports itself overdue.
+pub(crate) fn drain_deadline(rsd: &RestateDeployment) -> Option<chrono::DateTime<chrono::Utc>> {
+    let deleted_at = rsd.metadata.deletion_timestamp.as_ref()?;
+    deleted_at.0.checked_add_signed(chrono::TimeDelta::seconds(
+        rsd.spec.restate.drain_timeout_seconds(),
+    ))
 }
 
 /// What Restate believes about one registered deployment. Kept as separate facts
@@ -66,6 +101,7 @@ impl DeploymentUsage {
     /// Whether Restate still needs this deployment.
     pub(crate) fn is_active(&self, mode: CleanupMode) -> bool {
         match mode {
+            CleanupMode::ForceDeleting => false,
             CleanupMode::Deleting => self.in_flight_invocations() > 0,
             CleanupMode::Rollout => self.latest_for_service || self.in_flight_invocations() > 0,
         }
@@ -78,7 +114,8 @@ impl DeploymentUsage {
 /// `pinned_deployment_id` needs `target_service_name`, which is nested inside the encoded
 /// invocation target and so costs a decode per scanned row, plus a join against
 /// `sys_service` — on top of a second pass over `sys_invocation_status` across every
-/// partition. Only a deletion needs the answer: unpinned work is attributed through
+/// partition. Only a drain needs the answer -- a force deletion blocks on nothing, and
+/// unpinned work is attributed through
 /// `sys_service.deployment_id`, the same column that sets `latest_for_service`, so during a
 /// rollout a non-zero count could only ever name a deployment that flag is already holding.
 /// The rollout query therefore doesn't ask, and selects a constant so both modes return one
@@ -90,7 +127,7 @@ impl DeploymentUsage {
 /// cost of the reconcile path resting on an optimiser pass across server versions we don't
 /// pin.
 pub(crate) fn deployment_usage_query(mode: CleanupMode) -> String {
-    let (unpinned_cte, unpinned_count, unpinned_join) = if mode.is_deleting() {
+    let (unpinned_cte, unpinned_count, unpinned_join) = if mode.needs_unpinned_count() {
         (
             r#",
             unpinned AS (
@@ -182,11 +219,21 @@ impl DeploymentUsageRows {
 /// all-partition scans every 30 seconds for as long as it waits. Most drains finish in the
 /// first minutes, so poll at the floor early and stretch towards a cap the longer the wait
 /// has already run.
-pub(crate) fn blocked_deletion_requeue(blocked_for: Duration) -> Duration {
+/// The backoff is capped by `until_deadline` where there is one, so a drain that has
+/// already settled on the ceiling doesn't sleep through its own timeout.
+pub(crate) fn blocked_deletion_requeue(
+    blocked_for: Duration,
+    until_deadline: Option<Duration>,
+) -> Duration {
     const FLOOR: Duration = Duration::from_secs(30);
     const CEILING: Duration = Duration::from_secs(300);
 
-    (blocked_for / 4).clamp(FLOOR, CEILING)
+    let backoff = (blocked_for / 4).clamp(FLOOR, CEILING);
+
+    match until_deadline {
+        Some(until_deadline) => backoff.min(until_deadline.max(Duration::from_secs(1))),
+        None => backoff,
+    }
 }
 
 /// What one pass of cleanup did and did not manage to remove.
@@ -196,6 +243,9 @@ pub(crate) struct CleanupOutcome {
     pub blocking: Vec<BlockingVersion>,
     /// When the soonest drained-but-not-yet-due version comes up for removal.
     pub next_removal: Option<chrono::DateTime<chrono::Utc>>,
+    /// Versions torn down while invocations were still in flight. Only a force deletion
+    /// produces these.
+    pub abandoned: Vec<BlockingVersion>,
 }
 
 /// A version that cleanup could not remove because Restate still needs it.
@@ -215,6 +265,21 @@ pub(crate) fn describe_blocking_versions(blocking: &[BlockingVersion]) -> String
             format!(
                 "{name} ({} pinned, {} unpinned invocations)",
                 usage.pinned_invocations, usage.unpinned_invocations
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Render the versions a force deletion tore down with work still in flight. The counts
+/// are pinned-only: the query a force deletion runs doesn't attribute unpinned work.
+pub(crate) fn describe_abandoned_versions(abandoned: &[BlockingVersion]) -> String {
+    abandoned
+        .iter()
+        .map(|BlockingVersion { name, usage }| {
+            format!(
+                "{name} ({} unfinished invocations)",
+                usage.pinned_invocations
             )
         })
         .collect::<Vec<_>>()
@@ -574,6 +639,96 @@ mod tests {
         }
     }
 
+    /// `on_timeout` of `None` leaves the drain block off entirely, so the defaults apply.
+    fn deleting_rsd(
+        policy: &str,
+        on_timeout: Option<&str>,
+        timeout_seconds: i64,
+        deleted_secs_ago: i64,
+    ) -> RestateDeployment {
+        let spec = serde_json::from_value(serde_json::json!({
+            "replicas": 1,
+            "revisionHistoryLimit": 10,
+            "template": { "metadata": null, "spec": {} },
+            "restate": {
+                "register": { "url": "http://restate:9070/" },
+                "deletePolicy": policy,
+                "drain": on_timeout.map(|on_timeout| serde_json::json!({
+                    "timeoutSeconds": timeout_seconds,
+                    "onTimeout": on_timeout,
+                })),
+            },
+        }))
+        .expect("test RestateDeploymentSpec deserializes");
+
+        let mut rsd = RestateDeployment::new("greeter", spec);
+        rsd.metadata.deletion_timestamp =
+            Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                chrono::Utc::now() - chrono::TimeDelta::seconds(deleted_secs_ago),
+            ));
+        rsd
+    }
+
+    #[test]
+    fn force_deletion_waits_for_nothing() {
+        for u in [usage(true, 0, 0), usage(true, 3, 9), usage(false, 1, 0)] {
+            assert!(!u.is_active(CleanupMode::ForceDeleting));
+        }
+    }
+
+    #[test]
+    fn mode_follows_the_delete_policy() {
+        let mut not_deleting = deleting_rsd("force", None, 3600, 0);
+        not_deleting.metadata.deletion_timestamp = None;
+        assert_eq!(CleanupMode::for_rsd(&not_deleting), CleanupMode::Rollout);
+
+        assert_eq!(
+            CleanupMode::for_rsd(&deleting_rsd("force", None, 3600, 0)),
+            CleanupMode::ForceDeleting
+        );
+
+        // a drain waits past its deadline; only the status changes there
+        assert_eq!(
+            CleanupMode::for_rsd(&deleting_rsd("drain", Some("hold"), 3600, 0)),
+            CleanupMode::Deleting
+        );
+        assert_eq!(
+            CleanupMode::for_rsd(&deleting_rsd("drain", Some("hold"), 3600, 7200)),
+            CleanupMode::Deleting
+        );
+
+        assert_eq!(
+            CleanupMode::for_rsd(&deleting_rsd("drain", Some("force"), 3600, 60)),
+            CleanupMode::Deleting
+        );
+        assert_eq!(
+            CleanupMode::for_rsd(&deleting_rsd("drain", Some("force"), 3600, 3601)),
+            CleanupMode::ForceDeleting
+        );
+
+        // no drain block at all is a `hold`, so it holds however far past the deadline
+        // it is -- the one case that must not start forcing by omission
+        assert_eq!(
+            CleanupMode::for_rsd(&deleting_rsd("drain", None, 3600, 7200)),
+            CleanupMode::Deleting
+        );
+    }
+
+    #[test]
+    fn default_delete_policy_is_a_one_hour_drain_that_holds() {
+        let mut rsd = deleting_rsd("drain", Some("force"), 3600, 0);
+        rsd.spec.restate.delete_policy = None;
+        rsd.spec.restate.drain = None;
+
+        assert_eq!(CleanupMode::for_rsd(&rsd), CleanupMode::Deleting);
+        assert_eq!(rsd.spec.restate.drain_timeout_seconds(), 3600);
+        assert_eq!(rsd.spec.restate.drain_on_timeout(), OnTimeout::Hold);
+        assert_eq!(
+            drain_deadline(&rsd),
+            Some(rsd.metadata.deletion_timestamp.as_ref().unwrap().0 + chrono::TimeDelta::hours(1))
+        );
+    }
+
     #[test]
     fn latest_endpoint_is_active_during_rollout_but_not_during_deletion() {
         let u = usage(true, 0, 0);
@@ -648,6 +803,50 @@ mod tests {
     }
 
     #[test]
+    fn force_deletion_does_not_pay_for_the_unpinned_count_either() {
+        // nothing blocks a force deletion, so there is nothing to attribute
+        let query = deployment_usage_query(CleanupMode::ForceDeleting);
+        assert_eq!(query.matches("sys_invocation_status").count(), 1);
+        assert!(!query.contains("unpinned AS"));
+    }
+
+    #[test]
+    fn force_deletion_still_removes_drained_versions_immediately() {
+        assert!(CleanupMode::ForceDeleting.skips_drain_delay());
+        assert!(!CleanupMode::Deleting.skips_drain_delay());
+        assert!(!CleanupMode::Rollout.skips_drain_delay());
+
+        // the revision history limit must not hold a version back from either deletion
+        assert!(!retain_for_rollback(CleanupMode::ForceDeleting, 0, 10));
+    }
+
+    #[test]
+    fn abandoned_versions_report_what_was_walked_over() {
+        assert_eq!(
+            describe_abandoned_versions(&[BlockingVersion {
+                name: "greeter-abc123".into(),
+                usage: usage(false, 4, 0),
+            }]),
+            "greeter-abc123 (4 unfinished invocations)"
+        );
+    }
+
+    #[test]
+    fn blocked_deletion_does_not_sleep_through_the_deadline() {
+        let requeue = |secs, until| {
+            blocked_deletion_requeue(Duration::from_secs(secs), Some(Duration::from_secs(until)))
+        };
+
+        // an `onTimeout: force` drain waiting an hour is on the 300s ceiling, but
+        // its deadline is 45s away
+        assert_eq!(requeue(3600, 45), Duration::from_secs(45));
+        assert_eq!(requeue(3600, 600), Duration::from_secs(300));
+
+        // never zero, or the reconciler spins on the deadline
+        assert_eq!(requeue(3600, 0), Duration::from_secs(1));
+    }
+
+    #[test]
     fn deleting_query_counts_unpinned_work_through_the_service() {
         let query = deployment_usage_query(CleanupMode::Deleting);
 
@@ -673,7 +872,7 @@ mod tests {
 
     #[test]
     fn blocked_deletion_polls_hard_early_and_backs_off_later() {
-        let requeue = |secs| blocked_deletion_requeue(Duration::from_secs(secs));
+        let requeue = |secs| blocked_deletion_requeue(Duration::from_secs(secs), None);
 
         // the common case -- a drain that finishes in the first minutes -- keeps the
         // 30s cadence it had before the backoff

--- a/src/controllers/restatedeployment/cleanup.rs
+++ b/src/controllers/restatedeployment/cleanup.rs
@@ -253,6 +253,8 @@ pub(crate) struct CleanupOutcome {
 pub(crate) struct BlockingVersion {
     /// The ReplicaSet or Configuration name.
     pub name: String,
+    /// The Restate deployment it is registered as.
+    pub deployment_id: Option<String>,
     pub usage: DeploymentUsage,
 }
 
@@ -261,7 +263,7 @@ pub(crate) struct BlockingVersion {
 pub(crate) fn describe_blocking_versions(blocking: &[BlockingVersion]) -> String {
     blocking
         .iter()
-        .map(|BlockingVersion { name, usage }| {
+        .map(|BlockingVersion { name, usage, .. }| {
             format!(
                 "{name} ({} pinned, {} unpinned invocations)",
                 usage.pinned_invocations, usage.unpinned_invocations
@@ -271,16 +273,24 @@ pub(crate) fn describe_blocking_versions(blocking: &[BlockingVersion]) -> String
         .join(", ")
 }
 
-/// Render the versions a force deletion tore down with work still in flight. The counts
-/// are pinned-only: the query a force deletion runs doesn't attribute unpinned work.
+/// Render the versions a force deletion tore down with work still in flight.
+///
+/// Usually pinned-only, because the query a force deletion runs doesn't attribute unpinned
+/// work -- so the count is labelled "pinned" rather than "unfinished", which would read as
+/// a total it isn't. A pass whose `onTimeout: force` deadline expired after the query ran
+/// does have the unpinned count, and reports it.
 pub(crate) fn describe_abandoned_versions(abandoned: &[BlockingVersion]) -> String {
     abandoned
         .iter()
-        .map(|BlockingVersion { name, usage }| {
-            format!(
-                "{name} ({} unfinished invocations)",
-                usage.pinned_invocations
-            )
+        .map(|BlockingVersion { name, usage, .. }| {
+            if usage.unpinned_invocations > 0 {
+                format!(
+                    "{name} ({} pinned, {} unpinned invocations)",
+                    usage.pinned_invocations, usage.unpinned_invocations
+                )
+            } else {
+                format!("{name} ({} pinned invocations)", usage.pinned_invocations)
+            }
         })
         .collect::<Vec<_>>()
         .join(", ")
@@ -631,6 +641,14 @@ mod tests {
         }
     }
 
+    fn blocking(name: &str, usage: DeploymentUsage) -> BlockingVersion {
+        BlockingVersion {
+            name: name.into(),
+            deployment_id: None,
+            usage,
+        }
+    }
+
     fn usage(latest: bool, pinned: u64, unpinned: u64) -> DeploymentUsage {
         DeploymentUsage {
             latest_for_service: latest,
@@ -822,12 +840,18 @@ mod tests {
 
     #[test]
     fn abandoned_versions_report_what_was_walked_over() {
+        // the force query doesn't attribute unpinned work, so the count says "pinned"
+        // rather than claiming to be every unfinished invocation
         assert_eq!(
-            describe_abandoned_versions(&[BlockingVersion {
-                name: "greeter-abc123".into(),
-                usage: usage(false, 4, 0),
-            }]),
-            "greeter-abc123 (4 unfinished invocations)"
+            describe_abandoned_versions(&[blocking("greeter-abc123", usage(false, 4, 0))]),
+            "greeter-abc123 (4 pinned invocations)"
+        );
+
+        // ...but an `onTimeout: force` drain that crossed its deadline after the query ran
+        // does have the unpinned count, and must not drop it
+        assert_eq!(
+            describe_abandoned_versions(&[blocking("greeter-abc123", usage(false, 4, 7))]),
+            "greeter-abc123 (4 pinned, 7 unpinned invocations)"
         );
     }
 
@@ -889,14 +913,8 @@ mod tests {
     #[test]
     fn blocking_versions_name_the_work_holding_the_deletion() {
         let described = describe_blocking_versions(&[
-            BlockingVersion {
-                name: "greeter-abc123".into(),
-                usage: usage(true, 2, 0),
-            },
-            BlockingVersion {
-                name: "greeter-def456".into(),
-                usage: usage(false, 0, 7),
-            },
+            blocking("greeter-abc123", usage(true, 2, 0)),
+            blocking("greeter-def456", usage(false, 0, 7)),
         ]);
 
         assert_eq!(

--- a/src/controllers/restatedeployment/cleanup.rs
+++ b/src/controllers/restatedeployment/cleanup.rs
@@ -189,6 +189,15 @@ pub(crate) fn blocked_deletion_requeue(blocked_for: Duration) -> Duration {
     (blocked_for / 4).clamp(FLOOR, CEILING)
 }
 
+/// What one pass of cleanup did and did not manage to remove.
+#[derive(Debug, Default)]
+pub(crate) struct CleanupOutcome {
+    /// Versions Restate still needs, which cleanup therefore left alone.
+    pub blocking: Vec<BlockingVersion>,
+    /// When the soonest drained-but-not-yet-due version comes up for removal.
+    pub next_removal: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 /// A version that cleanup could not remove because Restate still needs it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BlockingVersion {

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -2134,6 +2134,23 @@ mod tests {
         .expect("test RestateDeployment deserializes")
     }
 
+    /// The pause annotation suspends management of a RestateDeployment, not its teardown:
+    /// a paused RSD that is deleted has to reconcile anyway, or it is left registered in
+    /// Restate with in-flight invocations and nothing coming back for it.
+    #[test]
+    fn deleting_a_paused_restatedeployment_is_not_suspended() {
+        let mut rsd = paused_rsd("drain", "hold");
+
+        // while it is alive the annotation does what it says
+        assert!(reconciliation_suspended(&rsd));
+
+        rsd.metadata.deletion_timestamp = Some(Time(chrono::Utc::now()));
+        assert!(
+            !reconciliation_suspended(&rsd),
+            "a deleted RestateDeployment must reconcile even while paused",
+        );
+    }
+
     /// The `Disabled` state and its `Reconciling` condition are wrong the moment a paused
     /// object starts deleting, and nothing else clears them -- the main status apply does
     /// not run during a deletion. Clearing keeps the other conditions: a stale `Ready`

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -48,7 +48,7 @@ use crate::{Error, Result};
 
 // Import our reconcilers
 use crate::controllers::restatedeployment::cleanup::{
-    CleanupMode, DeploymentUsage, DeploymentUsageMap, DeploymentUsageRows,
+    CleanupMode, CleanupOutcome, DeploymentUsage, DeploymentUsageMap, DeploymentUsageRows,
     RESTATE_REMOVE_VERSION_AT_ANNOTATION, blocked_deletion_requeue, deployment_usage_query,
     describe_blocking_versions, unschedule_version_removal,
 };
@@ -565,12 +565,13 @@ impl RestateDeployment {
                         &rs_api,
                         &my_uid,
                         self,
+                        CleanupMode::Rollout,
                         &deployments,
                         Some(&versioned_name), // exclude the replicaset which may not be registered
                     )
                     .await
                     {
-                        Ok((_, _)) => return Err(ready_err),
+                        Ok(_) => return Err(ready_err),
                         Err(cleanup_err) => {
                             error!(
                                 "Failed to clean up old replicasets while waiting for current replicaset to become ready: {cleanup_err}"
@@ -682,18 +683,19 @@ impl RestateDeployment {
 
         // Clean up old ReplicaSets that are no longer needed
 
-        let (_, next_removal) = reconcilers::replicaset::cleanup_old_replicasets(
+        let outcome = reconcilers::replicaset::cleanup_old_replicasets(
             namespace,
             &ctx,
             &rs_api,
             &my_uid,
             self,
+            CleanupMode::Rollout,
             &deployments,
             Some(&versioned_name),
         )
         .await?;
 
-        Ok((replicaset, next_removal))
+        Ok((replicaset, outcome.next_removal))
     }
 
     /// Note the suspension in the status, and leave everything else alone.
@@ -1227,7 +1229,8 @@ impl RestateDeployment {
             };
         }
 
-        let deployments = self.list_deployments(&ctx, CleanupMode::Deleting).await?;
+        let mode = CleanupMode::for_rsd(self);
+        let deployments = self.list_deployments(&ctx, mode).await?;
 
         let my_uid = self.uid().expect("RestateDeployment to have a uid");
 
@@ -1237,13 +1240,17 @@ impl RestateDeployment {
             Some(crate::resources::restatedeployments::DeploymentMode::Knative)
         );
 
-        let (blocking, next_removal) = if is_knative {
+        let CleanupOutcome {
+            blocking,
+            next_removal,
+        } = if is_knative {
             // Knative cleanup path
             reconcilers::knative::cleanup_old_configurations(
                 namespace,
                 &ctx,
                 &my_uid,
                 self,
+                mode,
                 &deployments,
                 None,
             )
@@ -1256,6 +1263,7 @@ impl RestateDeployment {
                 &rs_api,
                 &my_uid,
                 self,
+                mode,
                 &deployments,
                 None,
             )

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -1258,6 +1258,80 @@ impl RestateDeployment {
         }
     }
 
+    /// The conditions to keep, or `None` when there are no suspension marks to clear and
+    /// so nothing to write.
+    fn suspension_to_clear(&self) -> Option<Vec<RestateDeploymentCondition>> {
+        let status = self.status.as_ref();
+
+        let stale_state = status
+            .and_then(|status| status.reconciliation)
+            .is_some_and(|state| state != ReconciliationState::Reconciling);
+        let stale_condition = status
+            .and_then(|status| status.conditions.as_ref())
+            .is_some_and(|conditions| {
+                conditions
+                    .iter()
+                    .any(|cond| cond.r#type == RECONCILING_CONDITION)
+            });
+
+        if !stale_state && !stale_condition {
+            return None;
+        }
+
+        // Applying `conditions` claims the whole list, so send it back minus the one that
+        // no longer applies. A stale `Ready` is still worth having; it says when the
+        // deployment was last healthy.
+        Some(
+            status
+                .and_then(|status| status.conditions.clone())
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|cond| cond.r#type != RECONCILING_CONDITION)
+                .collect(),
+        )
+    }
+
+    /// Clear the suspension marks left behind by [`Self::reconcile_suspended`].
+    ///
+    /// A paused RestateDeployment reconciles again the moment it is deleted, so its
+    /// `Disabled` state and `Reconciling` condition go stale immediately: they say the
+    /// operator is leaving the resource alone while it is in fact tearing it down, next
+    /// to a `.status.deletion` that updates every pass. Nothing else clears them, because
+    /// the main status apply doesn't run during a deletion.
+    ///
+    /// Written under the field manager that set them, so this is a hand-off rather than a
+    /// fight, and only when there is something to hand over.
+    async fn clear_suspension(&self, ctx: &Context, namespace: &str) {
+        let Some(conditions) = self.suspension_to_clear() else {
+            return;
+        };
+
+        let rsd_api: Api<RestateDeployment> = Api::namespaced(ctx.client.clone(), namespace);
+        let patch = json!({
+            "apiVersion": RestateDeployment::api_version(&()),
+            "kind": RestateDeployment::kind(&()),
+            "status": {
+                "reconciliation": ReconciliationState::Reconciling,
+                "conditions": conditions,
+            },
+        });
+
+        if let Err(err) = rsd_api
+            .patch_status(
+                &self.name_any(),
+                &PatchParams::apply("restate-operator").force(),
+                &Patch::Apply(patch),
+            )
+            .await
+        {
+            // Cosmetic next to the teardown itself, which is about to carry on regardless.
+            warn!(
+                "Failed to clear the suspended status of deleting RestateDeployment '{}' in namespace {namespace}: {err}",
+                self.name_any(),
+            );
+        }
+    }
+
     /// Report deletion progress on `.status.deletion`, under its own field manager: the
     /// main status apply doesn't claim that field, and doesn't run at all while deleting.
     async fn report_deletion(&self, ctx: &Context, namespace: &str, deletion: DeletionStatus) {
@@ -1307,6 +1381,10 @@ impl RestateDeployment {
 
     // Finalizer cleanup (the object was deleted, ensure nothing is orphaned)
     async fn cleanup(&self, ctx: Arc<Context>, namespace: &str) -> Result<Action> {
+        // Before anything reports progress: a paused object arrives here still claiming
+        // the operator is leaving it alone.
+        self.clear_suspension(&ctx, namespace).await;
+
         ctx.recorder
             .publish(
                 &Event {
@@ -2029,6 +2107,87 @@ mod tests {
             crate::resources::restatedeployments::DeletePolicy::Force
         );
         assert_eq!(force_status.deadline, None);
+    }
+
+    fn paused_rsd(policy: &str, on_timeout: &str) -> RestateDeployment {
+        use crate::controllers::{RECONCILE_ANNOTATION, RECONCILE_DISABLED};
+
+        serde_json::from_value(json!({
+            "apiVersion": "restate.dev/v1beta1",
+            "kind": "RestateDeployment",
+            "metadata": {
+                "name": "greeter",
+                "namespace": "apps",
+                "annotations": { RECONCILE_ANNOTATION: RECONCILE_DISABLED },
+            },
+            "spec": {
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "template": { "spec": {} },
+                "restate": {
+                    "register": { "url": "http://restate:9070/" },
+                    "deletePolicy": policy,
+                    "drain": { "timeoutSeconds": 60, "onTimeout": on_timeout },
+                },
+            },
+        }))
+        .expect("test RestateDeployment deserializes")
+    }
+
+    /// The `Disabled` state and its `Reconciling` condition are wrong the moment a paused
+    /// object starts deleting, and nothing else clears them -- the main status apply does
+    /// not run during a deletion. Clearing keeps the other conditions: a stale `Ready`
+    /// still says when the deployment was last healthy.
+    #[test]
+    fn a_deleting_rsd_no_longer_claims_to_be_suspended() {
+        let mut rsd = paused_rsd("drain", "hold");
+        rsd.metadata.deletion_timestamp = Some(Time(chrono::Utc::now()));
+
+        let ready = RestateDeploymentCondition {
+            last_transition_time: None,
+            message: Some("was healthy".into()),
+            reason: Some("Available".into()),
+            status: "True".into(),
+            r#type: "Ready".into(),
+        };
+        let suspended = RestateDeploymentCondition {
+            last_transition_time: None,
+            message: Some(suspended_message()),
+            reason: Some(ReconciliationState::Disabled.as_str().into()),
+            status: "False".into(),
+            r#type: RECONCILING_CONDITION.into(),
+        };
+
+        // nothing to hand over: no suspension marks, so no write at all
+        let mut status = RestateDeploymentStatus {
+            conditions: Some(vec![ready.clone()]),
+            reconciliation: Some(ReconciliationState::Reconciling),
+            ..Default::default()
+        };
+        rsd.status = Some(status.clone());
+        assert_eq!(rsd.suspension_to_clear(), None);
+
+        // ...whereas a paused one hands over the state and drops only its own condition
+        status.conditions = Some(vec![ready.clone(), suspended]);
+        status.reconciliation = Some(ReconciliationState::Disabled);
+        rsd.status = Some(status.clone());
+
+        let kept = rsd
+            .suspension_to_clear()
+            .expect("a suspended deleting RSD has marks to clear");
+        assert_eq!(
+            kept.iter()
+                .map(|cond| cond.r#type.as_str())
+                .collect::<Vec<_>>(),
+            vec!["Ready"],
+            "clearing the suspension must not take the other conditions with it",
+        );
+
+        // a resume that never finished is just as wrong once the object is deleting
+        status.reconciliation = Some(ReconciliationState::ResumingReconciliation);
+        status.conditions = Some(vec![ready]);
+        rsd.status = Some(status);
+        assert!(rsd.suspension_to_clear().is_some());
     }
 
     /// The finalizer wrapper must not swallow the error's identity on the way to metrics,

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -40,18 +40,18 @@ use crate::resources::knative::{Configuration, Revision, Route};
 use crate::resources::restatecloudenvironments::{InProcessTunnelParams, RestateCloudEnvironment};
 use crate::resources::restateclusters::RestateCluster;
 use crate::resources::restatedeployments::{
-    RESTATE_DEPLOYMENT_FINALIZER, RestateAdminEndpoint, RestateDeployment,
-    RestateDeploymentCondition, RestateDeploymentStatus,
+    DeletionPhase, DeletionStatus, PendingInvocations, RESTATE_DEPLOYMENT_FINALIZER,
+    RestateAdminEndpoint, RestateDeployment, RestateDeploymentCondition, RestateDeploymentStatus,
 };
 use crate::telemetry;
 use crate::{Error, Result};
 
 // Import our reconcilers
 use crate::controllers::restatedeployment::cleanup::{
-    CleanupMode, CleanupOutcome, DeploymentUsage, DeploymentUsageMap, DeploymentUsageRows,
-    RESTATE_REMOVE_VERSION_AT_ANNOTATION, blocked_deletion_requeue, deployment_usage_query,
-    describe_abandoned_versions, describe_blocking_versions, drain_deadline,
-    unschedule_version_removal,
+    BlockingVersion, CleanupMode, CleanupOutcome, DeploymentUsage, DeploymentUsageMap,
+    DeploymentUsageRows, RESTATE_REMOVE_VERSION_AT_ANNOTATION, blocked_deletion_requeue,
+    deployment_usage_query, describe_abandoned_versions, describe_blocking_versions,
+    drain_deadline, unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::reconcilers;
 use crate::controllers::restatedeployment::registration::{self, RegistrationAction};
@@ -226,7 +226,10 @@ async fn reconcile(rs: Arc<RestateDeployment>, ctx: Arc<Context>) -> Result<Acti
                 .await?;
 
             let err = Error::FinalizerError(Box::new(err));
-            ctx.metrics.reconcile_failure(rs.as_ref(), &err);
+            // Label the failure with the variant the reconciler actually raised. The
+            // wrapper above would otherwise collapse every one of them into
+            // `FinalizerError`, which is what `error_policy` unwraps for too.
+            ctx.metrics.reconcile_failure(rs.as_ref(), root_cause(&err));
             Err(err)
         }
     }
@@ -258,6 +261,10 @@ fn error_policy<K, C>(_rs: Arc<K>, err: &Error, _ctx: C) -> Action {
             requeue_after: Some(requeue_after),
         }
         | Error::DeploymentInUse {
+            requeue_after: Some(requeue_after),
+            ..
+        }
+        | Error::DeletionDrainOverdue {
             requeue_after: Some(requeue_after),
             ..
         } => Action::requeue(*requeue_after),
@@ -1196,10 +1203,106 @@ impl RestateDeployment {
             .unwrap_or_default()
     }
 
+    /// Whether the drain is past its deadline and still waiting, so it should say so.
+    ///
+    /// Only `onTimeout: hold` is: it is the one setting still stuck once the deadline
+    /// passes. An `onTimeout: force` drain can be past its deadline for a single pass --
+    /// it crossed while that pass was running -- but force-deregisters on the next one,
+    /// so reporting it `Overdue` and telling the user to force would be wrong.
+    /// `deletePolicy: force` never waits at all.
+    fn drain_overdue(&self) -> bool {
+        use crate::resources::restatedeployments::{DeletePolicy, OnTimeout};
+
+        self.spec.restate.delete_policy() == DeletePolicy::Drain
+            && self.spec.restate.drain_on_timeout() == OnTimeout::Hold
+            && drain_deadline(self).is_some_and(|deadline| deadline <= chrono::Utc::now())
+    }
+
+    fn deletion_status(
+        &self,
+        phase: DeletionPhase,
+        message: String,
+        blocking: &[BlockingVersion],
+    ) -> DeletionStatus {
+        let policy = self.spec.restate.delete_policy();
+        DeletionStatus {
+            policy,
+            phase,
+            started_at: self.metadata.deletion_timestamp.clone(),
+            deadline: if policy == crate::resources::restatedeployments::DeletePolicy::Force {
+                None
+            } else {
+                drain_deadline(self).map(Time)
+            },
+            // `force` has no deadline to reach, so there is nothing for it to do there
+            on_timeout: match policy {
+                crate::resources::restatedeployments::DeletePolicy::Force => None,
+                crate::resources::restatedeployments::DeletePolicy::Drain => {
+                    Some(self.spec.restate.drain_on_timeout())
+                }
+            },
+            message: Some(message),
+            total_pending_invocations: blocking
+                .iter()
+                .map(|version| version.usage.in_flight_invocations() as i64)
+                .sum(),
+            pending_invocations: blocking
+                .iter()
+                .map(|version| PendingInvocations {
+                    version: version.name.clone(),
+                    deployment_id: version.deployment_id.clone(),
+                    pinned: version.usage.pinned_invocations as i64,
+                    unpinned: version.usage.unpinned_invocations as i64,
+                })
+                .collect(),
+        }
+    }
+
+    /// Report deletion progress on `.status.deletion`, under its own field manager: the
+    /// main status apply doesn't claim that field, and doesn't run at all while deleting.
+    async fn report_deletion(&self, ctx: &Context, namespace: &str, deletion: DeletionStatus) {
+        let rsd_api: Api<RestateDeployment> = Api::namespaced(ctx.client.clone(), namespace);
+        let patch = json!({
+            "apiVersion": RestateDeployment::api_version(&()),
+            "kind": RestateDeployment::kind(&()),
+            "status": { "deletion": deletion },
+        });
+
+        if let Err(err) = rsd_api
+            .patch_status(
+                &self.name_any(),
+                &PatchParams::apply("restate-operator/deletion").force(),
+                &Patch::Apply(patch),
+            )
+            .await
+        {
+            // the error the caller is about to return says the same thing
+            warn!(
+                "Failed to report deletion status of RestateDeployment '{}' in namespace {namespace}: {err}",
+                self.name_any(),
+            );
+        }
+    }
+
     /// How long until the drain gives up waiting, if it hasn't already.
     fn until_drain_deadline(&self) -> Option<Duration> {
         let deadline = drain_deadline(self)?;
-        (deadline - chrono::Utc::now()).to_std().ok()
+        match (deadline - chrono::Utc::now()).to_std() {
+            Ok(remaining) => Some(remaining),
+            // An `onTimeout: force` drain that crosses its deadline during an awaited
+            // operation must get another pass immediately so cleanup can switch to force
+            // mode. A `hold` has no mode transition to wake up for once its reporting
+            // deadline is in the past.
+            Err(_)
+                if self.spec.restate.delete_policy()
+                    == crate::resources::restatedeployments::DeletePolicy::Drain
+                    && self.spec.restate.drain_on_timeout()
+                        == crate::resources::restatedeployments::OnTimeout::Force =>
+            {
+                Some(Duration::ZERO)
+            }
+            Err(_) => None,
+        }
     }
 
     // Finalizer cleanup (the object was deleted, ensure nothing is orphaned)
@@ -1236,8 +1339,28 @@ impl RestateDeployment {
             };
         }
 
+        let query_mode = CleanupMode::for_rsd(self);
+        if query_mode == CleanupMode::ForceDeleting {
+            // Write this before the first admin call, so a force deletion that is
+            // blocked on an unavailable Restate endpoint still says what it is doing.
+            self.report_deletion(
+                &ctx,
+                namespace,
+                self.deletion_status(
+                    DeletionPhase::Forcing,
+                    "Deregistering from Restate without waiting for in-flight invocations".into(),
+                    &[],
+                ),
+            )
+            .await;
+        }
+
+        let deployments = self.list_deployments(&ctx, query_mode).await?;
+
+        // The usage query can be expensive. Re-evaluate after it so a
+        // an `onTimeout: force` drain whose deadline passed while the query ran tears down
+        // in this pass instead of waiting for the next scheduled reconcile.
         let mode = CleanupMode::for_rsd(self);
-        let deployments = self.list_deployments(&ctx, mode).await?;
 
         let my_uid = self.uid().expect("RestateDeployment to have a uid");
 
@@ -1246,6 +1369,21 @@ impl RestateDeployment {
             self.spec.deployment_mode,
             Some(crate::resources::restatedeployments::DeploymentMode::Knative)
         );
+
+        if mode == CleanupMode::ForceDeleting && query_mode != CleanupMode::ForceDeleting {
+            // The deadline crossed during the usage query, so this pass changed to force
+            // mode after the initial status-reporting point.
+            self.report_deletion(
+                &ctx,
+                namespace,
+                self.deletion_status(
+                    DeletionPhase::Forcing,
+                    "Deregistering from Restate without waiting for in-flight invocations".into(),
+                    &[],
+                ),
+            )
+            .await;
+        }
 
         let CleanupOutcome {
             blocking,
@@ -1314,6 +1452,8 @@ impl RestateDeployment {
 
         if !blocking.is_empty() {
             let blocked_by = describe_blocking_versions(&blocking);
+            let timeout_seconds = self.spec.restate.drain_timeout_seconds();
+            let overdue = self.drain_overdue();
 
             debug!(
                 "Cannot process deletion of RestateDeployment '{}' from Restate as {} version(s) still have unfinished invocations: {blocked_by}",
@@ -1321,16 +1461,46 @@ impl RestateDeployment {
                 blocking.len(),
             );
 
+            let (phase, message) = if overdue {
+                (
+                    DeletionPhase::Overdue,
+                    format!(
+                        "Still waiting on {blocked_by} after the {timeout_seconds}s drain timeout"
+                    ),
+                )
+            } else {
+                (
+                    DeletionPhase::Draining,
+                    format!("Waiting for in-flight invocations against {blocked_by}"),
+                )
+            };
+            self.report_deletion(
+                &ctx,
+                namespace,
+                self.deletion_status(phase, message, &blocking),
+            )
+            .await;
+
+            let requeue_after = Some(blocked_deletion_requeue(
+                self.blocked_for(),
+                self.until_drain_deadline(),
+            ));
+
             // Named versions and counts rather than the bare message: `reconcile` publishes
             // this as a Warning event, and it is the only place a stuck deletion explains
             // itself. Unpinned work includes scheduled invocations, whose execution time
             // can be arbitrarily far out, so "wait for it" is not always sound advice.
+            if overdue {
+                return Err(Error::DeletionDrainOverdue {
+                    blocked_by,
+                    timeout_seconds,
+                    requeue_after,
+                });
+            }
+
             return Err(Error::DeploymentInUse {
                 blocked_by,
-                requeue_after: Some(blocked_deletion_requeue(
-                    self.blocked_for(),
-                    self.until_drain_deadline(),
-                )),
+                requeue_after,
             });
         }
 
@@ -1340,13 +1510,37 @@ impl RestateDeployment {
                 self.name_any()
             );
 
+            self.report_deletion(
+                &ctx,
+                namespace,
+                self.deletion_status(
+                    DeletionPhase::Draining,
+                    "Drained; waiting out the drain delay before removing old versions".into(),
+                    &[],
+                ),
+            )
+            .await;
+
             // Floor at 1s: `num_seconds` truncates, so a deadline under a second away would
             // otherwise requeue with no delay and spin the reconciler — each turn of which
             // re-runs the admin query above — until the deadline passes.
             let secs_until_next_removal = (next_removal - chrono::Utc::now()).num_seconds().max(1);
+            let mut requeue_after = Duration::from_secs(secs_until_next_removal as u64);
+
+            // An `onTimeout: force` deadline can pass while cleanup is awaiting Kubernetes
+            // or Restate. Never let the drain-delay timer hide that transition; wake up
+            // immediately and recompute the cleanup mode.
+            if self.spec.restate.delete_policy()
+                == crate::resources::restatedeployments::DeletePolicy::Drain
+                && self.spec.restate.drain_on_timeout()
+                    == crate::resources::restatedeployments::OnTimeout::Force
+                && let Some(until_deadline) = self.until_drain_deadline()
+            {
+                requeue_after = requeue_after.min(until_deadline.max(Duration::from_secs(1)));
+            }
 
             return Err(Error::DeploymentDraining {
-                requeue_after: Some(Duration::from_secs(secs_until_next_removal as u64)),
+                requeue_after: Some(requeue_after),
             });
         }
 
@@ -1722,6 +1916,180 @@ mod tests {
             error_policy(Arc::new(()), &wrapped, ()),
             Action::requeue(Duration::from_secs(120))
         );
+    }
+
+    /// A timed-out drain paces its retries the same way.
+    #[test]
+    fn timed_out_drain_backoff_survives_the_finalizer_wrapper() {
+        let wrapped = Error::FinalizerError(Box::new(
+            kube::runtime::finalizer::Error::CleanupFailed(Error::DeletionDrainOverdue {
+                blocked_by: "greeter-abc123 (1 pinned, 0 unpinned invocations)".into(),
+                timeout_seconds: 3600,
+                requeue_after: Some(Duration::from_secs(300)),
+            }),
+        ));
+
+        assert_eq!(
+            error_policy(Arc::new(()), &wrapped, ()),
+            Action::requeue(Duration::from_secs(300))
+        );
+    }
+
+    #[test]
+    fn deletion_status_reports_the_versions_holding_the_deletion() {
+        let mut rsd: RestateDeployment = serde_json::from_value(json!({
+            "apiVersion": "restate.dev/v1beta1",
+            "kind": "RestateDeployment",
+            "metadata": { "name": "greeter", "namespace": "apps" },
+            "spec": {
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "template": { "spec": {} },
+                "restate": {
+                    "register": { "url": "http://restate:9070/" },
+                    "deletePolicy": "drain",
+                    "drain": { "timeoutSeconds": 60, "onTimeout": "force" },
+                },
+            },
+        }))
+        .expect("test RestateDeployment deserializes");
+
+        let deleted_at = chrono::Utc::now() - chrono::TimeDelta::seconds(600);
+        rsd.metadata.deletion_timestamp = Some(Time(deleted_at));
+
+        // an `onTimeout: force` drain past its deadline is about to force, not stuck: it never
+        // reports itself timed out, however far past the deadline it is
+        assert!(!rsd.drain_overdue());
+
+        let status = rsd.deletion_status(
+            DeletionPhase::Overdue,
+            "held up".into(),
+            &[
+                BlockingVersion {
+                    name: "greeter-abc123".into(),
+                    deployment_id: Some("dp_abc123".into()),
+                    usage: DeploymentUsage {
+                        latest_for_service: true,
+                        pinned_invocations: 2,
+                        unpinned_invocations: 3,
+                    },
+                },
+                BlockingVersion {
+                    name: "greeter-def456".into(),
+                    deployment_id: Some("dp_def456".into()),
+                    usage: DeploymentUsage {
+                        latest_for_service: false,
+                        pinned_invocations: 1,
+                        unpinned_invocations: 0,
+                    },
+                },
+            ],
+        );
+
+        assert_eq!(status.total_pending_invocations, 6);
+        assert_eq!(status.started_at, Some(Time(deleted_at)));
+        assert_eq!(
+            status.deadline,
+            Some(Time(deleted_at + chrono::TimeDelta::seconds(60)))
+        );
+        assert_eq!(
+            status
+                .pending_invocations
+                .iter()
+                .map(|pending| (
+                    pending.version.as_str(),
+                    pending.deployment_id.as_deref(),
+                    pending.pinned,
+                    pending.unpinned
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                ("greeter-abc123", Some("dp_abc123"), 2, 3),
+                ("greeter-def456", Some("dp_def456"), 1, 0),
+            ],
+        );
+
+        // ...whereas a holding drain has nothing else to do at the deadline, so it does
+        rsd.spec
+            .restate
+            .drain
+            .as_mut()
+            .expect("drain block")
+            .on_timeout = Some(crate::resources::restatedeployments::OnTimeout::Hold);
+        assert!(rsd.drain_overdue());
+
+        // ...and `force` never waits in the first place, so it neither times out nor
+        // carries a deadline
+        rsd.spec.restate.delete_policy =
+            Some(crate::resources::restatedeployments::DeletePolicy::Force);
+        assert!(!rsd.drain_overdue());
+        let force_status = rsd.deletion_status(DeletionPhase::Forcing, "forcing".into(), &[]);
+        assert_eq!(
+            force_status.policy,
+            crate::resources::restatedeployments::DeletePolicy::Force
+        );
+        assert_eq!(force_status.deadline, None);
+    }
+
+    /// The finalizer wrapper must not swallow the error's identity on the way to metrics,
+    /// or every RestateDeployment failure is labelled `FinalizerError`.
+    #[test]
+    fn metrics_label_the_error_the_reconciler_raised() {
+        let wrapped = Error::FinalizerError(Box::new(
+            kube::runtime::finalizer::Error::CleanupFailed(Error::DeletionDrainOverdue {
+                blocked_by: "greeter-abc123 (1 pinned, 0 unpinned invocations)".into(),
+                timeout_seconds: 3600,
+                requeue_after: Some(Duration::from_secs(300)),
+            }),
+        ));
+
+        assert_eq!(wrapped.metric_label(), "FinalizerError");
+        assert_eq!(root_cause(&wrapped).metric_label(), "DeletionDrainOverdue");
+    }
+
+    #[test]
+    fn an_expired_force_on_timeout_deadline_requeues_immediately() {
+        let mut rsd: RestateDeployment = serde_json::from_value(json!({
+            "apiVersion": "restate.dev/v1beta1",
+            "kind": "RestateDeployment",
+            "metadata": { "name": "greeter", "namespace": "apps" },
+            "spec": {
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "template": { "spec": {} },
+                "restate": {
+                    "register": { "url": "http://restate:9070/" },
+                    "deletePolicy": "drain",
+                    "drain": { "timeoutSeconds": 60, "onTimeout": "force" },
+                },
+            },
+        }))
+        .expect("test RestateDeployment deserializes");
+        rsd.metadata.deletion_timestamp =
+            Some(Time(chrono::Utc::now() - chrono::TimeDelta::seconds(61)));
+
+        assert_eq!(rsd.until_drain_deadline(), Some(Duration::ZERO));
+
+        // A holding drain uses the same deadline for status only; once it has passed,
+        // normal backoff applies because there is no cleanup-mode transition to wake.
+        rsd.spec
+            .restate
+            .drain
+            .as_mut()
+            .expect("drain block")
+            .on_timeout = Some(crate::resources::restatedeployments::OnTimeout::Hold);
+        assert_eq!(rsd.until_drain_deadline(), None);
+
+        // ...and neither does a `force`, which never had a drain to wait out
+        rsd.spec.restate.delete_policy =
+            Some(crate::resources::restatedeployments::DeletePolicy::Force);
+        rsd.spec
+            .restate
+            .drain
+            .as_mut()
+            .expect("drain block")
+            .on_timeout = Some(crate::resources::restatedeployments::OnTimeout::Force);
+        assert_eq!(rsd.until_drain_deadline(), None);
     }
 
     #[test]

--- a/src/controllers/restatedeployment/controller.rs
+++ b/src/controllers/restatedeployment/controller.rs
@@ -50,7 +50,8 @@ use crate::{Error, Result};
 use crate::controllers::restatedeployment::cleanup::{
     CleanupMode, CleanupOutcome, DeploymentUsage, DeploymentUsageMap, DeploymentUsageRows,
     RESTATE_REMOVE_VERSION_AT_ANNOTATION, blocked_deletion_requeue, deployment_usage_query,
-    describe_blocking_versions, unschedule_version_removal,
+    describe_abandoned_versions, describe_blocking_versions, drain_deadline,
+    unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::reconcilers;
 use crate::controllers::restatedeployment::registration::{self, RegistrationAction};
@@ -1195,6 +1196,12 @@ impl RestateDeployment {
             .unwrap_or_default()
     }
 
+    /// How long until the drain gives up waiting, if it hasn't already.
+    fn until_drain_deadline(&self) -> Option<Duration> {
+        let deadline = drain_deadline(self)?;
+        (deadline - chrono::Utc::now()).to_std().ok()
+    }
+
     // Finalizer cleanup (the object was deleted, ensure nothing is orphaned)
     async fn cleanup(&self, ctx: Arc<Context>, namespace: &str) -> Result<Action> {
         ctx.recorder
@@ -1243,6 +1250,7 @@ impl RestateDeployment {
         let CleanupOutcome {
             blocking,
             next_removal,
+            abandoned,
         } = if is_knative {
             // Knative cleanup path
             reconcilers::knative::cleanup_old_configurations(
@@ -1270,6 +1278,40 @@ impl RestateDeployment {
             .await?
         };
 
+        if !abandoned.is_empty() {
+            let abandoned = describe_abandoned_versions(&abandoned);
+
+            warn!(
+                "Force-deleting RestateDeployment '{}' from Restate with unfinished invocations against {abandoned}",
+                self.name_any(),
+            );
+
+            // The teardown above already happened, so a failure to publish here must not
+            // fail the pass: the next one finds nothing abandoned and would never retry
+            // the event. The warning above it is the record that survives either way.
+            if let Err(err) = ctx
+                .recorder
+                .publish(
+                    &Event {
+                        type_: EventType::Warning,
+                        reason: "ForcedDeletion".into(),
+                        note: Some(format!(
+                            "Deregistered version(s) with unfinished invocations: {abandoned}"
+                        )),
+                        action: "Deleting".into(),
+                        secondary: None,
+                    },
+                    &self.object_ref(&()),
+                )
+                .await
+            {
+                warn!(
+                    "Failed to publish ForcedDeletion event for RestateDeployment '{}' in namespace {namespace}: {err}",
+                    self.name_any(),
+                );
+            }
+        }
+
         if !blocking.is_empty() {
             let blocked_by = describe_blocking_versions(&blocking);
 
@@ -1285,7 +1327,10 @@ impl RestateDeployment {
             // can be arbitrarily far out, so "wait for it" is not always sound advice.
             return Err(Error::DeploymentInUse {
                 blocked_by,
-                requeue_after: Some(blocked_deletion_requeue(self.blocked_for())),
+                requeue_after: Some(blocked_deletion_requeue(
+                    self.blocked_for(),
+                    self.until_drain_deadline(),
+                )),
             });
         }
 

--- a/src/controllers/restatedeployment/e2e.rs
+++ b/src/controllers/restatedeployment/e2e.rs
@@ -263,3 +263,75 @@ async fn legacy_query_tracks_safe_rollout_decisions() {
     })
     .await;
 }
+
+/// The deleting flavour of the query is the one a drain blocks on, and the only one that
+/// attributes unpinned work. Neither its extra CTE nor the columns it reaches for
+/// (`target_service_name`, joined against `sys_service`) are exercised by the rollout
+/// test above, and a schema change under either would silently un-block deletions that
+/// should be held.
+#[tokio::test]
+#[ignore = "needs Docker; run `just test-e2e`"]
+async fn legacy_query_attributes_unpinned_work_when_deleting() {
+    let server = RestateServer::start(LEGACY_IMAGE);
+    let admin = Admin {
+        client: reqwest::Client::new(),
+        admin_url: server.admin_url.clone(),
+    };
+
+    // As above: wait out the partition-placement transient before trusting a result.
+    let _: DeploymentUsageRows = admin
+        .query(&deployment_usage_query(CleanupMode::Deleting))
+        .await;
+
+    let v1 = admin.register(&serve_greeter().await).await;
+
+    // Being a service's endpoint keeps a version alive through a rollout but not through a
+    // deletion -- a deletion is removing the service, so only in-flight work can hold it.
+    let usage = admin.usage(CleanupMode::Deleting).await;
+    assert!(usage[&v1].latest_for_service);
+    assert!(usage[&v1].is_active(CleanupMode::Rollout));
+    assert!(!usage[&v1].is_active(CleanupMode::Deleting));
+
+    // A delayed invocation is accepted but bound to no deployment: it is exactly the
+    // unpinned work only this flavour attributes, and the case the feature exists for --
+    // a scheduled invocation whose execution time is arbitrarily far out.
+    let response = admin
+        .client
+        .post(format!(
+            "{}/Greeter/greet/send?delay=600s",
+            server.ingress_url
+        ))
+        .json(&"unpinned")
+        .send()
+        .await
+        .expect("schedule delayed invocation");
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    assert!(
+        status.is_success(),
+        "delayed send failed ({status}): {body}"
+    );
+
+    await_ok(
+        "delayed invocation to be attributed to v1 as unpinned",
+        || async {
+            admin
+                .usage(CleanupMode::Deleting)
+                .await
+                .get(&v1)
+                .is_some_and(|usage| usage.unpinned_invocations > 0)
+        },
+    )
+    .await;
+
+    // It is unpinned, not pinned, and it holds the drain open.
+    let usage = admin.usage(CleanupMode::Deleting).await;
+    assert_eq!(usage[&v1].pinned_invocations, 0);
+    assert!(usage[&v1].is_active(CleanupMode::Deleting));
+
+    // A force deletion doesn't run the CTE, so the same work reports as zero there and
+    // holds nothing. This is what lets a force deletion skip the expensive half.
+    let forcing = admin.usage(CleanupMode::ForceDeleting).await;
+    assert_eq!(forcing[&v1].unpinned_invocations, 0);
+    assert!(!forcing[&v1].is_active(CleanupMode::ForceDeleting));
+}

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -916,6 +916,7 @@ pub async fn cleanup_old_configurations(
 
         if let Some(usage) = deployment.filter(|usage| usage.is_active(mode)) {
             blocking.push(BlockingVersion {
+                deployment_id: config_deployment_id.cloned(),
                 name: config_name.clone(),
                 usage,
             });
@@ -961,6 +962,7 @@ pub async fn cleanup_old_configurations(
 
                 if let Some(usage) = deployment.filter(|usage| usage.in_flight_invocations() > 0) {
                     abandoned.push(BlockingVersion {
+                        deployment_id: config_deployment_id.cloned(),
                         name: config_name.clone(),
                         usage,
                     });

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -10,8 +10,9 @@ use tracing::*;
 use url::Url;
 
 use crate::controllers::restatedeployment::cleanup::{
-    BlockingVersion, CleanupMode, DeploymentUsageMap, RESTATE_REMOVE_VERSION_AT_ANNOTATION,
-    retain_for_rollback, schedule_version_removal, unschedule_version_removal,
+    BlockingVersion, CleanupMode, CleanupOutcome, DeploymentUsageMap,
+    RESTATE_REMOVE_VERSION_AT_ANNOTATION, retain_for_rollback, schedule_version_removal,
+    unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::controller::{
     Context, RESTATE_DEPLOYMENT_ID_ANNOTATION, propagated_labels,
@@ -240,10 +241,18 @@ pub async fn reconcile_knative(
     status.deployment_id = Some(deployment_id);
 
     // Cleanup old Configurations (mirrors ReplicaSet cleanup pattern)
-    let (_, next_removal) =
-        cleanup_old_configurations(namespace, ctx, &rsd_uid, rsd, &deployments, Some(&tag)).await?;
+    let outcome = cleanup_old_configurations(
+        namespace,
+        ctx,
+        &rsd_uid,
+        rsd,
+        CleanupMode::Rollout,
+        &deployments,
+        Some(&tag),
+    )
+    .await?;
 
-    Ok(next_removal)
+    Ok(outcome.next_removal)
 }
 
 /// Determine the tag for this deployment
@@ -823,9 +832,10 @@ pub async fn cleanup_old_configurations(
     ctx: &Context,
     rsd_uid: &str,
     rsd: &RestateDeployment,
+    mode: CleanupMode,
     deployments: &DeploymentUsageMap,
     active_tag: Option<&str>,
-) -> Result<(Vec<BlockingVersion>, Option<chrono::DateTime<chrono::Utc>>)> {
+) -> Result<CleanupOutcome> {
     // Use reflector cache instead of API list() call
     let configurations_cell = std::cell::Cell::new(Vec::new());
 
@@ -887,9 +897,6 @@ pub async fn cleanup_old_configurations(
     let mut next_removal = None;
 
     let now = chrono::Utc::now();
-
-    // As in `cleanup_old_replicasets`.
-    let mode = CleanupMode::for_rsd(rsd);
 
     for config in configurations {
         let config_name = config.name_any();
@@ -1021,7 +1028,10 @@ pub async fn cleanup_old_configurations(
         );
     }
 
-    Ok((blocking, next_removal))
+    Ok(CleanupOutcome {
+        blocking,
+        next_removal,
+    })
 }
 
 /// Get tag from Configuration annotation

--- a/src/controllers/restatedeployment/reconcilers/knative.rs
+++ b/src/controllers/restatedeployment/reconcilers/knative.rs
@@ -892,6 +892,8 @@ pub async fn cleanup_old_configurations(
 
     // keep track of the configurations that are still in-use by restate (active services or invocations)
     let mut blocking = Vec::new();
+    // versions a force deletion tore down with invocations still running
+    let mut abandoned = Vec::new();
     // Keep track of how many zero-scaled configurations there are (for revision history limit)
     let mut historic_count = 0;
     let mut next_removal = None;
@@ -936,7 +938,10 @@ pub async fn cleanup_old_configurations(
                     .ok()
             });
 
-        let current_remove_at_in_past = current_remove_at.is_some_and(|c| c < now);
+        // a force deletion doesn't wait out the drain delay, so every version it gets
+        // this far with is due for removal now
+        let current_remove_at_in_past =
+            current_remove_at.is_some_and(|c| c < now) || mode.skips_drain_delay();
 
         match (
             current_remove_at,
@@ -952,6 +957,13 @@ pub async fn cleanup_old_configurations(
                         config_name, historic_count, rsd.spec.revision_history_limit
                     );
                     continue;
+                }
+
+                if let Some(usage) = deployment.filter(|usage| usage.in_flight_invocations() > 0) {
+                    abandoned.push(BlockingVersion {
+                        name: config_name.clone(),
+                        usage,
+                    });
                 }
 
                 if deployment_exists {
@@ -1031,6 +1043,7 @@ pub async fn cleanup_old_configurations(
     Ok(CleanupOutcome {
         blocking,
         next_removal,
+        abandoned,
     })
 }
 

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -327,6 +327,8 @@ pub async fn cleanup_old_replicasets(
 
     // keep track of the rs that are still in-use by restate (active services or invocations)
     let mut blocking = Vec::new();
+    // versions a force deletion tore down with invocations still running
+    let mut abandoned = Vec::new();
     // Keep track of how many zero-scaled rs there are (for revision history limit)
     let mut historic_count = 0;
     let mut next_removal = None;
@@ -440,7 +442,10 @@ pub async fn cleanup_old_replicasets(
                     .ok()
             });
 
-        let current_remove_at_in_past = current_remove_at.is_some_and(|c| c < now);
+        // a force deletion doesn't wait out the drain delay, so every version it gets
+        // this far with is due for removal now
+        let current_remove_at_in_past =
+            current_remove_at.is_some_and(|c| c < now) || mode.skips_drain_delay();
 
         match (
             current_remove_at,
@@ -492,6 +497,13 @@ pub async fn cleanup_old_replicasets(
                     historic_count += 1;
                     // we haven't hit that limit yet, so we don't need to delete this rs
                     continue;
+                }
+
+                if let Some(usage) = deployment.filter(|usage| usage.in_flight_invocations() > 0) {
+                    abandoned.push(BlockingVersion {
+                        name: rs_name.clone(),
+                        usage,
+                    });
                 }
 
                 if deployment_exists {
@@ -570,6 +582,7 @@ pub async fn cleanup_old_replicasets(
     Ok(CleanupOutcome {
         blocking,
         next_removal,
+        abandoned,
     })
 }
 
@@ -968,6 +981,47 @@ mod tests {
             }
         }
 
+        /// Stand-in for the Restate admin API: records the request line into the same
+        /// call log as the apiserver stub, and answers 200 to everything.
+        async fn admin_stub(calls: Calls) -> url::Url {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+            let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                .await
+                .expect("admin stub binds");
+            let url = format!("http://{}/", listener.local_addr().expect("stub address"));
+
+            tokio::spawn(async move {
+                while let Ok((mut socket, _)) = listener.accept().await {
+                    let calls = calls.clone();
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 2048];
+                        let read = socket.read(&mut buf).await.unwrap_or(0);
+                        if let Some(request_line) =
+                            String::from_utf8_lossy(&buf[..read]).lines().next()
+                        {
+                            let mut parts = request_line.split_whitespace();
+                            let method = parts.next().unwrap_or_default();
+                            let path = parts.next().unwrap_or_default();
+                            calls.0.lock().expect("calls are not poisoned").push(Call {
+                                method: method.to_owned(),
+                                path: path.to_owned(),
+                                field_manager: None,
+                                content_type: None,
+                            });
+                        }
+                        let _ = socket
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: 2\r\n\r\n{}",
+                            )
+                            .await;
+                    });
+                }
+            });
+
+            url.parse().expect("stub url parses")
+        }
+
         fn rsd(autoscaling: bool, deleting: bool) -> RestateDeployment {
             let spec = serde_json::from_value(json!({
                 "replicas": 3,
@@ -1062,6 +1116,7 @@ mod tests {
             let CleanupOutcome {
                 blocking,
                 next_removal,
+                ..
             } = cleanup_old_replicasets(
                 NAMESPACE,
                 &harness.ctx,
@@ -1106,6 +1161,7 @@ mod tests {
             let CleanupOutcome {
                 blocking,
                 next_removal,
+                ..
             } = cleanup_old_replicasets(
                 NAMESPACE,
                 &harness.ctx,
@@ -1126,6 +1182,70 @@ mod tests {
                 harness.calls.matching(VERSION),
                 Vec::<String>::new(),
                 "nothing is touched until the deadline passes"
+            );
+        }
+
+        /// `deletePolicy: force` doesn't wait: a version with invocations in flight and a
+        /// drain deadline still ahead of it is torn down on this pass, and says what it
+        /// walked over.
+        #[tokio::test]
+        async fn force_deletion_tears_down_a_busy_version_immediately() {
+            let remove_at = chrono::Utc::now() + chrono::TimeDelta::seconds(300);
+            let harness = harness(
+                vec![version("dp_busy", Some(remove_at))],
+                vec![version_hpa()],
+            );
+
+            let mut rsd = rsd(true, true);
+            rsd.spec.restate.register.url = Some(admin_stub(harness.calls.clone()).await);
+
+            let busy = DeploymentUsage {
+                latest_for_service: true,
+                pinned_invocations: 4,
+                unpinned_invocations: 0,
+            };
+
+            let CleanupOutcome {
+                blocking,
+                abandoned,
+                ..
+            } = cleanup_old_replicasets(
+                NAMESPACE,
+                &harness.ctx,
+                &harness.rs_api,
+                RSD_UID,
+                &rsd,
+                CleanupMode::ForceDeleting,
+                &usage_of("dp_busy", busy),
+                None,
+            )
+            .await
+            .expect("cleanup succeeds");
+
+            assert!(blocking.is_empty(), "nothing holds a force deletion");
+            assert_eq!(
+                abandoned,
+                vec![BlockingVersion {
+                    name: VERSION.into(),
+                    usage: busy,
+                }],
+            );
+            assert_eq!(
+                harness.calls.matching(VERSION),
+                vec![
+                    format!(
+                        "DELETE /apis/autoscaling/v2/namespaces/{NAMESPACE}/horizontalpodautoscalers/{VERSION}"
+                    ),
+                    format!(
+                        "PATCH /apis/apps/v1/namespaces/{NAMESPACE}/replicasets/{VERSION}/scale"
+                    ),
+                    format!("DELETE /apis/apps/v1/namespaces/{NAMESPACE}/replicasets/{VERSION}"),
+                ],
+                "no remove-version-at patch: the drain delay is skipped entirely"
+            );
+            assert_eq!(
+                harness.calls.matching("/deployments/"),
+                vec!["DELETE /deployments/dp_busy?force=true".to_owned()],
             );
         }
 

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -14,8 +14,9 @@ use serde_json::json;
 use tracing::*;
 
 use crate::controllers::restatedeployment::cleanup::{
-    BlockingVersion, CleanupMode, DeploymentUsageMap, RESTATE_REMOVE_VERSION_AT_ANNOTATION,
-    retain_for_rollback, schedule_version_removal, unschedule_version_removal,
+    BlockingVersion, CleanupMode, CleanupOutcome, DeploymentUsageMap,
+    RESTATE_REMOVE_VERSION_AT_ANNOTATION, retain_for_rollback, schedule_version_removal,
+    unschedule_version_removal,
 };
 use crate::controllers::restatedeployment::controller::{
     APP_MANAGED_BY_LABEL, Context, OWNED_BY_LABEL, RESTATE_DEPLOYMENT_ID_ANNOTATION,
@@ -275,9 +276,10 @@ pub async fn cleanup_old_replicasets(
     rs_api: &Api<ReplicaSet>,
     rsd_uid: &str,
     rsd: &RestateDeployment,
+    mode: CleanupMode,
     deployments: &DeploymentUsageMap,
     except_rs: Option<&str>,
-) -> Result<(Vec<BlockingVersion>, Option<chrono::DateTime<chrono::Utc>>)> {
+) -> Result<CleanupOutcome> {
     let replicasets_cell = std::cell::Cell::new(Vec::new());
 
     let _ = ctx.replicasets_store.find(|rs| {
@@ -331,8 +333,6 @@ pub async fn cleanup_old_replicasets(
 
     let now = chrono::Utc::now();
 
-    let mode = CleanupMode::for_rsd(rsd);
-
     for rs in replicasets {
         let rs_name = rs.name_any();
 
@@ -355,7 +355,7 @@ pub async fn cleanup_old_replicasets(
             // handled unconditionally below, before scale-down.)
             match super::autoscaling::plan_active_version_hpa(
                 rsd.spec.autoscaling.is_some(),
-                rsd.metadata.deletion_timestamp.is_some(),
+                mode.is_deleting(),
             ) {
                 HpaPlan::Ensure => {
                     if let Some(template) = rsd.spec.autoscaling.as_ref()
@@ -567,7 +567,10 @@ pub async fn cleanup_old_replicasets(
         );
     }
 
-    Ok((blocking, next_removal))
+    Ok(CleanupOutcome {
+        blocking,
+        next_removal,
+    })
 }
 
 #[cfg(test)]
@@ -1056,12 +1059,16 @@ mod tests {
             let rsd = rsd(true, false);
             let harness = harness(vec![version("dp_gone", None)], vec![version_hpa()]);
 
-            let (blocking, next_removal) = cleanup_old_replicasets(
+            let CleanupOutcome {
+                blocking,
+                next_removal,
+            } = cleanup_old_replicasets(
                 NAMESPACE,
                 &harness.ctx,
                 &harness.rs_api,
                 RSD_UID,
                 &rsd,
+                CleanupMode::Rollout,
                 // the endpoint was deregistered by other means, so the version is
                 // scaled down on this pass rather than waiting out a drain
                 &DeploymentUsageMap::new(),
@@ -1096,12 +1103,16 @@ mod tests {
                 vec![version_hpa()],
             );
 
-            let (blocking, next_removal) = cleanup_old_replicasets(
+            let CleanupOutcome {
+                blocking,
+                next_removal,
+            } = cleanup_old_replicasets(
                 NAMESPACE,
                 &harness.ctx,
                 &harness.rs_api,
                 RSD_UID,
                 &rsd,
+                CleanupMode::Rollout,
                 // registered, superseded, and nothing in flight: drained but not yet due
                 &usage_of("dp_draining", DeploymentUsage::default()),
                 None,
@@ -1136,12 +1147,13 @@ mod tests {
                 unpinned_invocations: 0,
             };
 
-            let (blocking, _) = cleanup_old_replicasets(
+            let CleanupOutcome { blocking, .. } = cleanup_old_replicasets(
                 NAMESPACE,
                 &harness.ctx,
                 &harness.rs_api,
                 RSD_UID,
                 &rsd,
+                CleanupMode::Deleting,
                 &usage_of("dp_busy", busy),
                 None,
             )
@@ -1174,12 +1186,13 @@ mod tests {
 
             // superseded with nothing in flight, so this pass stamps a deadline
             let stamping = harness(vec![version("dp_super", None)], vec![]);
-            let (_, next_removal) = cleanup_old_replicasets(
+            let CleanupOutcome { next_removal, .. } = cleanup_old_replicasets(
                 NAMESPACE,
                 &stamping.ctx,
                 &stamping.rs_api,
                 RSD_UID,
                 &rsd,
+                CleanupMode::Rollout,
                 &usage_of("dp_super", DeploymentUsage::default()),
                 None,
             )
@@ -1201,12 +1214,13 @@ mod tests {
                 pinned_invocations: 1,
                 unpinned_invocations: 0,
             };
-            let (blocking, _) = cleanup_old_replicasets(
+            let CleanupOutcome { blocking, .. } = cleanup_old_replicasets(
                 NAMESPACE,
                 &clearing.ctx,
                 &clearing.rs_api,
                 RSD_UID,
                 &rsd,
+                CleanupMode::Rollout,
                 &usage_of("dp_pinned", pinned),
                 None,
             )

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -603,6 +603,8 @@ mod tests {
                     use_http11: None,
                     tunnel_mode,
                     drain_delay_seconds: None,
+                    delete_policy: None,
+                    drain: None,
                 },
                 autoscaling: None,
             },

--- a/src/controllers/restatedeployment/reconcilers/replicaset.rs
+++ b/src/controllers/restatedeployment/reconcilers/replicaset.rs
@@ -347,6 +347,7 @@ pub async fn cleanup_old_replicasets(
 
         if let Some(usage) = deployment.filter(|usage| usage.is_active(mode)) {
             blocking.push(BlockingVersion {
+                deployment_id: rs_deployment_id.cloned(),
                 name: rs_name.clone(),
                 usage,
             });
@@ -501,6 +502,7 @@ pub async fn cleanup_old_replicasets(
 
                 if let Some(usage) = deployment.filter(|usage| usage.in_flight_invocations() > 0) {
                     abandoned.push(BlockingVersion {
+                        deployment_id: rs_deployment_id.cloned(),
                         name: rs_name.clone(),
                         usage,
                     });
@@ -1227,6 +1229,7 @@ mod tests {
                 abandoned,
                 vec![BlockingVersion {
                     name: VERSION.into(),
+                    deployment_id: Some("dp_busy".into()),
                     usage: busy,
                 }],
             );
@@ -1284,6 +1287,7 @@ mod tests {
                 blocking,
                 vec![BlockingVersion {
                     name: VERSION.into(),
+                    deployment_id: Some("dp_busy".into()),
                     usage: busy,
                 }],
                 "in-flight invocations hold the deletion, and say so"
@@ -1351,6 +1355,7 @@ mod tests {
                 blocking,
                 vec![BlockingVersion {
                     name: VERSION.into(),
+                    deployment_id: Some("dp_pinned".into()),
                     usage: pinned,
                 }],
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,6 +86,15 @@ pub enum Error {
     },
 
     #[error(
+        "This RestateDeployment is still backing active versions in Restate after the {timeout_seconds}s drain timeout: {blocked_by}. Cancel/complete the outstanding invocations, raise `spec.restate.drain.timeoutSeconds`, or set `spec.restate.drain.onTimeout: force` (or `spec.restate.deletePolicy: force`) to delete without waiting for them."
+    )]
+    DeletionDrainOverdue {
+        blocked_by: String,
+        timeout_seconds: i64,
+        requeue_after: Option<Duration>,
+    },
+
+    #[error(
         "This RestateDeployment is backing recently-active versions in Restate. It will be removed after the drain delay period."
     )]
     DeploymentDraining { requeue_after: Option<Duration> },
@@ -129,6 +138,7 @@ impl Error {
             Error::HashCollision => "HashCollision",
             Error::DeploymentNotLatest { .. } => "DeploymentNotLatest",
             Error::DeploymentInUse { .. } => "DeploymentInUse",
+            Error::DeletionDrainOverdue { .. } => "DeletionDrainOverdue",
             Error::DeploymentDraining { .. } => "DeploymentDraining",
             Error::ConfigurationNotReady { .. } => "ConfigurationNotReady",
             Error::RouteNotReady { .. } => "RouteNotReady",

--- a/src/resources/restatedeployments.rs
+++ b/src/resources/restatedeployments.rs
@@ -42,6 +42,48 @@ pub enum TunnelMode {
     InProcess,
 }
 
+/// What to do about in-flight invocations when a RestateDeployment is deleted
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DeletePolicy {
+    /// Drain (default): wait for in-flight invocations to finish before removing the
+    /// deployment from Restate. `drain` sets how long to wait and what to do at the
+    /// deadline
+    Drain,
+    /// Deregister and tear down immediately, without draining
+    Force,
+}
+
+/// What a drain does once its timeout has passed
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnTimeout {
+    /// Hold (default): keep waiting. The deletion stays held until the invocations
+    /// finish, and `.status.deletion` reports the drain as overdue
+    Hold,
+    /// Force-deregister, abandoning whatever is still in flight
+    Force,
+}
+
+/// How a `deletePolicy: drain` waits
+#[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DrainSpec {
+    /// Seconds to wait for in-flight invocations to finish. Defaults to 3600 (1 hour).
+    /// Under `onTimeout: hold` this only sets when the drain reports itself overdue; it
+    /// never lets the deletion through
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub timeout_seconds: Option<i64>,
+
+    /// What to do once `timeoutSeconds` has passed. Defaults to `hold`.
+    /// - `hold`: keep waiting, and report the drain as overdue
+    /// - `force`: force-deregister, abandoning whatever is left
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "on_timeout_schema")]
+    pub on_timeout: Option<OnTimeout>,
+}
+
 /// Knative-specific deployment configuration
 #[derive(Deserialize, Serialize, Clone, Debug, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -106,7 +148,9 @@ pub struct KnativeDeploymentSpec {
     printcolumn = r#"{"name":"Deployment ID", "type":"string", "jsonPath":".status.deploymentId", "priority": 1}"#,
     printcolumn = r#"{"name":"Containers", "type":"string", "jsonPath":".spec.template.spec.containers[*].name", "priority": 1}"#,
     printcolumn = r#"{"name":"Images", "type":"string", "jsonPath":".spec.template.spec.containers[*].image", "priority": 1}"#,
-    printcolumn = r#"{"name":"Selector", "type":"string", "jsonPath":".status.labelSelector", "priority": 1}"#
+    printcolumn = r#"{"name":"Selector", "type":"string", "jsonPath":".status.labelSelector", "priority": 1}"#,
+    printcolumn = r#"{"name":"Deletion", "type":"string", "jsonPath":".status.deletion.phase", "priority": 1}"#,
+    printcolumn = r#"{"name":"Pending Invocations", "type":"integer", "jsonPath":".status.deletion.totalPendingInvocations", "priority": 1}"#
 )]
 #[kube(status = "RestateDeploymentStatus", shortname = "rsd")]
 #[serde(rename_all = "camelCase")]
@@ -323,6 +367,19 @@ pub struct RestateSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 0))]
     pub drain_delay_seconds: Option<i64>,
+
+    /// What to do about in-flight invocations when this RestateDeployment is deleted.
+    /// Defaults to `drain`.
+    /// - `drain`: wait for in-flight invocations to finish, on the terms set by `drain`.
+    /// - `force`: deregister and tear down immediately, without draining.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "delete_policy_schema")]
+    pub delete_policy: Option<DeletePolicy>,
+
+    /// How `deletePolicy: drain` waits: how long, and whether it eventually gives up.
+    /// Ignored by `deletePolicy: force`, which never waits.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drain: Option<DrainSpec>,
 }
 
 impl RestateSpec {
@@ -333,12 +390,51 @@ impl RestateSpec {
     pub fn is_in_process_tunnel(&self) -> bool {
         matches!(self.tunnel_mode, Some(TunnelMode::InProcess))
     }
+
+    pub fn delete_policy(&self) -> DeletePolicy {
+        self.delete_policy.unwrap_or(DeletePolicy::Drain)
+    }
+
+    pub fn drain_timeout_seconds(&self) -> i64 {
+        self.drain
+            .as_ref()
+            .and_then(|drain| drain.timeout_seconds)
+            .unwrap_or(3600)
+            .max(0)
+    }
+
+    /// What the drain does at its deadline. `force` never gets this far, so it reads as
+    /// the default rather than as a decision anyone made.
+    pub fn drain_on_timeout(&self) -> OnTimeout {
+        self.drain
+            .as_ref()
+            .and_then(|drain| drain.on_timeout)
+            .unwrap_or(OnTimeout::Hold)
+    }
 }
 
 fn tunnel_mode_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
     schemars::json_schema!({
         "description": "How Restate Cloud reaches this deployment. Only takes effect with `register.cloud` (`in-process` requires it, and is not supported in Knative mode). `external` (default): invocations are forwarded to this deployment's Service by the tunnel-client pods managed by the RestateCloudEnvironment. `in-process`: the deployment's pods hold their own outbound tunnel connections (e.g. with @restatedev/restate-sdk-tunnel), so no inbound networking to them is needed; the operator injects RESTATE_INPROC_* environment variables identifying the revision into the pod template and registers the per-revision tunnel URL.",
         "enum": ["external", "in-process"],
+        "type": "string",
+        "nullable": true
+    })
+}
+
+fn delete_policy_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "description": "What to do about in-flight invocations when this RestateDeployment is deleted. Defaults to `drain`. `drain`: wait for in-flight invocations to finish, on the terms set by `drain` (how long, and whether to give up). `force`: deregister and tear down immediately, without draining.",
+        "enum": ["drain", "force"],
+        "type": "string",
+        "nullable": true
+    })
+}
+
+fn on_timeout_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "description": "What to do once the drain's `timeoutSeconds` has passed. Defaults to `hold`. `hold`: keep waiting; the deletion stays held until the invocations finish, and `.status.deletion` reports the drain as overdue. `force`: force-deregister, abandoning whatever is still in flight.",
+        "enum": ["hold", "force"],
         "type": "string",
         "nullable": true
     })
@@ -586,6 +682,101 @@ pub struct RestateDeploymentStatus {
     /// The label selector of the RestateDeployment as a string, for `kubectl get rsd -o wide`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label_selector: Option<String>,
+
+    /// Progress of an in-flight deletion. Only set once the RestateDeployment has been
+    /// deleted and the operator is working through `spec.restate.deletePolicy`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deletion: Option<DeletionStatus>,
+}
+
+/// Where a deletion has got to
+#[derive(Deserialize, Serialize, Clone, Copy, Debug, JsonSchema, PartialEq, Eq)]
+pub enum DeletionPhase {
+    /// Waiting for in-flight invocations to finish, or for the drain delay to elapse
+    Draining,
+    /// The drain's `timeoutSeconds` has passed and invocations are still in flight.
+    /// Under `onTimeout: hold` the deletion stays blocked until they finish, the
+    /// timeout is raised, or the policy is changed to `force`
+    Overdue,
+    /// Removing the deployment from Restate without waiting for in-flight invocations
+    Forcing,
+}
+
+/// Progress of an in-flight deletion
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletionStatus {
+    /// The policy being applied
+    #[schemars(schema_with = "delete_policy_status_schema")]
+    pub policy: DeletePolicy,
+
+    /// Where the deletion has got to
+    #[schemars(schema_with = "deletion_phase_schema")]
+    pub phase: DeletionPhase,
+
+    /// When deletion was requested
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Time>,
+
+    /// When the drain timeout expires. Unset under `deletePolicy: force`
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deadline: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Time>,
+
+    /// What happens at the `deadline`: `hold` keeps waiting, `force` gives up and
+    /// deregisters. Unset under `deletePolicy: force`, which has no deadline to reach
+    // `default` is what tells schemars the field is optional: `schema_with` hides the
+    // `Option` from it, and a required field the operator never sets under `force` would
+    // have the API server reject the status apply.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "on_timeout_schema")]
+    pub on_timeout: Option<OnTimeout>,
+
+    /// Human-readable explanation of what the deletion is waiting for
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    /// Total invocations across all versions holding the deletion
+    pub total_pending_invocations: i64,
+
+    /// The versions holding the deletion, and the invocations they are waiting on
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub pending_invocations: Vec<PendingInvocations>,
+}
+
+/// Invocations holding one version of a deleting RestateDeployment
+#[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PendingInvocations {
+    /// The ReplicaSet (or Knative Configuration) name
+    pub version: String,
+
+    /// The Restate deployment ID this version is registered as
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deployment_id: Option<String>,
+
+    /// Unfinished invocations already bound to this version
+    pub pinned: i64,
+
+    /// Unfinished invocations not yet bound to any version, but targeting a service this
+    /// version is the endpoint for. Not counted under `deletePolicy: force`, which does
+    /// not run the query that attributes them
+    pub unpinned: i64,
+}
+
+fn delete_policy_status_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "description": "The policy being applied",
+        "enum": ["drain", "force"],
+        "type": "string"
+    })
+}
+
+fn deletion_phase_schema(_g: &mut schemars::SchemaGenerator) -> Schema {
+    schemars::json_schema!({
+        "description": "Where the deletion has got to. `Draining`: waiting for in-flight invocations to finish, or for the drain delay to elapse. `Overdue`: the drain's `timeoutSeconds` has passed and invocations are still in flight; under `onTimeout: hold` the deletion stays blocked until they finish, the timeout is raised, or the policy is changed to `force`. `Forcing`: removing the deployment from Restate without waiting for in-flight invocations.",
+        "enum": ["Draining", "Overdue", "Forcing"],
+        "type": "string"
+    })
 }
 
 /// Knative deployment status


### PR DESCRIPTION
This set of commits adds a deletion policy to the deployment spec.

There are three modes:
* Drain (default) which waits for all inflight innovations to end
* Drain-then-Force, which waits for the drain up to a time out and then forces
* Force: immediate de-register
